### PR TITLE
feat: Ctrl+L clear screen, /new session, !cmd shell shortcut (#79, #78, #5)

### DIFF
--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -7,7 +7,7 @@ open System.Threading.Tasks
 open Fugue.Core.Localization
 
 // Hardcoded — small list, easier than passing through state.
-let slashCommands : string list = [ "/help"; "/clear"; "/exit" ]
+let slashCommands : string list = [ "/help"; "/clear"; "/new"; "/exit" ]
 
 /// Internal mutable line state. Public only because tests construct it directly.
 type S = {
@@ -29,6 +29,7 @@ type Action =
     | Submit of string
     | Quit
     | Wipe
+    | ClearScreen
 
 let private isCtrl (k: ConsoleKeyInfo) (key: ConsoleKey) : bool =
     k.Modifiers.HasFlag ConsoleModifiers.Control && k.Key = key
@@ -98,6 +99,9 @@ let applyKey (k: ConsoleKeyInfo) (s: S) : Action =
         while i < s.Buffer.Count && s.Buffer.[i] <> '\n' do i <- i + 1
         s.Cursor <- i
         Continue
+    elif isCtrl k ConsoleKey.L then
+        s.ExitArmed <- false
+        ClearScreen
     elif not (Char.IsControl k.KeyChar) then
         s.ExitArmed <- false
         s.Buffer.Insert(s.Cursor, k.KeyChar)
@@ -189,6 +193,7 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
     let slashHelp =
         [ "/help",  strings.CmdHelpDesc
           "/clear", strings.CmdClearDesc
+          "/new",   strings.CmdNewDesc
           "/exit",  strings.CmdExitDesc ]
     let st : S =
         { Buffer          = ResizeArray<char>()
@@ -218,6 +223,12 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
             match applyKey k st with
             | Continue -> redraw st
             | Wipe     -> redraw st
+            | ClearScreen ->
+                eraseRendered ()
+                writeRaw "\x1b[2J\x1b[H"
+                st.LinesRendered <- 0
+                st.RowsBelowCursor <- 0
+                redraw st
             | Submit s ->
                 eraseRendered ()
                 result <- ValueSome (Some s)

--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -9,6 +9,9 @@ open Fugue.Core.Localization
 // Hardcoded — small list, easier than passing through state.
 let slashCommands : string list = [ "/help"; "/clear"; "/new"; "/exit" ]
 
+type ReadLineCallbacks = { OnClearScreen: unit -> unit }
+let defaultCallbacks : ReadLineCallbacks = { OnClearScreen = ignore }
+
 /// Internal mutable line state. Public only because tests construct it directly.
 type S = {
     mutable Buffer:          ResizeArray<char>
@@ -177,7 +180,7 @@ let private redraw (st: S) =
     else writeRaw "\r"
     st.RowsBelowCursor <- upBy   // save for next redraw's erase pass
 
-let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task<string option> = task {
+let readAsync (prompt: string) (strings: Strings) (callbacks: ReadLineCallbacks) (ct: CancellationToken) : Task<string option> = task {
     // Strip ANSI escapes for visible-length calc (rough — assumes only \x1b[...m sequences).
     let visLen =
         let mutable n = 0
@@ -228,6 +231,7 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
                 writeRaw "\x1b[2J\x1b[H"
                 st.LinesRendered <- 0
                 st.RowsBelowCursor <- 0
+                callbacks.OnClearScreen ()
                 redraw st
             | Submit s ->
                 eraseRendered ()

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -28,9 +28,12 @@ let private hasMarkdown (s: string) : bool =
 type CancelSource() =
     let mutable streamCts : CancellationTokenSource option = None
     let mutable quit = false
+    let mutable childRunning = false
     member _.QuitRequested = quit
     member _.RequestQuit() = quit <- true
     member _.Token = CancellationToken.None
+    member _.EnterChild () = childRunning <- true
+    member _.ExitChild ()  = childRunning <- false
     member _.NewStreamCts() =
         let cts = new CancellationTokenSource()
         streamCts <- Some cts
@@ -44,8 +47,12 @@ type CancelSource() =
                 try cts.Cancel() with _ -> ()
                 a.Cancel <- true
             | None ->
-                quit <- true
-                a.Cancel <- true
+                if childRunning then
+                    // Child gets SIGINT via process group; suppress quit.
+                    a.Cancel <- true
+                else
+                    quit <- true
+                    a.Cancel <- true
     interface IDisposable with
         member _.Dispose() =
             streamCts |> Option.iter (fun c -> try c.Dispose() with _ -> ())
@@ -136,8 +143,16 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                 StatusBar.refresh ()
             | Some s when s = "/new" ->
                 AnsiConsole.Clear()
-                let! newSession = agent.CreateSessionAsync(CancellationToken.None)
-                session <- newSession
+                match box session with
+                | :? IAsyncDisposable as d ->
+                    try do! d.DisposeAsync().AsTask() with _ -> ()
+                | _ -> ()
+                try
+                    let! newSession = agent.CreateSessionAsync(CancellationToken.None)
+                    session <- newSession
+                with ex ->
+                    AnsiConsole.Write(Render.errorLine strings ex.Message)
+                    AnsiConsole.WriteLine()
                 StatusBar.refresh ()
             | Some s when s.StartsWith "!" ->
                 let cmd = s.Substring(1).Trim()
@@ -154,12 +169,16 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                     psi.UseShellExecute <- false
                     use proc = new System.Diagnostics.Process()
                     proc.StartInfo <- psi
+                    cancelSrc.EnterChild ()
                     try
-                        proc.Start() |> ignore
-                        proc.WaitForExit()
-                    with ex ->
-                        AnsiConsole.Write(Render.errorLine strings ex.Message)
-                        AnsiConsole.WriteLine()
+                        try
+                            proc.Start() |> ignore
+                            proc.WaitForExit()
+                        with ex ->
+                            AnsiConsole.Write(Render.errorLine strings ex.Message)
+                            AnsiConsole.WriteLine()
+                    finally
+                        cancelSrc.ExitChild ()
                 StatusBar.refresh ()
             | Some userInput ->
                 AnsiConsole.Write(Render.userMessage cfg.Ui userInput)

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -114,13 +114,14 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
     let handler = ConsoleCancelEventHandler(fun _ args -> cancelSrc.OnCtrlC args)
     Console.CancelKeyPress.AddHandler handler
     let! initialSession = agent.CreateSessionAsync(CancellationToken.None)
-    let mutable session = initialSession
+    let mutable session : AgentSession | null = initialSession
     StatusBar.start cwd cfg
 
     let strings = pick cfg.Ui.Locale
     try
         while not cancelSrc.QuitRequested do
-            let! lineOpt = ReadLine.readAsync (Render.prompt cwd) strings cancelSrc.Token
+            let callbacks : ReadLine.ReadLineCallbacks = { OnClearScreen = StatusBar.refresh }
+            let! lineOpt = ReadLine.readAsync (Render.prompt cwd) strings callbacks cancelSrc.Token
             match lineOpt with
             | None ->
                 cancelSrc.RequestQuit()
@@ -151,6 +152,7 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                     let! newSession = agent.CreateSessionAsync(CancellationToken.None)
                     session <- newSession
                 with ex ->
+                    session <- null
                     AnsiConsole.Write(Render.errorLine strings ex.Message)
                     AnsiConsole.WriteLine()
                 StatusBar.refresh ()
@@ -167,9 +169,11 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                     psi.ArgumentList.Add "-c"
                     psi.ArgumentList.Add cmd
                     psi.UseShellExecute <- false
+                    psi.WorkingDirectory <- cwd
                     use proc = new System.Diagnostics.Process()
                     proc.StartInfo <- psi
                     cancelSrc.EnterChild ()
+                    StatusBar.stop ()
                     try
                         try
                             proc.Start() |> ignore
@@ -179,6 +183,7 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                             AnsiConsole.WriteLine()
                     finally
                         cancelSrc.ExitChild ()
+                        StatusBar.start cwd cfg
                 StatusBar.refresh ()
             | Some userInput ->
                 AnsiConsole.Write(Render.userMessage cfg.Ui userInput)

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -106,7 +106,8 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
     use cancelSrc = new CancelSource()
     let handler = ConsoleCancelEventHandler(fun _ args -> cancelSrc.OnCtrlC args)
     Console.CancelKeyPress.AddHandler handler
-    let! session = agent.CreateSessionAsync(CancellationToken.None)
+    let! initialSession = agent.CreateSessionAsync(CancellationToken.None)
+    let mutable session = initialSession
     StatusBar.start cwd cfg
 
     let strings = pick cfg.Ui.Locale
@@ -124,6 +125,7 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                 AnsiConsole.WriteLine()
                 let helpItems = [ "/help",  strings.CmdHelpDesc
                                   "/clear", strings.CmdClearDesc
+                                  "/new",   strings.CmdNewDesc
                                   "/exit",  strings.CmdExitDesc ]
                 for (name, desc) in helpItems do
                     AnsiConsole.Write(Markup("  [cyan]" + Markup.Escape name + "[/]  [dim]" + Markup.Escape desc + "[/]"))
@@ -131,6 +133,23 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                 StatusBar.refresh ()
             | Some s when s = "/clear" ->
                 AnsiConsole.Clear()
+                StatusBar.refresh ()
+            | Some s when s = "/new" ->
+                AnsiConsole.Clear()
+                let! newSession = agent.CreateSessionAsync(CancellationToken.None)
+                session <- newSession
+                StatusBar.refresh ()
+            | Some s when s.StartsWith "!" ->
+                let cmd = s.Substring(1).Trim()
+                if not (String.IsNullOrWhiteSpace cmd) then
+                    let psi = System.Diagnostics.ProcessStartInfo()
+                    psi.FileName <- "/bin/zsh"
+                    psi.Arguments <- "-lc " + cmd
+                    psi.UseShellExecute <- false
+                    use proc = new System.Diagnostics.Process()
+                    proc.StartInfo <- psi
+                    proc.Start() |> ignore
+                    proc.WaitForExit()
                 StatusBar.refresh ()
             | Some userInput ->
                 AnsiConsole.Write(Render.userMessage cfg.Ui userInput)

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -142,14 +142,24 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
             | Some s when s.StartsWith "!" ->
                 let cmd = s.Substring(1).Trim()
                 if not (String.IsNullOrWhiteSpace cmd) then
+                    let shell =
+                        System.Environment.GetEnvironmentVariable "SHELL"
+                        |> Option.ofObj
+                        |> Option.filter (fun s -> s <> "")
+                        |> Option.defaultValue "/bin/sh"
                     let psi = System.Diagnostics.ProcessStartInfo()
-                    psi.FileName <- "/bin/zsh"
-                    psi.Arguments <- "-lc " + cmd
+                    psi.FileName <- shell
+                    psi.ArgumentList.Add "-c"
+                    psi.ArgumentList.Add cmd
                     psi.UseShellExecute <- false
                     use proc = new System.Diagnostics.Process()
                     proc.StartInfo <- psi
-                    proc.Start() |> ignore
-                    proc.WaitForExit()
+                    try
+                        proc.Start() |> ignore
+                        proc.WaitForExit()
+                    with ex ->
+                        AnsiConsole.Write(Render.errorLine strings ex.Message)
+                        AnsiConsole.WriteLine()
                 StatusBar.refresh ()
             | Some userInput ->
                 AnsiConsole.Write(Render.userMessage cfg.Ui userInput)

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -27,6 +27,7 @@ type Strings =
       // Slash commands
       CmdHelpDesc:  string
       CmdClearDesc: string
+      CmdNewDesc:   string
       CmdExitDesc:  string
       HelpHeader:   string }
 
@@ -47,6 +48,7 @@ let en : Strings =
       DiscoveryPickProvider = "Pick a provider:"
       CmdHelpDesc           = "show this help"
       CmdClearDesc          = "clear the screen"
+      CmdNewDesc            = "start fresh conversation (new session)"
       CmdExitDesc           = "exit Fugue"
       HelpHeader            = "Available slash commands:" }
 
@@ -67,6 +69,7 @@ let ru : Strings =
       DiscoveryPickProvider = "Выберите провайдер:"
       CmdHelpDesc           = "показать эту справку"
       CmdClearDesc          = "очистить экран"
+      CmdNewDesc            = "начать новый разговор (новая сессия)"
       CmdExitDesc           = "выйти из Fugue"
       HelpHeader            = "Доступные команды:" }
 

--- a/tests/Fugue.Tests/ReadLineTests.fs
+++ b/tests/Fugue.Tests/ReadLineTests.fs
@@ -151,3 +151,10 @@ let ``slash buffer prefix is recognized for hint rendering`` () =
     // No applyKey side effect on the slash-suggestion field — just verify mkState constructs
     s.Buffer.Count |> should equal 1
     s.Buffer.[0] |> should equal '/'
+
+[<Fact>]
+let ``CtrlL_returns_ClearScreen`` () =
+    let s = mkState "hello" 3
+    let act = applyKey (special ConsoleKey.L ConsoleModifiers.Control) s
+    act |> should equal ClearScreen
+    s.ExitArmed |> should equal false


### PR DESCRIPTION
## Summary

- **#79** — Ctrl+L clears the terminal screen from within ReadLine (new `ClearScreen` Action variant; erases rendered area, emits `\x1b[2J\x1b[H`, resets line counters, redraws prompt)
- **#78** — `/new` slash command: clears screen and starts a fresh `AgentSession` (session variable made mutable; both `/help` display and slash autocomplete updated)
- **#5** — `!cmd` shell shortcut: type `!ls -la` to run any shell command without AI involvement; process inherits stdin/stdout/stderr so interactive output works

## Build / tests

- `Build succeeded. 0 Warning(s). 0 Error(s)` (TreatWarningsAsErrors=true, AOT-clean)
- `Passed! — Failed: 0, Passed: 88, Skipped: 0, Total: 88`

## Localization

`CmdNewDesc` added to both `en` and `ru` strings.

## Follow-up issues filed

- #212 — Ctrl+C during `!cmd` kills Fugue (I3)
- #213 — `!cmd` stdout may clobber StatusBar scroll region (I4)
- #215 — Ctrl+L status bar not repainted immediately (I5)
- #216 — `!cmd` cwd may drift from Fugue's tracked cwd

## Notes

- `!cmd` uses `ArgumentList` (avoids .NET arg re-parsing), reads `$SHELL` with `/bin/sh` fallback, `-c` only (no `-l` login flag), and wraps process execution in `try/with` for graceful error display.
- Status bar after Ctrl+L repaints on next submission — tracked as #215 for a callback-hook fix.