### PR TITLE
feat(cli): elapsed time display during streaming (#253)

### DIFF
--- a/src/Fugue.Cli/Fugue.Cli.fsproj
+++ b/src/Fugue.Cli/Fugue.Cli.fsproj
@@ -24,6 +24,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Fugue.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="ReadLine.fs" />
     <Compile Include="MarkdownRender.fs" />
     <Compile Include="DiffRender.fs" />

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -58,6 +58,7 @@ let private streamAndRender
     let toolMeta = Dictionary<string, string * string>()
     let mutable assistantStreaming = false   // are we mid-line in the plain-text stream
 
+    StatusBar.startStreaming()
     try
         let stream = Conversation.run agent session input streamCts.Token
         let enumerator = stream.GetAsyncEnumerator(streamCts.Token)
@@ -75,6 +76,7 @@ let private streamAndRender
                     if assistantStreaming then
                         Console.Out.WriteLine ()
                         assistantStreaming <- false
+                    StatusBar.refresh()
                 | Conversation.ToolCompleted(id, output, isErr) ->
                     let name, args =
                         match toolMeta.TryGetValue id with
@@ -85,6 +87,7 @@ let private streamAndRender
                         else Render.Completed(name, args, output)
                     AnsiConsole.Write(Render.toolBullet strings state)
                     AnsiConsole.WriteLine ()
+                    StatusBar.refresh()
                 | Conversation.Finished -> ()
                 | Conversation.Failed ex -> raise ex
             else hasNext <- false
@@ -98,6 +101,8 @@ let private streamAndRender
         if assistantStreaming then Console.Out.WriteLine ()
         AnsiConsole.Write(Render.errorLine strings ex.Message)
         AnsiConsole.WriteLine()
+    StatusBar.stopStreaming()
+    StatusBar.refresh()
 }
 
 [<RequiresUnreferencedCode("Calls Conversation.run which uses STJ reflection; System.Text.Json is TrimmerRootAssembly")>]

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -60,49 +60,51 @@ let private streamAndRender
 
     StatusBar.startStreaming()
     try
-        let stream = Conversation.run agent session input streamCts.Token
-        let enumerator = stream.GetAsyncEnumerator(streamCts.Token)
-        let mutable hasNext = true
-        while hasNext do
-            let! step = enumerator.MoveNextAsync().AsTask()
-            if step then
-                match enumerator.Current with
-                | Conversation.TextChunk t ->
-                    Console.Out.Write t
-                    Console.Out.Flush()
-                    assistantStreaming <- true
-                | Conversation.ToolStarted(id, name, args) ->
-                    toolMeta.[id] <- (name, args)
-                    if assistantStreaming then
-                        Console.Out.WriteLine ()
-                        assistantStreaming <- false
-                    StatusBar.refresh()
-                | Conversation.ToolCompleted(id, output, isErr) ->
-                    let name, args =
-                        match toolMeta.TryGetValue id with
-                        | true, v -> v
-                        | false, _ -> "?", "?"
-                    let state =
-                        if isErr then Render.Failed(name, args, output)
-                        else Render.Completed(name, args, output)
-                    AnsiConsole.Write(Render.toolBullet strings state)
-                    AnsiConsole.WriteLine ()
-                    StatusBar.refresh()
-                | Conversation.Finished -> ()
-                | Conversation.Failed ex -> raise ex
-            else hasNext <- false
-        if assistantStreaming then Console.Out.WriteLine ()
-    with
-    | :? OperationCanceledException ->
-        if assistantStreaming then Console.Out.WriteLine ()
-        AnsiConsole.Write(Render.cancelled strings)
-        AnsiConsole.WriteLine()
-    | ex ->
-        if assistantStreaming then Console.Out.WriteLine ()
-        AnsiConsole.Write(Render.errorLine strings ex.Message)
-        AnsiConsole.WriteLine()
-    StatusBar.stopStreaming()
-    StatusBar.refresh()
+        try
+            let stream = Conversation.run agent session input streamCts.Token
+            let enumerator = stream.GetAsyncEnumerator(streamCts.Token)
+            let mutable hasNext = true
+            while hasNext do
+                let! step = enumerator.MoveNextAsync().AsTask()
+                if step then
+                    match enumerator.Current with
+                    | Conversation.TextChunk t ->
+                        Console.Out.Write t
+                        Console.Out.Flush()
+                        assistantStreaming <- true
+                    | Conversation.ToolStarted(id, name, args) ->
+                        toolMeta.[id] <- (name, args)
+                        if assistantStreaming then
+                            Console.Out.WriteLine ()
+                            assistantStreaming <- false
+                        StatusBar.refresh()
+                    | Conversation.ToolCompleted(id, output, isErr) ->
+                        let name, args =
+                            match toolMeta.TryGetValue id with
+                            | true, v -> v
+                            | false, _ -> "?", "?"
+                        let state =
+                            if isErr then Render.Failed(name, args, output)
+                            else Render.Completed(name, args, output)
+                        AnsiConsole.Write(Render.toolBullet strings state)
+                        AnsiConsole.WriteLine ()
+                        StatusBar.refresh()
+                    | Conversation.Finished -> ()
+                    | Conversation.Failed ex -> raise ex
+                else hasNext <- false
+            if assistantStreaming then Console.Out.WriteLine ()
+        with
+        | :? OperationCanceledException ->
+            if assistantStreaming then Console.Out.WriteLine ()
+            AnsiConsole.Write(Render.cancelled strings)
+            AnsiConsole.WriteLine()
+        | ex ->
+            if assistantStreaming then Console.Out.WriteLine ()
+            AnsiConsole.Write(Render.errorLine strings ex.Message)
+            AnsiConsole.WriteLine()
+    finally
+        StatusBar.stopStreaming()
+        StatusBar.refresh()
 }
 
 [<RequiresUnreferencedCode("Calls Conversation.run which uses STJ reflection; System.Text.Json is TrimmerRootAssembly")>]

--- a/src/Fugue.Cli/StatusBar.fs
+++ b/src/Fugue.Cli/StatusBar.fs
@@ -14,6 +14,7 @@ let mutable private cwd: string = "."
 let mutable private cfg: AppConfig option = None
 let mutable private active = false
 let mutable private branchCache : string * DateTime = "", DateTime.MinValue
+let mutable private streamingSince : DateTime option = None
 
 let private branchOf (cwd: string) : string =
     let now = DateTime.UtcNow
@@ -56,6 +57,13 @@ let private providerLabel (cfg: AppConfig) : string =
     | OpenAI(_, m)    -> "openai:" + shortModel m
     | Ollama(_, m)    -> "ollama:" + shortModel m
 
+let internal formatElapsed (t: TimeSpan) : string =
+    if t.TotalSeconds < 60.0 then sprintf "%.1fs" t.TotalSeconds
+    else sprintf "%dm %ds" (int t.TotalMinutes) t.Seconds
+
+let startStreaming () = streamingSince <- Some DateTime.UtcNow
+let stopStreaming ()  = streamingSince <- None
+
 let refresh () =
     if not active then () else
     let height = Console.WindowHeight
@@ -65,10 +73,16 @@ let refresh () =
         | None   -> Fugue.Core.Localization.en
     let line1 =
         "\x1b[90m" + (homeRel cwd) + " " + strings.StatusBarOn + " \x1b[1m" + (branchOf cwd) + "\x1b[0m"
+    let elapsedSuffix =
+        match streamingSince with
+        | Some since ->
+            let elapsed = DateTime.UtcNow - since
+            " · " + formatElapsed elapsed
+        | None -> ""
     let line2 =
         match cfg with
-        | Some c -> "\x1b[90m" + strings.StatusBarApp + " · " + (providerLabel c) + "\x1b[0m"
-        | None   -> "\x1b[90m" + strings.StatusBarApp + "\x1b[0m"
+        | Some c -> "\x1b[90m" + strings.StatusBarApp + " · " + (providerLabel c) + elapsedSuffix + "\x1b[0m"
+        | None   -> "\x1b[90m" + strings.StatusBarApp + elapsedSuffix + "\x1b[0m"
     // save cursor, jump to bottom-1, clear two lines, write, restore
     writeRaw "\x1b[s"
     writeRaw ("\x1b[" + string (height - 1) + ";1H")

--- a/tests/Fugue.Tests/Fugue.Tests.fsproj
+++ b/tests/Fugue.Tests/Fugue.Tests.fsproj
@@ -20,6 +20,7 @@
     <Compile Include="MarkdownRenderTests.fs" />
     <Compile Include="DiffRenderTests.fs" />
     <Compile Include="RenderTests.fs" />
+    <Compile Include="StatusBarTests.fs" />
     <Compile Include="ReadToolTests.fs" />
     <Compile Include="WriteToolTests.fs" />
     <Compile Include="EditToolTests.fs" />

--- a/tests/Fugue.Tests/StatusBarTests.fs
+++ b/tests/Fugue.Tests/StatusBarTests.fs
@@ -1,0 +1,16 @@
+module Fugue.Tests.StatusBarTests
+
+open System
+open Xunit
+open FsUnit.Xunit
+open Fugue.Cli
+
+[<Fact>]
+let ``formatElapsed under 60s shows decimal seconds`` () =
+    let t = TimeSpan.FromSeconds 2.3
+    StatusBar.formatElapsed t |> should equal "2.3s"
+
+[<Fact>]
+let ``formatElapsed over 60s shows minutes and seconds`` () =
+    let t = TimeSpan.FromSeconds 65.0
+    StatusBar.formatElapsed t |> should equal "1m 5s"


### PR DESCRIPTION
## Summary
- Shows elapsed time in the StatusBar second line during AI streaming (e.g. `· 2.3s` or `· 1m 5s`)
- Updates at event boundaries: ToolStarted, ToolCompleted, and stream end
- `formatElapsed` is a pure internal function, fully unit-tested
- Cleanup guaranteed via `try/finally` — `stopStreaming()` runs on success, cancel, and error

## Changes
- `src/Fugue.Cli/StatusBar.fs` — `streamingSince`, `formatElapsed`, `startStreaming`, `stopStreaming`, elapsed suffix in `refresh()`
- `src/Fugue.Cli/Repl.fs` — `startStreaming()` / `try/finally stopStreaming()` + `refresh()` on tool events
- `src/Fugue.Cli/Fugue.Cli.fsproj` — `InternalsVisibleTo` for test assembly
- `tests/Fugue.Tests/StatusBarTests.fs` — 2 unit tests for `formatElapsed`

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 108/108 pass
- [x] Code review: APPROVED (post-fix)
- [x] Reality check: APPROVED

Closes #253