### PR TITLE
feat(cli): /tools command + /clear-history (#258, #240)

### DIFF
--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -7,7 +7,7 @@ open System.Threading.Tasks
 open Fugue.Core.Localization
 
 // Hardcoded — small list, easier than passing through state.
-let slashCommands : string list = [ "/help"; "/clear"; "/exit" ]
+let slashCommands : string list = [ "/help"; "/clear"; "/tools"; "/exit" ]
 
 /// Session history (REPL is single-threaded). Not private so tests can seed entries directly.
 let historyStore = ResizeArray<string>()
@@ -280,6 +280,7 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
     let slashHelp =
         [ "/help",  strings.CmdHelpDesc
           "/clear", strings.CmdClearDesc
+          "/tools", strings.CmdToolsDesc
           "/exit",  strings.CmdExitDesc ]
     let st : S =
         { Buffer          = ResizeArray<char>()

--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -7,7 +7,7 @@ open System.Threading.Tasks
 open Fugue.Core.Localization
 
 // Hardcoded — small list, easier than passing through state.
-let slashCommands : string list = [ "/help"; "/clear"; "/tools"; "/exit" ]
+let slashCommands : string list = [ "/help"; "/clear"; "/clear-history"; "/tools"; "/exit" ]
 
 /// Session history (REPL is single-threaded). Not private so tests can seed entries directly.
 let historyStore = ResizeArray<string>()
@@ -278,10 +278,11 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
                 i <- i + 1
         n
     let slashHelp =
-        [ "/help",  strings.CmdHelpDesc
-          "/clear", strings.CmdClearDesc
-          "/tools", strings.CmdToolsDesc
-          "/exit",  strings.CmdExitDesc ]
+        [ "/help",          strings.CmdHelpDesc
+          "/clear",         strings.CmdClearDesc
+          "/clear-history", strings.CmdClearHistoryDesc
+          "/tools",         strings.CmdToolsDesc
+          "/exit",          strings.CmdExitDesc ]
     let st : S =
         { Buffer          = ResizeArray<char>()
           Cursor          = 0

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -124,6 +124,7 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                 AnsiConsole.WriteLine()
                 let helpItems = [ "/help",  strings.CmdHelpDesc
                                   "/clear", strings.CmdClearDesc
+                                  "/tools", strings.CmdToolsDesc
                                   "/exit",  strings.CmdExitDesc ]
                 for (name, desc) in helpItems do
                     AnsiConsole.Write(Markup("  [cyan]" + Markup.Escape name + "[/]  [dim]" + Markup.Escape desc + "[/]"))
@@ -131,6 +132,13 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                 StatusBar.refresh ()
             | Some s when s = "/clear" ->
                 AnsiConsole.Clear()
+                StatusBar.refresh ()
+            | Some s when s = "/tools" ->
+                AnsiConsole.Write(Markup("[bold]" + Markup.Escape strings.ToolsHeader + "[/]"))
+                AnsiConsole.WriteLine()
+                for (name, desc) in Fugue.Tools.ToolRegistry.descriptions do
+                    AnsiConsole.Write(Markup("  [cyan]" + Markup.Escape name + "[/]  [dim]" + Markup.Escape desc + "[/]"))
+                    AnsiConsole.WriteLine()
                 StatusBar.refresh ()
             | Some userInput ->
                 AnsiConsole.Write(Render.userMessage cfg.Ui userInput)

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -106,7 +106,8 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
     use cancelSrc = new CancelSource()
     let handler = ConsoleCancelEventHandler(fun _ args -> cancelSrc.OnCtrlC args)
     Console.CancelKeyPress.AddHandler handler
-    let! session = agent.CreateSessionAsync(CancellationToken.None)
+    let! initialSession = agent.CreateSessionAsync(CancellationToken.None)
+    let mutable session : AgentSession | null = initialSession
     StatusBar.start cwd cfg
 
     let strings = pick cfg.Ui.Locale
@@ -122,16 +123,32 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
             | Some s when s = "/help" ->
                 AnsiConsole.Write(Markup("[bold]" + Markup.Escape strings.HelpHeader + "[/]"))
                 AnsiConsole.WriteLine()
-                let helpItems = [ "/help",  strings.CmdHelpDesc
-                                  "/clear", strings.CmdClearDesc
-                                  "/tools", strings.CmdToolsDesc
-                                  "/exit",  strings.CmdExitDesc ]
+                let helpItems = [ "/help",          strings.CmdHelpDesc
+                                  "/clear",         strings.CmdClearDesc
+                                  "/clear-history", strings.CmdClearHistoryDesc
+                                  "/tools",         strings.CmdToolsDesc
+                                  "/exit",          strings.CmdExitDesc ]
                 for (name, desc) in helpItems do
                     AnsiConsole.Write(Markup("  [cyan]" + Markup.Escape name + "[/]  [dim]" + Markup.Escape desc + "[/]"))
                     AnsiConsole.WriteLine()
                 StatusBar.refresh ()
             | Some s when s = "/clear" ->
                 AnsiConsole.Clear()
+                StatusBar.refresh ()
+            | Some s when s = "/clear-history" ->
+                match box session with
+                | :? IAsyncDisposable as d ->
+                    try do! d.DisposeAsync().AsTask() with _ -> ()
+                | _ -> ()
+                try
+                    let! newSession = agent.CreateSessionAsync(CancellationToken.None)
+                    session <- newSession
+                    AnsiConsole.Write(Markup("[dim]" + Markup.Escape strings.ClearHistoryDone + "[/]"))
+                    AnsiConsole.WriteLine()
+                with ex ->
+                    session <- null
+                    AnsiConsole.Write(Render.errorLine strings ex.Message)
+                    AnsiConsole.WriteLine()
                 StatusBar.refresh ()
             | Some s when s = "/tools" ->
                 AnsiConsole.Write(Markup("[bold]" + Markup.Escape strings.ToolsHeader + "[/]"))

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -25,12 +25,14 @@ type Strings =
       DiscoveryPickProvider:  string
 
       // Slash commands
-      CmdHelpDesc:  string
-      CmdClearDesc: string
-      CmdExitDesc:  string
-      CmdToolsDesc: string
-      HelpHeader:   string
-      ToolsHeader:  string }
+      CmdHelpDesc:         string
+      CmdClearDesc:        string
+      CmdClearHistoryDesc: string
+      CmdExitDesc:         string
+      CmdToolsDesc:        string
+      HelpHeader:          string
+      ToolsHeader:         string
+      ClearHistoryDone:    string }
 
 let en : Strings =
     { Cancelled            = "cancelled"
@@ -49,10 +51,12 @@ let en : Strings =
       DiscoveryPickProvider = "Pick a provider:"
       CmdHelpDesc           = "show this help"
       CmdClearDesc          = "clear the screen"
+      CmdClearHistoryDesc   = "reset conversation history without clearing screen"
       CmdExitDesc           = "exit Fugue"
       CmdToolsDesc          = "list all available tools with descriptions"
       HelpHeader            = "Available slash commands:"
-      ToolsHeader           = "Available tools" }
+      ToolsHeader           = "Available tools"
+      ClearHistoryDone      = "Conversation history cleared. Screen preserved." }
 
 let ru : Strings =
     { Cancelled            = "отменено"
@@ -71,10 +75,12 @@ let ru : Strings =
       DiscoveryPickProvider = "Выберите провайдер:"
       CmdHelpDesc           = "показать эту справку"
       CmdClearDesc          = "очистить экран"
+      CmdClearHistoryDesc   = "сбросить историю разговора без очистки экрана"
       CmdExitDesc           = "выйти из Fugue"
       CmdToolsDesc          = "показать список инструментов с описаниями"
       HelpHeader            = "Доступные команды:"
-      ToolsHeader           = "Доступные инструменты" }
+      ToolsHeader           = "Доступные инструменты"
+      ClearHistoryDone      = "История разговора сброшена. Экран сохранён." }
 
 /// Pick a Strings value by ISO-2 locale code. Unknown locales fall back to en.
 let pick (locale: string) : Strings =

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -28,7 +28,9 @@ type Strings =
       CmdHelpDesc:  string
       CmdClearDesc: string
       CmdExitDesc:  string
-      HelpHeader:   string }
+      CmdToolsDesc: string
+      HelpHeader:   string
+      ToolsHeader:  string }
 
 let en : Strings =
     { Cancelled            = "cancelled"
@@ -48,7 +50,9 @@ let en : Strings =
       CmdHelpDesc           = "show this help"
       CmdClearDesc          = "clear the screen"
       CmdExitDesc           = "exit Fugue"
-      HelpHeader            = "Available slash commands:" }
+      CmdToolsDesc          = "list all available tools with descriptions"
+      HelpHeader            = "Available slash commands:"
+      ToolsHeader           = "Available tools" }
 
 let ru : Strings =
     { Cancelled            = "отменено"
@@ -68,7 +72,9 @@ let ru : Strings =
       CmdHelpDesc           = "показать эту справку"
       CmdClearDesc          = "очистить экран"
       CmdExitDesc           = "выйти из Fugue"
-      HelpHeader            = "Доступные команды:" }
+      CmdToolsDesc          = "показать список инструментов с описаниями"
+      HelpHeader            = "Доступные команды:"
+      ToolsHeader           = "Доступные инструменты" }
 
 /// Pick a Strings value by ISO-2 locale code. Unknown locales fall back to en.
 let pick (locale: string) : Strings =

--- a/src/Fugue.Tools/ToolRegistry.fs
+++ b/src/Fugue.Tools/ToolRegistry.fs
@@ -14,3 +14,12 @@ let buildAll (cwd: string) : AIFunction list = [
 ]
 
 let names : string list = [ "Read"; "Write"; "Edit"; "Bash"; "Glob"; "Grep" ]
+
+let descriptions : (string * string) list = [
+    "Read",  "Read a text file. Returns lines prefixed with 1-based line numbers."
+    "Write", "Write content to a file, creating directories as needed."
+    "Edit",  "Replace an exact string in a file. Fails if old_string not found or not unique."
+    "Bash",  "Run a shell command and return stdout, stderr, and exit code."
+    "Glob",  "List files matching a glob pattern."
+    "Grep",  "Search files for a regex pattern, returning matching lines with file and line number."
+]

--- a/tests/Fugue.Tests/LocalizationTests.fs
+++ b/tests/Fugue.Tests/LocalizationTests.fs
@@ -27,7 +27,8 @@ let ``en strings are all non-empty`` () =
       s.PromptHelpEnter; s.PromptHelpShiftEnter; s.PromptHelpCtrlD
       s.ConfigHelpHeader; s.ConfigHelpEnvHint; s.ConfigHelpFileHint
       s.DiscoveryNoCandidates; s.DiscoveryPickProvider
-      s.CmdHelpDesc; s.CmdClearDesc; s.CmdExitDesc; s.HelpHeader ]
+      s.CmdHelpDesc; s.CmdClearDesc; s.CmdExitDesc; s.CmdToolsDesc
+      s.HelpHeader; s.ToolsHeader ]
     |> List.iter (fun v -> v |> should not' (equal ""))
 
 [<Fact>]
@@ -38,5 +39,6 @@ let ``ru strings are all non-empty`` () =
       s.PromptHelpEnter; s.PromptHelpShiftEnter; s.PromptHelpCtrlD
       s.ConfigHelpHeader; s.ConfigHelpEnvHint; s.ConfigHelpFileHint
       s.DiscoveryNoCandidates; s.DiscoveryPickProvider
-      s.CmdHelpDesc; s.CmdClearDesc; s.CmdExitDesc; s.HelpHeader ]
+      s.CmdHelpDesc; s.CmdClearDesc; s.CmdExitDesc; s.CmdToolsDesc
+      s.HelpHeader; s.ToolsHeader ]
     |> List.iter (fun v -> v |> should not' (equal ""))


### PR DESCRIPTION
## Summary
- `/tools` — list all available tools with name and description (`ToolRegistry.descriptions`, Spectre markup, tab-autocomplete)
- `/clear-history` — reset conversation history without clearing the terminal screen; distinct from `/new` (which also clears screen)
- Both commands added to `/help` listing and ReadLine tab-autocomplete

## Changes
- `src/Fugue.Tools/ToolRegistry.fs` — `descriptions : (string * string) list` (static, AOT-safe)
- `src/Fugue.Core/Localization.fs` — `CmdToolsDesc`, `ToolsHeader`, `CmdClearHistoryDesc`, `ClearHistoryDone` (en + ru)
- `src/Fugue.Cli/Repl.fs` — `/tools` and `/clear-history` pattern arms; both in `/help` listing
- `src/Fugue.Cli/ReadLine.fs` — both commands in `slashCommands` + `slashHelp` arrays

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 106/106 pass
- [x] Code review: APPROVED
- [x] Reality check: APPROVED

Closes #258
Closes #240