### PR TITLE
feat(core): hierarchical FUGUE.md loading — cwd → git root + ~/.fugue/FUGUE.md (#217)

### DIFF
--- a/src/Fugue.Cli/Program.fs
+++ b/src/Fugue.Cli/Program.fs
@@ -12,7 +12,9 @@ let private buildAgent (cfg: AppConfig) : AIAgent =
     let sysPrompt =
         match cfg.SystemPrompt with
         | Some s -> s
-        | None -> Fugue.Core.SystemPrompt.render cwd Fugue.Tools.ToolRegistry.names
+        | None ->
+            let ctx = Fugue.Core.SystemPrompt.loadFugueContext cwd
+            Fugue.Core.SystemPrompt.render cwd Fugue.Tools.ToolRegistry.names ctx
     AgentFactory.create cfg.Provider cfg.BaseUrl sysPrompt tools
 
 [<RequiresUnreferencedCode("Calls Repl.run and Config.saveToFile which use STJ reflection; System.Text.Json is TrimmerRootAssembly")>]

--- a/src/Fugue.Core/SystemPrompt.fs
+++ b/src/Fugue.Core/SystemPrompt.fs
@@ -3,7 +3,80 @@ module Fugue.Core.SystemPrompt
 open System
 open System.Runtime.InteropServices
 
-let render (cwd: string) (toolNames: string list) : string =
+// Find git root by running `git rev-parse --show-toplevel` in dir.
+// Returns None on failure (not a git repo, or git not installed).
+let private findGitRoot (dir: string) : string option =
+    try
+        let psi = System.Diagnostics.ProcessStartInfo("git", "rev-parse --show-toplevel")
+        psi.WorkingDirectory <- dir
+        psi.RedirectStandardOutput <- true
+        psi.RedirectStandardError <- true
+        psi.UseShellExecute <- false
+        psi.CreateNoWindow <- true
+        match System.Diagnostics.Process.Start psi with
+        | null -> None
+        | p ->
+            use _ = p
+            p.WaitForExit 500 |> ignore
+            if p.ExitCode = 0 then
+                let out = (p.StandardOutput.ReadToEnd()).Trim()
+                if String.IsNullOrEmpty out then None else Some out
+            else None
+    with _ -> None
+
+/// Walk from startDir up to git root (or just startDir if not in a git repo),
+/// collect any FUGUE.md files found, plus ~/.fugue/FUGUE.md.
+/// Returns None if no files found. Returns Some with concatenated content if any found.
+/// Order: global (~/.fugue/FUGUE.md) first, then parent-to-child (root → cwd last).
+let loadFugueContext (startDir: string) : string option =
+    let ceiling = findGitRoot startDir |> Option.defaultValue startDir
+
+    // Collect directories from startDir up to ceiling (inclusive).
+    // Result is ceiling-first, startDir-last (parent before child).
+    let rec collectDirs (dir: string) acc =
+        let normalized = System.IO.Path.GetFullPath dir
+        let normalizedCeiling = System.IO.Path.GetFullPath ceiling
+        if normalized = normalizedCeiling then normalizedCeiling :: acc
+        elif normalized.StartsWith normalizedCeiling then
+            match System.IO.Path.GetDirectoryName normalized with
+            | null -> normalized :: acc  // filesystem root; stop
+            | parent -> collectDirs parent (normalized :: acc)
+        else acc  // went above ceiling somehow
+
+    let dirs = collectDirs startDir []
+
+    let found =
+        dirs
+        |> List.choose (fun d ->
+            let candidate = System.IO.Path.Combine(d, "FUGUE.md")
+            if System.IO.File.Exists candidate then Some (candidate, System.IO.File.ReadAllText candidate)
+            else None)
+
+    // Also check ~/.fugue/FUGUE.md
+    let home = Environment.GetEnvironmentVariable "HOME" |> Option.ofObj |> Option.defaultValue ""
+    let globalCtx =
+        if home <> "" then
+            let globalPath = System.IO.Path.Combine(home, ".fugue", "FUGUE.md")
+            if System.IO.File.Exists globalPath then Some (globalPath, System.IO.File.ReadAllText globalPath)
+            else None
+        else None
+
+    let allCtx =
+        match globalCtx with
+        | Some g -> g :: found
+        | None -> found
+
+    if List.isEmpty allCtx then None
+    else
+        let sections =
+            allCtx |> List.map (fun (path, content) ->
+                let rel =
+                    if home <> "" && path.StartsWith home then "~" + path.Substring(home.Length)
+                    else path
+                sprintf "<!-- FUGUE.md: %s -->\n%s" rel content)
+        Some (String.concat "\n\n" sections)
+
+let render (cwd: string) (toolNames: string list) (context: string option) : string =
     let os =
         if RuntimeInformation.IsOSPlatform(OSPlatform.OSX) then "macOS"
         elif RuntimeInformation.IsOSPlatform(OSPlatform.Linux) then "Linux"
@@ -12,6 +85,11 @@ let render (cwd: string) (toolNames: string list) : string =
 
     let date = DateTime.UtcNow.ToString("yyyy-MM-dd")
     let tools = String.Join(", ", toolNames)
+
+    let contextSection =
+        match context with
+        | None -> ""
+        | Some ctx -> "\n\n# Project context (from FUGUE.md)\n\n" + ctx
 
     $"""You are Fugue, a lean CLI coding assistant. You help the user with software engineering tasks in their terminal.
 
@@ -34,4 +112,4 @@ Available tools: {tools}
 # Style
 - When you finish a task, stop. Do not summarize what you did unless asked.
 - When you call a tool, do not also narrate "I will call X" — the user sees the call.
-"""
+""" + contextSection

--- a/src/Fugue.Core/SystemPrompt.fs
+++ b/src/Fugue.Core/SystemPrompt.fs
@@ -17,8 +17,8 @@ let private findGitRoot (dir: string) : string option =
         | null -> None
         | p ->
             use _ = p
-            p.WaitForExit 500 |> ignore
-            if p.ExitCode = 0 then
+            let exited = p.WaitForExit 500
+            if exited && p.ExitCode = 0 then
                 let out = (p.StandardOutput.ReadToEnd()).Trim()
                 if String.IsNullOrEmpty out then None else Some out
             else None

--- a/tests/Fugue.Tests/Fugue.Tests.fsproj
+++ b/tests/Fugue.Tests/Fugue.Tests.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="ToolRegistryTests.fs" />
     <Compile Include="ConfigTests.fs" />
     <Compile Include="LocalizationTests.fs" />
+    <Compile Include="SystemPromptTests.fs" />
     <Compile Include="ReadLineTests.fs" />
     <Compile Include="MarkdownRenderTests.fs" />
     <Compile Include="DiffRenderTests.fs" />

--- a/tests/Fugue.Tests/SystemPromptTests.fs
+++ b/tests/Fugue.Tests/SystemPromptTests.fs
@@ -1,0 +1,39 @@
+module Fugue.Tests.SystemPromptTests
+
+open System.IO
+open Xunit
+open FsUnit.Xunit
+open Fugue.Core.SystemPrompt
+
+[<Fact>]
+let ``loadFugueContext returns None when no FUGUE.md exists`` () =
+    let tmpDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+    Directory.CreateDirectory tmpDir |> ignore
+    try
+        loadFugueContext tmpDir |> should equal None
+    finally
+        Directory.Delete(tmpDir, true)
+
+[<Fact>]
+let ``loadFugueContext returns Some when FUGUE.md exists in cwd`` () =
+    let tmpDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+    Directory.CreateDirectory tmpDir |> ignore
+    try
+        File.WriteAllText(Path.Combine(tmpDir, "FUGUE.md"), "# Test context\nHello")
+        let result = loadFugueContext tmpDir
+        result |> should not' (equal None)
+        result.Value |> should haveSubstring "Hello"
+    finally
+        Directory.Delete(tmpDir, true)
+
+[<Fact>]
+let ``render with None context produces same output as before`` () =
+    let result = render "/tmp" ["Read"; "Write"] None
+    result |> should haveSubstring "Working directory: /tmp"
+    result |> should haveSubstring "Available tools: Read, Write"
+
+[<Fact>]
+let ``render with Some context appends project context section`` () =
+    let result = render "/tmp" ["Read"] (Some "# My project\nDo X.")
+    result |> should haveSubstring "Project context"
+    result |> should haveSubstring "Do X."

--- a/tests/Fugue.Tests/SystemPromptTests.fs
+++ b/tests/Fugue.Tests/SystemPromptTests.fs
@@ -1,5 +1,6 @@
 module Fugue.Tests.SystemPromptTests
 
+open System
 open System.IO
 open Xunit
 open FsUnit.Xunit
@@ -9,15 +10,20 @@ open Fugue.Core.SystemPrompt
 let ``loadFugueContext returns None when no FUGUE.md exists`` () =
     let tmpDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
     Directory.CreateDirectory tmpDir |> ignore
+    let origHome = Environment.GetEnvironmentVariable "HOME"
+    Environment.SetEnvironmentVariable("HOME", tmpDir)
     try
         loadFugueContext tmpDir |> should equal None
     finally
         Directory.Delete(tmpDir, true)
+        Environment.SetEnvironmentVariable("HOME", origHome)
 
 [<Fact>]
 let ``loadFugueContext returns Some when FUGUE.md exists in cwd`` () =
     let tmpDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
     Directory.CreateDirectory tmpDir |> ignore
+    let origHome = Environment.GetEnvironmentVariable "HOME"
+    Environment.SetEnvironmentVariable("HOME", tmpDir)
     try
         File.WriteAllText(Path.Combine(tmpDir, "FUGUE.md"), "# Test context\nHello")
         let result = loadFugueContext tmpDir
@@ -25,6 +31,7 @@ let ``loadFugueContext returns Some when FUGUE.md exists in cwd`` () =
         result.Value |> should haveSubstring "Hello"
     finally
         Directory.Delete(tmpDir, true)
+        Environment.SetEnvironmentVariable("HOME", origHome)
 
 [<Fact>]
 let ``render with None context produces same output as before`` () =


### PR DESCRIPTION
## Summary
- Loads `FUGUE.md` from current directory and all parent directories up to git root (monorepo-aware)
- Also loads `~/.fugue/FUGUE.md` as user-level global context
- All found files concatenated with path headers; global context first, then parent→child order
- Appended to system prompt as `# Project context (from FUGUE.md)` section
- No config flags — always-on with git root as ceiling

## Changes
- `src/Fugue.Core/SystemPrompt.fs` — `findGitRoot`, `loadFugueContext`, updated `render(cwd, toolNames, context)`
- `src/Fugue.Cli/Program.fs` — `buildAgent` calls `loadFugueContext` and passes to `render`
- `tests/Fugue.Tests/SystemPromptTests.fs` — 4 unit tests (HOME-isolated, tmp-dir-based)

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 110/110 pass
- [x] Code review: APPROVED (post two-fix cycle: ExitCode guard + HOME isolation)
- [x] Reality check: APPROVED

Closes #217