### PR TITLE
feat(cli): /short and /long verbosity commands (#236)

### DIFF
--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -7,7 +7,7 @@ open System.Threading.Tasks
 open Fugue.Core.Localization
 
 // Hardcoded — small list, easier than passing through state.
-let slashCommands : string list = [ "/help"; "/clear"; "/exit" ]
+let slashCommands : string list = [ "/help"; "/clear"; "/short"; "/long"; "/exit" ]
 
 /// Session history (REPL is single-threaded). Not private so tests can seed entries directly.
 let historyStore = ResizeArray<string>()
@@ -280,6 +280,8 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
     let slashHelp =
         [ "/help",  strings.CmdHelpDesc
           "/clear", strings.CmdClearDesc
+          "/short", strings.CmdShortDesc
+          "/long",  strings.CmdLongDesc
           "/exit",  strings.CmdExitDesc ]
     let st : S =
         { Buffer          = ResizeArray<char>()

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -110,6 +110,7 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
     StatusBar.start cwd cfg
 
     let strings = pick cfg.Ui.Locale
+    let mutable verbosityPrefix : string option = None
     try
         while not cancelSrc.QuitRequested do
             let! lineOpt = ReadLine.readAsync (Render.prompt cwd) strings cancelSrc.Token
@@ -124,6 +125,8 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                 AnsiConsole.WriteLine()
                 let helpItems = [ "/help",  strings.CmdHelpDesc
                                   "/clear", strings.CmdClearDesc
+                                  "/short", strings.CmdShortDesc
+                                  "/long",  strings.CmdLongDesc
                                   "/exit",  strings.CmdExitDesc ]
                 for (name, desc) in helpItems do
                     AnsiConsole.Write(Markup("  [cyan]" + Markup.Escape name + "[/]  [dim]" + Markup.Escape desc + "[/]"))
@@ -132,10 +135,24 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
             | Some s when s = "/clear" ->
                 AnsiConsole.Clear()
                 StatusBar.refresh ()
+            | Some s when s = "/short" ->
+                verbosityPrefix <- Some "[VERBOSITY: respond briefly, 1-2 sentences per point, no elaboration unless asked]\n\n"
+                AnsiConsole.Write(Markup("[dim]" + Markup.Escape strings.VerbosityShortSet + "[/]"))
+                AnsiConsole.WriteLine()
+                StatusBar.refresh ()
+            | Some s when s = "/long" ->
+                verbosityPrefix <- Some "[VERBOSITY: respond in detail, include explanations, examples, and context]\n\n"
+                AnsiConsole.Write(Markup("[dim]" + Markup.Escape strings.VerbosityLongSet + "[/]"))
+                AnsiConsole.WriteLine()
+                StatusBar.refresh ()
             | Some userInput ->
                 AnsiConsole.Write(Render.userMessage cfg.Ui userInput)
                 AnsiConsole.WriteLine()
-                do! streamAndRender agent session userInput cfg cancelSrc
+                let effectiveInput =
+                    match verbosityPrefix with
+                    | Some prefix -> prefix + userInput
+                    | None -> userInput
+                do! streamAndRender agent session effectiveInput cfg cancelSrc
                 StatusBar.refresh ()
     finally
         Console.CancelKeyPress.RemoveHandler handler

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -25,10 +25,16 @@ type Strings =
       DiscoveryPickProvider:  string
 
       // Slash commands
-      CmdHelpDesc:  string
-      CmdClearDesc: string
-      CmdExitDesc:  string
-      HelpHeader:   string }
+      CmdHelpDesc:       string
+      CmdClearDesc:      string
+      CmdExitDesc:       string
+      CmdShortDesc:      string
+      CmdLongDesc:       string
+      HelpHeader:        string
+
+      // Verbosity feedback
+      VerbosityShortSet: string
+      VerbosityLongSet:  string }
 
 let en : Strings =
     { Cancelled            = "cancelled"
@@ -48,7 +54,11 @@ let en : Strings =
       CmdHelpDesc           = "show this help"
       CmdClearDesc          = "clear the screen"
       CmdExitDesc           = "exit Fugue"
-      HelpHeader            = "Available slash commands:" }
+      CmdShortDesc          = "switch to brief responses"
+      CmdLongDesc           = "switch to detailed responses"
+      HelpHeader            = "Available slash commands:"
+      VerbosityShortSet     = "Brevity mode on. Responses will be concise."
+      VerbosityLongSet      = "Detail mode on. Responses will be thorough." }
 
 let ru : Strings =
     { Cancelled            = "отменено"
@@ -68,7 +78,11 @@ let ru : Strings =
       CmdHelpDesc           = "показать эту справку"
       CmdClearDesc          = "очистить экран"
       CmdExitDesc           = "выйти из Fugue"
-      HelpHeader            = "Доступные команды:" }
+      CmdShortDesc          = "переключиться на краткие ответы"
+      CmdLongDesc           = "переключиться на подробные ответы"
+      HelpHeader            = "Доступные команды:"
+      VerbosityShortSet     = "Режим краткости включён. Ответы будут краткими."
+      VerbosityLongSet      = "Режим подробности включён. Ответы будут развёрнутыми." }
 
 /// Pick a Strings value by ISO-2 locale code. Unknown locales fall back to en.
 let pick (locale: string) : Strings =


### PR DESCRIPTION
## Summary
- `/short` — sets brevity mode, prepends conciseness instruction to each message for the session
- `/long` — sets detail mode, prepends thoroughness instruction to each message
- Verbosity prefix is per-session state (inside `run`, not module-level)
- User sees their original input; model receives `prefix + input`
- Both in `/help` + tab-autocomplete

## Changes
- `src/Fugue.Core/Localization.fs` — 4 new strings (en + ru): `CmdShortDesc`, `CmdLongDesc`, `VerbosityShortSet`, `VerbosityLongSet`
- `src/Fugue.Cli/Repl.fs` — `verbosityPrefix` mutable, `/short`+`/long` arms, `effectiveInput` dispatch
- `src/Fugue.Cli/ReadLine.fs` — both commands in `slashCommands` + `slashHelp`

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 106/106 pass
- [x] Reality check: APPROVED
- [x] Code review: APPROVED

Closes #236