### PR TITLE
feat(cli): /summary command — ask agent to summarize the session (#209)

### DIFF
--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -7,7 +7,7 @@ open System.Threading.Tasks
 open Fugue.Core.Localization
 
 // Hardcoded — small list, easier than passing through state.
-let slashCommands : string list = [ "/help"; "/clear"; "/exit" ]
+let slashCommands : string list = [ "/help"; "/clear"; "/summary"; "/exit" ]
 
 /// Session history (REPL is single-threaded). Not private so tests can seed entries directly.
 let historyStore = ResizeArray<string>()
@@ -278,9 +278,10 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
                 i <- i + 1
         n
     let slashHelp =
-        [ "/help",  strings.CmdHelpDesc
-          "/clear", strings.CmdClearDesc
-          "/exit",  strings.CmdExitDesc ]
+        [ "/help",    strings.CmdHelpDesc
+          "/clear",   strings.CmdClearDesc
+          "/summary", strings.CmdSummaryDesc
+          "/exit",    strings.CmdExitDesc ]
     let st : S =
         { Buffer          = ResizeArray<char>()
           Cursor          = 0

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -122,15 +122,28 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
             | Some s when s = "/help" ->
                 AnsiConsole.Write(Markup("[bold]" + Markup.Escape strings.HelpHeader + "[/]"))
                 AnsiConsole.WriteLine()
-                let helpItems = [ "/help",  strings.CmdHelpDesc
-                                  "/clear", strings.CmdClearDesc
-                                  "/exit",  strings.CmdExitDesc ]
+                let helpItems = [ "/help",    strings.CmdHelpDesc
+                                  "/clear",   strings.CmdClearDesc
+                                  "/summary", strings.CmdSummaryDesc
+                                  "/exit",    strings.CmdExitDesc ]
                 for (name, desc) in helpItems do
                     AnsiConsole.Write(Markup("  [cyan]" + Markup.Escape name + "[/]  [dim]" + Markup.Escape desc + "[/]"))
                     AnsiConsole.WriteLine()
                 StatusBar.refresh ()
             | Some s when s = "/clear" ->
                 AnsiConsole.Clear()
+                StatusBar.refresh ()
+            | Some s when s = "/summary" ->
+                let summaryPrompt =
+                    "Please generate a structured summary of our session so far.\n\n" +
+                    "Include:\n" +
+                    "- What we worked on (tasks, files changed, problems solved)\n" +
+                    "- Key decisions made\n" +
+                    "- Any open questions or next steps\n\n" +
+                    "Be concise but complete."
+                AnsiConsole.Write(Render.userMessage cfg.Ui "/summary")
+                AnsiConsole.WriteLine()
+                do! streamAndRender agent session summaryPrompt cfg cancelSrc
                 StatusBar.refresh ()
             | Some userInput ->
                 AnsiConsole.Write(Render.userMessage cfg.Ui userInput)

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -25,10 +25,11 @@ type Strings =
       DiscoveryPickProvider:  string
 
       // Slash commands
-      CmdHelpDesc:  string
-      CmdClearDesc: string
-      CmdExitDesc:  string
-      HelpHeader:   string }
+      CmdHelpDesc:    string
+      CmdClearDesc:   string
+      CmdExitDesc:    string
+      CmdSummaryDesc: string
+      HelpHeader:     string }
 
 let en : Strings =
     { Cancelled            = "cancelled"
@@ -48,6 +49,7 @@ let en : Strings =
       CmdHelpDesc           = "show this help"
       CmdClearDesc          = "clear the screen"
       CmdExitDesc           = "exit Fugue"
+      CmdSummaryDesc        = "ask the agent to summarize the current session"
       HelpHeader            = "Available slash commands:" }
 
 let ru : Strings =
@@ -68,6 +70,7 @@ let ru : Strings =
       CmdHelpDesc           = "показать эту справку"
       CmdClearDesc          = "очистить экран"
       CmdExitDesc           = "выйти из Fugue"
+      CmdSummaryDesc        = "попросить агента резюмировать текущую сессию"
       HelpHeader            = "Доступные команды:" }
 
 /// Pick a Strings value by ISO-2 locale code. Unknown locales fall back to en.


### PR DESCRIPTION
## Summary
- `/summary` slash command sends a structured summary request to the AI agent
- User sees `/summary` on screen; model receives a multi-line prompt asking for tasks, decisions, and next steps
- Added to `/help` listing and tab-autocomplete

## Changes
- `src/Fugue.Core/Localization.fs` — `CmdSummaryDesc` (en + ru)
- `src/Fugue.Cli/Repl.fs` — `/summary` pattern arm with hardcoded `summaryPrompt`
- `src/Fugue.Cli/ReadLine.fs` — `/summary` in `slashCommands` + `slashHelp`

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 106/106 pass
- [x] Reality check: APPROVED
- [x] Code review: APPROVED

Closes #209