### PR TITLE
feat(tools): Tree tool — PathSafety guard + glob validation (#256)

### DIFF
--- a/src/Fugue.Tools/AiFunctions/TreeFn.fs
+++ b/src/Fugue.Tools/AiFunctions/TreeFn.fs
@@ -1,0 +1,27 @@
+module Fugue.Tools.AiFunctions.TreeFn
+
+open Microsoft.Extensions.AI
+open Fugue.Tools.AiFunctions
+
+let private schema = DelegatedFn.parseSchema """{
+  "type":"object",
+  "properties":{
+    "path":  {"type":"string","description":"Directory path (absolute or cwd-relative). Defaults to '.' if omitted."},
+    "depth": {"type":"integer","description":"Max depth to recurse. Default 3."},
+    "glob":  {"type":"string","description":"Filename pattern to filter (e.g. '*.fs'). Optional."}
+  },
+  "required":[]
+}"""
+
+let create (cwd: string) : AIFunction =
+    DelegatedFn.DelegatedAIFunction(
+        name        = "Tree",
+        description = "Show directory structure as an ASCII tree. Optionally filter by glob pattern.",
+        schema      = schema,
+        invoke      = fun args ct -> task {
+            ct.ThrowIfCancellationRequested()
+            let path  = Args.tryGetStr args "path"  |> Option.defaultValue "."
+            let depth = Args.tryGetInt  args "depth" |> Option.defaultValue 3
+            let glob  = Args.tryGetStr args "glob"
+            return Fugue.Tools.TreeTool.tree cwd path depth glob
+        }) :> AIFunction

--- a/src/Fugue.Tools/Fugue.Tools.fsproj
+++ b/src/Fugue.Tools/Fugue.Tools.fsproj
@@ -10,6 +10,7 @@
     <Compile Include="BashTool.fs" />
     <Compile Include="GlobTool.fs" />
     <Compile Include="GrepTool.fs" />
+    <Compile Include="TreeTool.fs" />
     <Compile Include="AiFunctions/Args.fs" />
     <Compile Include="AiFunctions/DelegatedFn.fs" />
     <Compile Include="AiFunctions/ReadFn.fs" />
@@ -18,6 +19,7 @@
     <Compile Include="AiFunctions/BashFn.fs" />
     <Compile Include="AiFunctions/GlobFn.fs" />
     <Compile Include="AiFunctions/GrepFn.fs" />
+    <Compile Include="AiFunctions/TreeFn.fs" />
     <Compile Include="ToolRegistry.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Fugue.Tools/ToolRegistry.fs
+++ b/src/Fugue.Tools/ToolRegistry.fs
@@ -3,7 +3,7 @@ module Fugue.Tools.ToolRegistry
 open Microsoft.Extensions.AI
 open Fugue.Tools.AiFunctions
 
-/// Build all six tools as no-reflection AIFunction subclasses.
+/// Build all tools as no-reflection AIFunction subclasses.
 let buildAll (cwd: string) : AIFunction list = [
     ReadFn.create  cwd
     WriteFn.create cwd
@@ -11,6 +11,7 @@ let buildAll (cwd: string) : AIFunction list = [
     BashFn.create  cwd
     GlobFn.create  cwd
     GrepFn.create  cwd
+    TreeFn.create  cwd
 ]
 
-let names : string list = [ "Read"; "Write"; "Edit"; "Bash"; "Glob"; "Grep" ]
+let names : string list = [ "Read"; "Write"; "Edit"; "Bash"; "Glob"; "Grep"; "Tree" ]

--- a/src/Fugue.Tools/TreeTool.fs
+++ b/src/Fugue.Tools/TreeTool.fs
@@ -2,43 +2,50 @@ module Fugue.Tools.TreeTool
 
 open System
 open System.IO
+open Fugue.Tools.PathSafety
 
 /// Render a directory tree rooted at `dir` up to `maxDepth` levels deep.
 /// `glob` is an optional filename pattern to filter (e.g., "*.fs").
 /// Returns the ASCII tree as a string.
 let tree (cwd: string) (dir: string) (maxDepth: int) (glob: string option) : string =
-    let root =
-        if Path.IsPathRooted dir then dir
-        else Path.GetFullPath(Path.Combine(cwd, dir))
-
-    if not (Directory.Exists root) then
+    let root = PathSafety.resolve cwd dir
+    if not (PathSafety.isUnder cwd root) then
+        sprintf "Error: path outside working directory: %s" dir
+    elif not (Directory.Exists root) then
         sprintf "Error: directory not found: %s" dir
     else
-        let sb = System.Text.StringBuilder()
-        let rootName = Path.GetFileName root |> Option.ofObj |> Option.defaultValue root
-        sb.AppendLine(rootName) |> ignore
+        let globError =
+            glob |> Option.bind (fun g ->
+                try Directory.GetFiles(root, g) |> ignore; None
+                with :? ArgumentException as ex -> Some (sprintf "Error: invalid glob pattern '%s': %s" g ex.Message))
+        match globError with
+        | Some err -> err
+        | None ->
+            let sb = System.Text.StringBuilder()
+            let rootName = Path.GetFileName root |> Option.ofObj |> Option.defaultValue root
+            sb.AppendLine(rootName) |> ignore
 
-        let rec renderDir (path: string) (prefix: string) (depth: int) =
-            if depth >= maxDepth then () else
-            let entries =
-                try
-                    let dirs  = Directory.GetDirectories(path) |> Array.sort
-                    let files =
-                        match glob with
-                        | None   -> Directory.GetFiles(path) |> Array.sort
-                        | Some g -> Directory.GetFiles(path, g) |> Array.sort
-                    Array.append dirs files
-                with _ -> [||]
+            let rec renderDir (path: string) (prefix: string) (depth: int) =
+                if depth >= maxDepth then () else
+                let entries =
+                    try
+                        let dirs  = Directory.GetDirectories(path) |> Array.sort
+                        let files =
+                            match glob with
+                            | None   -> Directory.GetFiles(path) |> Array.sort
+                            | Some g -> Directory.GetFiles(path, g) |> Array.sort
+                        Array.append dirs files
+                    with _ -> [||]
 
-            for i in 0 .. entries.Length - 1 do
-                let entry = entries.[i]
-                let isLast = (i = entries.Length - 1)
-                let connector   = if isLast then "└── " else "├── "
-                let childPrefix = if isLast then prefix + "    " else prefix + "│   "
-                let entryName = Path.GetFileName entry |> Option.ofObj |> Option.defaultValue entry
-                sb.AppendLine(prefix + connector + entryName) |> ignore
-                if Directory.Exists entry then
-                    renderDir entry childPrefix (depth + 1)
+                for i in 0 .. entries.Length - 1 do
+                    let entry = entries.[i]
+                    let isLast = (i = entries.Length - 1)
+                    let connector   = if isLast then "└── " else "├── "
+                    let childPrefix = if isLast then prefix + "    " else prefix + "│   "
+                    let entryName = Path.GetFileName entry |> Option.ofObj |> Option.defaultValue entry
+                    sb.AppendLine(prefix + connector + entryName) |> ignore
+                    if Directory.Exists entry then
+                        renderDir entry childPrefix (depth + 1)
 
-        renderDir root "" 0
-        sb.ToString().TrimEnd()
+            renderDir root "" 0
+            sb.ToString().TrimEnd()

--- a/src/Fugue.Tools/TreeTool.fs
+++ b/src/Fugue.Tools/TreeTool.fs
@@ -1,0 +1,44 @@
+module Fugue.Tools.TreeTool
+
+open System
+open System.IO
+
+/// Render a directory tree rooted at `dir` up to `maxDepth` levels deep.
+/// `glob` is an optional filename pattern to filter (e.g., "*.fs").
+/// Returns the ASCII tree as a string.
+let tree (cwd: string) (dir: string) (maxDepth: int) (glob: string option) : string =
+    let root =
+        if Path.IsPathRooted dir then dir
+        else Path.GetFullPath(Path.Combine(cwd, dir))
+
+    if not (Directory.Exists root) then
+        sprintf "Error: directory not found: %s" dir
+    else
+        let sb = System.Text.StringBuilder()
+        let rootName = Path.GetFileName root |> Option.ofObj |> Option.defaultValue root
+        sb.AppendLine(rootName) |> ignore
+
+        let rec renderDir (path: string) (prefix: string) (depth: int) =
+            if depth >= maxDepth then () else
+            let entries =
+                try
+                    let dirs  = Directory.GetDirectories(path) |> Array.sort
+                    let files =
+                        match glob with
+                        | None   -> Directory.GetFiles(path) |> Array.sort
+                        | Some g -> Directory.GetFiles(path, g) |> Array.sort
+                    Array.append dirs files
+                with _ -> [||]
+
+            for i in 0 .. entries.Length - 1 do
+                let entry = entries.[i]
+                let isLast = (i = entries.Length - 1)
+                let connector   = if isLast then "└── " else "├── "
+                let childPrefix = if isLast then prefix + "    " else prefix + "│   "
+                let entryName = Path.GetFileName entry |> Option.ofObj |> Option.defaultValue entry
+                sb.AppendLine(prefix + connector + entryName) |> ignore
+                if Directory.Exists entry then
+                    renderDir entry childPrefix (depth + 1)
+
+        renderDir root "" 0
+        sb.ToString().TrimEnd()

--- a/tests/Fugue.Tests/Fugue.Tests.fsproj
+++ b/tests/Fugue.Tests/Fugue.Tests.fsproj
@@ -26,6 +26,7 @@
     <Compile Include="BashToolTests.fs" />
     <Compile Include="GlobToolTests.fs" />
     <Compile Include="GrepToolTests.fs" />
+    <Compile Include="TreeToolTests.fs" />
     <Compile Include="DiscoveryTests.fs" />
     <Compile Include="ConversationTests.fs" />
     <Compile Include="Program.fs" />

--- a/tests/Fugue.Tests/ToolRegistryTests.fs
+++ b/tests/Fugue.Tests/ToolRegistryTests.fs
@@ -5,9 +5,9 @@ open FsUnit.Xunit
 open Fugue.Tools
 
 [<Fact>]
-let ``buildAll returns 6 functions`` () =
+let ``buildAll returns 7 functions`` () =
     let fns = ToolRegistry.buildAll "/tmp"
-    fns |> List.length |> should equal 6
+    fns |> List.length |> should equal 7
 
 [<Fact>]
 let ``buildAll names match the names list`` () =

--- a/tests/Fugue.Tests/TreeToolTests.fs
+++ b/tests/Fugue.Tests/TreeToolTests.fs
@@ -1,0 +1,45 @@
+module Fugue.Tests.TreeToolTests
+
+open System.IO
+open Xunit
+open FsUnit.Xunit
+open Fugue.Tools.TreeTool
+
+[<Fact>]
+let ``tree returns root directory name`` () =
+    let tmpDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+    Directory.CreateDirectory tmpDir |> ignore
+    try
+        let result = tree tmpDir "." 3 None
+        result |> should haveSubstring (Path.GetFileName tmpDir)
+    finally
+        Directory.Delete(tmpDir, true)
+
+[<Fact>]
+let ``tree lists files in directory`` () =
+    let tmpDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+    Directory.CreateDirectory tmpDir |> ignore
+    try
+        File.WriteAllText(Path.Combine(tmpDir, "hello.txt"), "hi")
+        let result = tree tmpDir "." 3 None
+        result |> should haveSubstring "hello.txt"
+    finally
+        Directory.Delete(tmpDir, true)
+
+[<Fact>]
+let ``tree filters by glob`` () =
+    let tmpDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+    Directory.CreateDirectory tmpDir |> ignore
+    try
+        File.WriteAllText(Path.Combine(tmpDir, "main.fs"), "")
+        File.WriteAllText(Path.Combine(tmpDir, "notes.txt"), "")
+        let result = tree tmpDir "." 3 (Some "*.fs")
+        result |> should haveSubstring "main.fs"
+        result |> should not' (haveSubstring "notes.txt")
+    finally
+        Directory.Delete(tmpDir, true)
+
+[<Fact>]
+let ``tree returns error for nonexistent directory`` () =
+    let result = tree "/tmp" "/tmp/does-not-exist-xyz" 3 None
+    result |> should haveSubstring "Error"

--- a/tests/Fugue.Tests/TreeToolTests.fs
+++ b/tests/Fugue.Tests/TreeToolTests.fs
@@ -43,3 +43,13 @@ let ``tree filters by glob`` () =
 let ``tree returns error for nonexistent directory`` () =
     let result = tree "/tmp" "/tmp/does-not-exist-xyz" 3 None
     result |> should haveSubstring "Error"
+
+[<Fact>]
+let ``tree rejects path outside working directory`` () =
+    let tmpDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+    Directory.CreateDirectory tmpDir |> ignore
+    try
+        let result = tree tmpDir "../etc" 3 None
+        result |> should haveSubstring "path outside working directory"
+    finally
+        Directory.Delete(tmpDir, true)


### PR DESCRIPTION
## Summary
- **Security fix**: `Tree path="../../.."` now returns `Error: path outside working directory` — uses `PathSafety.resolve` + `PathSafety.isUnder` consistent with all other file-touching tools (Read/Write/Edit/Glob/Grep)
- **Glob validation**: `ArgumentException` from invalid glob patterns is now surfaced at entry via `Option.bind` rather than silently producing an empty tree
- **Regression test**: `tree cwd "../etc" 3 None` → `"path outside working directory"` (locked in at the Tree layer, supplements PathSafety's own tests)

## Test plan
- [ ] `Tree path="../etc"` → "path outside working directory" error
- [ ] `Tree path="."` in normal directory → renders tree correctly
- [ ] `Tree glob="*.fs"` → only shows `.fs` files
- [ ] `dotnet test` green (111/111)

Closes #256