### PR TITLE
feat(cli): /summarize <path> command (#385)

### DIFF
--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -7,7 +7,7 @@ open System.Threading.Tasks
 open Fugue.Core.Localization
 
 // Hardcoded — small list, easier than passing through state.
-let slashCommands : string list = [ "/help"; "/clear"; "/exit" ]
+let slashCommands : string list = [ "/help"; "/clear"; "/exit"; "/summarize" ]
 
 /// Session history (REPL is single-threaded). Not private so tests can seed entries directly.
 let historyStore = ResizeArray<string>()
@@ -278,9 +278,10 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
                 i <- i + 1
         n
     let slashHelp =
-        [ "/help",  strings.CmdHelpDesc
-          "/clear", strings.CmdClearDesc
-          "/exit",  strings.CmdExitDesc ]
+        [ "/help",      strings.CmdHelpDesc
+          "/clear",     strings.CmdClearDesc
+          "/exit",      strings.CmdExitDesc
+          "/summarize", strings.CmdSummarizeDesc ]
     let st : S =
         { Buffer          = ResizeArray<char>()
           Cursor          = 0

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -122,15 +122,36 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
             | Some s when s = "/help" ->
                 AnsiConsole.Write(Markup("[bold]" + Markup.Escape strings.HelpHeader + "[/]"))
                 AnsiConsole.WriteLine()
-                let helpItems = [ "/help",  strings.CmdHelpDesc
-                                  "/clear", strings.CmdClearDesc
-                                  "/exit",  strings.CmdExitDesc ]
+                let helpItems = [ "/help",      strings.CmdHelpDesc
+                                  "/clear",     strings.CmdClearDesc
+                                  "/exit",      strings.CmdExitDesc
+                                  "/summarize", strings.CmdSummarizeDesc ]
                 for (name, desc) in helpItems do
                     AnsiConsole.Write(Markup("  [cyan]" + Markup.Escape name + "[/]  [dim]" + Markup.Escape desc + "[/]"))
                     AnsiConsole.WriteLine()
                 StatusBar.refresh ()
             | Some s when s = "/clear" ->
                 AnsiConsole.Clear()
+                StatusBar.refresh ()
+            | Some s when s.StartsWith "/summarize" ->
+                let rawArg = s.Substring("/summarize".Length).Trim()
+                if System.String.IsNullOrWhiteSpace rawArg then
+                    AnsiConsole.Write(Markup("[dim]Usage: /summarize <path>[/]"))
+                    AnsiConsole.WriteLine()
+                else
+                    let targetPath =
+                        if System.IO.Path.IsPathRooted rawArg then rawArg
+                        else System.IO.Path.GetFullPath(System.IO.Path.Combine(cwd, rawArg))
+                    let summarizePrompt =
+                        if System.IO.Directory.Exists targetPath then
+                            sprintf "Please summarize the directory '%s'.\n\nProvide a structured summary:\n1. Purpose — what does this module/package do?\n2. Public API — key functions, types, or entry points\n3. Key dependencies — what does it depend on?\n4. Notable design decisions — any interesting patterns or constraints\n\nBe concise (2–4 sentences per section). Use the Read and Glob tools to explore the files." rawArg
+                        elif System.IO.File.Exists targetPath then
+                            sprintf "Please summarize the file '%s'.\n\nProvide a structured summary:\n1. Purpose — what does this file do?\n2. Public API — exported functions or types\n3. Key dependencies — what modules/libraries does it use?\n4. Notable design decisions — any interesting patterns or constraints\n\nBe concise (2–4 sentences per section). Use the Read tool to examine the file." rawArg
+                        else
+                            sprintf "The path '%s' does not exist. Please let me know." rawArg
+                    AnsiConsole.Write(Render.userMessage cfg.Ui ("/summarize " + rawArg))
+                    AnsiConsole.WriteLine()
+                    do! streamAndRender agent session summarizePrompt cfg cancelSrc
                 StatusBar.refresh ()
             | Some userInput ->
                 AnsiConsole.Write(Render.userMessage cfg.Ui userInput)

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -25,10 +25,11 @@ type Strings =
       DiscoveryPickProvider:  string
 
       // Slash commands
-      CmdHelpDesc:  string
-      CmdClearDesc: string
-      CmdExitDesc:  string
-      HelpHeader:   string }
+      CmdHelpDesc:      string
+      CmdClearDesc:     string
+      CmdExitDesc:      string
+      CmdSummarizeDesc: string
+      HelpHeader:       string }
 
 let en : Strings =
     { Cancelled            = "cancelled"
@@ -48,6 +49,7 @@ let en : Strings =
       CmdHelpDesc           = "show this help"
       CmdClearDesc          = "clear the screen"
       CmdExitDesc           = "exit Fugue"
+      CmdSummarizeDesc      = "summarize a file or directory"
       HelpHeader            = "Available slash commands:" }
 
 let ru : Strings =
@@ -68,6 +70,7 @@ let ru : Strings =
       CmdHelpDesc           = "показать эту справку"
       CmdClearDesc          = "очистить экран"
       CmdExitDesc           = "выйти из Fugue"
+      CmdSummarizeDesc      = "резюме файла или директории"
       HelpHeader            = "Доступные команды:" }
 
 /// Pick a Strings value by ISO-2 locale code. Unknown locales fall back to en.


### PR DESCRIPTION
## Summary
- `/summarize <path>` — sends a structured AI prompt to summarize a file or directory (purpose, public API, dependencies, design decisions)
- Works for both files and directories; shows usage hint if no path provided
- Streams output progressively via streamAndRender

## Test plan
- [ ] `/summarize src/Fugue.Agent/` → AI summarizes the agent module
- [ ] `/summarize src/Fugue.Core/Config.fs` → AI summarizes the config file
- [ ] `/summarize` (no arg) → shows usage hint
- [ ] `/summarize nonexistent` → AI reports path not found
- [ ] `dotnet test` green

Closes #385