### PR TITLE
fix(tools): PathSafety.isUnder guard in Read/Write/Edit/Glob/Grep (#415)

### DIFF
--- a/src/Fugue.Tools/EditTool.fs
+++ b/src/Fugue.Tools/EditTool.fs
@@ -14,6 +14,8 @@ let edit
     ([<Description("If true, replace every occurrence; default false.")>] replaceAll: bool option)
     : string =
     let full = resolve cwd path
+    if not (isUnder cwd full) then
+        raise (UnauthorizedAccessException(sprintf "path outside working directory: %s" path))
     if not (File.Exists full) then raise (FileNotFoundException("file not found", full))
     let original = File.ReadAllText full
     let count =

--- a/src/Fugue.Tools/GlobTool.fs
+++ b/src/Fugue.Tools/GlobTool.fs
@@ -1,5 +1,6 @@
 module Fugue.Tools.GlobTool
 
+open System
 open System.IO
 open System.ComponentModel
 open Microsoft.Extensions.FileSystemGlobbing
@@ -12,6 +13,8 @@ let glob
     ([<Description("Search root, defaults to cwd.")>] root: string option)
     : string =
     let r = root |> Option.map (resolve cwd) |> Option.defaultValue cwd
+    if not (isUnder cwd r) then
+        raise (UnauthorizedAccessException(sprintf "search root outside working directory: %s" (Option.defaultValue "." root)))
     let matcher = Matcher()
     matcher.AddInclude pattern |> ignore
     let results = matcher.Execute(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper(DirectoryInfo r))

--- a/src/Fugue.Tools/GrepTool.fs
+++ b/src/Fugue.Tools/GrepTool.fs
@@ -15,6 +15,8 @@ let grep
     ([<Description("Optional include glob (e.g. **/*.fs); default = all files.")>] glob: string option)
     : string =
     let r = root |> Option.map (resolve cwd) |> Option.defaultValue cwd
+    if not (isUnder cwd r) then
+        raise (UnauthorizedAccessException(sprintf "search root outside working directory: %s" (Option.defaultValue "." root)))
     let regex = Regex(pattern, RegexOptions.Compiled)
 
     let files =

--- a/src/Fugue.Tools/ReadTool.fs
+++ b/src/Fugue.Tools/ReadTool.fs
@@ -13,6 +13,8 @@ let read
     ([<Description("Read at most this many lines (default unlimited).")>] limit: int option)
     : string =
     let full = resolve cwd path
+    if not (isUnder cwd full) then
+        raise (UnauthorizedAccessException(sprintf "path outside working directory: %s" path))
     if not (File.Exists full) then raise (FileNotFoundException("file not found", full))
 
     let allLines = File.ReadAllLines full

--- a/src/Fugue.Tools/WriteTool.fs
+++ b/src/Fugue.Tools/WriteTool.fs
@@ -13,6 +13,8 @@ let write
     ([<Description("Content to write (UTF-8, no BOM).")>] content: string)
     : string =
     let full = resolve cwd path
+    if not (isUnder cwd full) then
+        raise (UnauthorizedAccessException(sprintf "path outside working directory: %s" path))
     let dir = Path.GetDirectoryName full |> Option.ofObj |> Option.defaultValue "."
     if dir <> "." || not (Directory.Exists dir) then Directory.CreateDirectory dir |> ignore
     File.WriteAllText(full, content, UTF8Encoding(false))

--- a/tests/Fugue.Tests/Fugue.Tests.fsproj
+++ b/tests/Fugue.Tests/Fugue.Tests.fsproj
@@ -28,6 +28,7 @@
     <Compile Include="GrepToolTests.fs" />
     <Compile Include="DiscoveryTests.fs" />
     <Compile Include="ConversationTests.fs" />
+    <Compile Include="PathSafetyGuardTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Fugue.Tests/PathSafetyGuardTests.fs
+++ b/tests/Fugue.Tests/PathSafetyGuardTests.fs
@@ -1,0 +1,111 @@
+module Fugue.Tests.PathSafetyGuardTests
+
+open System
+open System.IO
+open Xunit
+open FsUnit.Xunit
+
+let private mkTmpDir () =
+    let d = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+    Directory.CreateDirectory d |> ignore
+    d
+
+[<Fact>]
+let ``ReadTool rejects path outside working directory`` () =
+    let tmpDir = mkTmpDir ()
+    try
+        (fun () -> Fugue.Tools.ReadTool.read tmpDir "../../etc/passwd" None None |> ignore)
+        |> should throw typeof<UnauthorizedAccessException>
+    finally
+        Directory.Delete(tmpDir, true)
+
+[<Fact>]
+let ``ReadTool rejects absolute path outside working directory`` () =
+    let tmpDir = mkTmpDir ()
+    try
+        (fun () -> Fugue.Tools.ReadTool.read tmpDir "/etc/passwd" None None |> ignore)
+        |> should throw typeof<UnauthorizedAccessException>
+    finally
+        Directory.Delete(tmpDir, true)
+
+[<Fact>]
+let ``WriteTool rejects path outside working directory`` () =
+    let tmpDir = mkTmpDir ()
+    try
+        (fun () -> Fugue.Tools.WriteTool.write tmpDir "../../evil.txt" "bad" |> ignore)
+        |> should throw typeof<UnauthorizedAccessException>
+    finally
+        Directory.Delete(tmpDir, true)
+
+[<Fact>]
+let ``WriteTool rejects absolute path outside working directory`` () =
+    let tmpDir = mkTmpDir ()
+    try
+        let outside = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+        (fun () -> Fugue.Tools.WriteTool.write tmpDir outside "bad" |> ignore)
+        |> should throw typeof<UnauthorizedAccessException>
+    finally
+        Directory.Delete(tmpDir, true)
+
+[<Fact>]
+let ``EditTool rejects path outside working directory`` () =
+    let tmpDir = mkTmpDir ()
+    try
+        (fun () -> Fugue.Tools.EditTool.edit tmpDir "../../etc/passwd" "old" "new" None |> ignore)
+        |> should throw typeof<UnauthorizedAccessException>
+    finally
+        Directory.Delete(tmpDir, true)
+
+[<Fact>]
+let ``EditTool rejects absolute path outside working directory`` () =
+    let tmpDir = mkTmpDir ()
+    try
+        let outside = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+        File.WriteAllText(outside, "content")
+        try
+            (fun () -> Fugue.Tools.EditTool.edit tmpDir outside "content" "other" None |> ignore)
+            |> should throw typeof<UnauthorizedAccessException>
+        finally
+            File.Delete outside
+    finally
+        Directory.Delete(tmpDir, true)
+
+[<Fact>]
+let ``GlobTool rejects root outside working directory`` () =
+    let tmpDir = mkTmpDir ()
+    let outsideDir = mkTmpDir ()
+    try
+        (fun () -> Fugue.Tools.GlobTool.glob tmpDir "**/*" (Some outsideDir) |> ignore)
+        |> should throw typeof<UnauthorizedAccessException>
+    finally
+        Directory.Delete(tmpDir, true)
+        Directory.Delete(outsideDir, true)
+
+[<Fact>]
+let ``GlobTool rejects traversal root outside working directory`` () =
+    let tmpDir = mkTmpDir ()
+    try
+        (fun () -> Fugue.Tools.GlobTool.glob tmpDir "**/*" (Some "../../etc") |> ignore)
+        |> should throw typeof<UnauthorizedAccessException>
+    finally
+        Directory.Delete(tmpDir, true)
+
+[<Fact>]
+let ``GrepTool rejects root outside working directory`` () =
+    let tmpDir = mkTmpDir ()
+    let outsideDir = mkTmpDir ()
+    try
+        (fun () -> Fugue.Tools.GrepTool.grep tmpDir "pattern" (Some outsideDir) None |> ignore)
+        |> should throw typeof<UnauthorizedAccessException>
+    finally
+        Directory.Delete(tmpDir, true)
+        Directory.Delete(outsideDir, true)
+
+[<Fact>]
+let ``GrepTool rejects traversal root outside working directory`` () =
+    let tmpDir = mkTmpDir ()
+    try
+        (fun () -> Fugue.Tools.GrepTool.grep tmpDir "pattern" (Some "../../etc") None |> ignore)
+        |> should throw typeof<UnauthorizedAccessException>
+    finally
+        Directory.Delete(tmpDir, true)


### PR DESCRIPTION
Security fix: path traversal now raises UnauthorizedAccessException in all 5 file tools. 10 regression tests added. Closes #415.