### PR TITLE
feat(tools): Read tool 1 MB file size guard (#403)

### DIFF
--- a/src/Fugue.Tools/ReadTool.fs
+++ b/src/Fugue.Tools/ReadTool.fs
@@ -5,6 +5,12 @@ open System.IO
 open System.ComponentModel
 open Fugue.Tools.PathSafety
 
+let private formatBytes (n: int64) : string =
+    if n >= 1_073_741_824L then sprintf "%.1f GB" (float n / 1_073_741_824.0)
+    elif n >= 1_048_576L then sprintf "%.1f MB" (float n / 1_048_576.0)
+    elif n >= 1024L then sprintf "%.1f KB" (float n / 1024.0)
+    else sprintf "%d B" n
+
 [<Description("Read a text file. Returns lines prefixed with 1-based line numbers (cat -n format).")>]
 let read
     ([<Description("File path (absolute or relative to working directory).")>] cwd: string)
@@ -14,6 +20,11 @@ let read
     : string =
     let full = resolve cwd path
     if not (File.Exists full) then raise (FileNotFoundException("file not found", full))
+    let sizeBytes = FileInfo(full).Length
+    if sizeBytes > 1_048_576L then
+        raise (InvalidOperationException(
+            sprintf "file too large (%s) — use Grep to search or Glob to list sections"
+                (formatBytes sizeBytes)))
 
     let allLines = File.ReadAllLines full
     let off = offset |> Option.defaultValue 0

--- a/tests/Fugue.Tests/ReadToolTests.fs
+++ b/tests/Fugue.Tests/ReadToolTests.fs
@@ -29,3 +29,15 @@ let ``Read of missing file throws`` () =
     let path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"))
     (fun () -> Fugue.Tools.ReadTool.read (Path.GetTempPath()) path None None |> ignore)
     |> should throw typeof<FileNotFoundException>
+
+[<Fact>]
+let ``read raises for file exceeding 1 MB limit`` () =
+    let tmpDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+    Directory.CreateDirectory tmpDir |> ignore
+    try
+        let largeFile = Path.Combine(tmpDir, "large.bin")
+        File.WriteAllBytes(largeFile, Array.zeroCreate 1_100_000)
+        (fun () -> Fugue.Tools.ReadTool.read tmpDir "large.bin" None None |> ignore)
+        |> should throw typeof<InvalidOperationException>
+    finally
+        Directory.Delete(tmpDir, true)


### PR DESCRIPTION
## Summary
Prevents context-window blowout from large files (binaries, logs, datasets).
- Files > 1 MB raise `InvalidOperationException` with human-readable size and a hint to use Grep/Glob instead
- Helper `formatBytes` formats bytes as KB/MB/GB
- Regression test covers the > 1 MB case

Closes #403