### PR TITLE
fix(tools): resolve symlinks in PathSafety to block escape via symlink

### DIFF
--- a/src/Fugue.Tools/PathSafety.fs
+++ b/src/Fugue.Tools/PathSafety.fs
@@ -3,11 +3,23 @@ module Fugue.Tools.PathSafety
 open System
 open System.IO
 
+let private realPath (p: string) : string =
+    // Resolve symlinks if the path exists; fall back to Path.GetFullPath if not.
+    try
+        let resolveInfo (fi: FileSystemInfo) =
+            match fi.ResolveLinkTarget(returnFinalTarget = true) with
+            | null -> p   // not a symlink
+            | target -> Path.GetFullPath target.FullName
+        if Directory.Exists p then resolveInfo (DirectoryInfo(p))
+        elif File.Exists p then resolveInfo (FileInfo(p))
+        else p
+    with _ -> p
+
 let resolve (cwd: string) (path: string) : string =
-    if Path.IsPathRooted path then
-        Path.GetFullPath path
-    else
-        Path.GetFullPath(Path.Combine(cwd, path))
+    let full =
+        if Path.IsPathRooted path then Path.GetFullPath path
+        else Path.GetFullPath(Path.Combine(cwd, path))
+    realPath full
 
 let isUnder (root: string) (path: string) : bool =
     let r = (Path.GetFullPath root).TrimEnd(Path.DirectorySeparatorChar) + string Path.DirectorySeparatorChar

--- a/tests/Fugue.Tests/Fugue.Tests.fsproj
+++ b/tests/Fugue.Tests/Fugue.Tests.fsproj
@@ -28,6 +28,7 @@
     <Compile Include="GrepToolTests.fs" />
     <Compile Include="DiscoveryTests.fs" />
     <Compile Include="ConversationTests.fs" />
+    <Compile Include="PathSafetySymlinkTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Fugue.Tests/PathSafetySymlinkTests.fs
+++ b/tests/Fugue.Tests/PathSafetySymlinkTests.fs
@@ -1,0 +1,26 @@
+module Fugue.Tests.PathSafetySymlinkTests
+
+open System.IO
+open Xunit
+open FsUnit.Xunit
+open Fugue.Tools
+
+[<Fact>]
+let ``isUnder blocks symlink pointing outside cwd`` () =
+    let tmpDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+    let outsideDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+    Directory.CreateDirectory tmpDir |> ignore
+    Directory.CreateDirectory outsideDir |> ignore
+    try
+        let linkPath = Path.Combine(tmpDir, "escape")
+        try
+            Directory.CreateSymbolicLink(linkPath, outsideDir) |> ignore
+        with _ ->
+            () // Skip if symlink creation fails (e.g., no privilege on Windows CI)
+        if Directory.Exists linkPath then
+            let resolved = PathSafety.resolve tmpDir "escape"
+            let safe = PathSafety.isUnder tmpDir resolved
+            safe |> should equal false
+    finally
+        try Directory.Delete(tmpDir, true) with _ -> ()
+        try Directory.Delete(outsideDir, true) with _ -> ()


### PR DESCRIPTION
Closes #454. Adds realPath helper using FileSystemInfo.ResolveLinkTarget(returnFinalTarget=true). Falls back to Path.GetFullPath if path doesn't exist yet or if symlink resolution fails. Adds regression test.