### PR TITLE
feat(readline): Tab completion for slash commands

### DIFF
--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -7,7 +7,10 @@ open System.Threading.Tasks
 open Fugue.Core.Localization
 
 // Hardcoded — small list, easier than passing through state.
-let slashCommands : string list = [ "/help"; "/clear"; "/exit" ]
+let slashCommands : string[] =
+    [| "/help"; "/clear"; "/new"; "/exit"; "/quit"
+       "/diff"; "/diff --staged"; "/init"; "/summarize"
+       "/tools"; "/clear-history"; "/short"; "/long"; "/summary"; "/doctor" |]
 
 /// Session history (REPL is single-threaded). Not private so tests can seed entries directly.
 let historyStore = ResizeArray<string>()
@@ -296,6 +299,9 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
           SlashHelp       = slashHelp }
 
     Console.TreatControlCAsInput <- true
+    // Tab-completion cycle state — resets on any non-Tab keypress.
+    let mutable tabMatches : string[] = [||]
+    let mutable tabIndex   = -1
     try
         redraw st
         let mutable result : string option voption = ValueNone
@@ -308,21 +314,45 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
                     writeRaw ("\x1b[" + string st.RowsBelowCursor + "B")
                 eraseLines st.LinesRendered
                 st.RowsBelowCursor <- 0
-            match applyKey k st with
-            | Continue -> redraw st
-            | Wipe     -> redraw st
-            | Submit s ->
-                eraseRendered ()
-                if not (String.IsNullOrWhiteSpace s) then
-                    if historyStore.Count = 0 || historyStore.[historyStore.Count - 1] <> s then
-                        historyStore.Add s
-                st.HistoryIdx <- -1
-                st.SavedBuffer <- None
-                result <- ValueSome (Some s)
-            | Quit ->
-                eraseRendered ()
-                writeRaw "\n"
-                result <- ValueSome None
+            if k.Key = ConsoleKey.Tab then
+                let currentInput = String(st.Buffer.ToArray())
+                if currentInput.StartsWith "/" then
+                    // If this is the first Tab or the buffer no longer starts with the
+                    // last completed candidate, recompute matches from the current input.
+                    let needsReset =
+                        tabMatches.Length = 0 ||
+                        (tabIndex >= 0 && tabIndex < tabMatches.Length &&
+                         currentInput <> tabMatches.[tabIndex])
+                    if needsReset then
+                        tabMatches <- slashCommands |> Array.filter (fun c -> c.StartsWith currentInput)
+                        tabIndex   <- -1
+                    if tabMatches.Length > 0 then
+                        tabIndex <- (tabIndex + 1) % tabMatches.Length
+                        let completed = tabMatches.[tabIndex]
+                        st.Buffer.Clear()
+                        st.Buffer.AddRange(completed.ToCharArray())
+                        st.Cursor <- st.Buffer.Count
+                        redraw st
+                // Tab on empty / non-slash input: ignore.
+            else
+                // Any non-Tab key resets the completion cycle.
+                tabMatches <- [||]
+                tabIndex   <- -1
+                match applyKey k st with
+                | Continue -> redraw st
+                | Wipe     -> redraw st
+                | Submit s ->
+                    eraseRendered ()
+                    if not (String.IsNullOrWhiteSpace s) then
+                        if historyStore.Count = 0 || historyStore.[historyStore.Count - 1] <> s then
+                            historyStore.Add s
+                    st.HistoryIdx <- -1
+                    st.SavedBuffer <- None
+                    result <- ValueSome (Some s)
+                | Quit ->
+                    eraseRendered ()
+                    writeRaw "\n"
+                    result <- ValueSome None
         return
             match result with
             | ValueSome v -> v

--- a/tests/Fugue.Tests/ReadLineTests.fs
+++ b/tests/Fugue.Tests/ReadLineTests.fs
@@ -344,3 +344,49 @@ let ``word_CtrlW_atZero_isNoOp`` () =
     act |> should equal Continue
     String(s.Buffer.ToArray()) |> should equal "hello"
     s.Cursor |> should equal 0
+
+// ── Tab-completion list tests ─────────────────────────────────────────────────
+
+[<Fact>]
+let ``tab_slashCommands_containsExpectedEntries`` () =
+    slashCommands |> should contain "/help"
+    slashCommands |> should contain "/clear"
+    slashCommands |> should contain "/new"
+    slashCommands |> should contain "/exit"
+    slashCommands |> should contain "/quit"
+    slashCommands |> should contain "/diff"
+    slashCommands |> should contain "/diff --staged"
+    slashCommands |> should contain "/init"
+    slashCommands |> should contain "/summarize"
+    slashCommands |> should contain "/tools"
+    slashCommands |> should contain "/clear-history"
+    slashCommands |> should contain "/short"
+    slashCommands |> should contain "/long"
+    slashCommands |> should contain "/summary"
+    slashCommands |> should contain "/doctor"
+
+[<Fact>]
+let ``tab_filterByPrefix_cl_returnsExpectedMatches`` () =
+    let matches = slashCommands |> Array.filter (fun c -> c.StartsWith "/cl")
+    matches |> should contain "/clear"
+    matches |> should contain "/clear-history"
+    matches.Length |> should equal 2
+
+[<Fact>]
+let ``tab_filterByPrefix_h_returnsSingleMatch`` () =
+    let matches = slashCommands |> Array.filter (fun c -> c.StartsWith "/h")
+    matches |> should equal [| "/help" |]
+
+[<Fact>]
+let ``tab_filterByPrefix_noMatch_returnsEmpty`` () =
+    let matches = slashCommands |> Array.filter (fun c -> c.StartsWith "/zzz")
+    matches |> should equal [||]
+
+[<Fact>]
+let ``tab_filterByPrefix_slash_returnsAll`` () =
+    let matches = slashCommands |> Array.filter (fun c -> c.StartsWith "/")
+    matches.Length |> should equal slashCommands.Length
+
+[<Fact>]
+let ``tab_allCommandsStartWithSlash`` () =
+    slashCommands |> Array.forall (fun c -> c.StartsWith "/") |> should equal true


### PR DESCRIPTION
## Summary

- Closes #437. Tab on a `/`-prefixed input cycles through matching slash commands.
- Single match completes immediately; multiple matches cycle on repeated Tab presses; resets on any other key.
- Expands `slashCommands` from 3 entries to the full 15-command list (`/help`, `/clear`, `/new`, `/exit`, `/quit`, `/diff`, `/diff --staged`, `/init`, `/summarize`, `/tools`, `/clear-history`, `/short`, `/long`, `/summary`, `/doctor`).

## Implementation notes

- Tab is intercepted at the `readAsync` loop level (before `applyKey`) using two closure-local mutables: `tabMatches: string[]` and `tabIndex: int`. No module-level state added.
- `applyKey` is unchanged — pure, AOT-safe, no reflection.
- Tab on empty or non-slash input is silently ignored (no bell, no auto-submit).

## Test plan

- [x] `tab_slashCommands_containsExpectedEntries` — all 15 commands present
- [x] `tab_filterByPrefix_cl_returnsExpectedMatches` — `/cl` → `["/clear"; "/clear-history"]`
- [x] `tab_filterByPrefix_h_returnsSingleMatch` — `/h` → `["/help"]`
- [x] `tab_filterByPrefix_noMatch_returnsEmpty` — `/zzz` → `[]`
- [x] `tab_filterByPrefix_slash_returnsAll` — `/` → all 15
- [x] `tab_allCommandsStartWithSlash` — invariant check
- Build: `0 Error(s) 0 Warning(s)`
- Tests: `112/112 passed`