### PR TITLE
feat(readline): undo/redo in current prompt (Ctrl+Z / Ctrl+Y)

### DIFF
--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -197,6 +197,24 @@ let applyKey (k: ConsoleKeyInfo) (s: S) : Action =
     else
         Continue
 
+// ── Undo/redo bounded-stack helpers ──────────────────────────────────────────
+
+let private maxUndo = 100
+
+/// Push `item` onto `stack`, evicting the oldest entry when full.
+/// Public so tests can exercise the bounded-push logic without going through readAsync.
+let pushBounded (stack: ResizeArray<'a>) (item: 'a) =
+    if stack.Count >= maxUndo then stack.RemoveAt 0
+    stack.Add item
+
+/// Pop the last element from a ResizeArray used as a stack. Returns None if empty.
+let private popResizeArray (stack: ResizeArray<'a>) : 'a option =
+    if stack.Count = 0 then None
+    else
+        let item = stack.[stack.Count - 1]
+        stack.RemoveAt(stack.Count - 1)
+        Some item
+
 let private writeRaw (s: string) =
     Console.Out.Write s
     Console.Out.Flush()
@@ -295,6 +313,32 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
           Width           = max 40 Console.WindowWidth
           SlashHelp       = slashHelp }
 
+    // Per-prompt undo/redo stacks (reset when readAsync returns).
+    let undoStack = ResizeArray<string * int>()
+    let redoStack = ResizeArray<string * int>()
+
+    let snapshot () = (String(st.Buffer.ToArray()), st.Cursor)
+
+    let pushUndo () =
+        pushBounded undoStack (snapshot ())
+        redoStack.Clear()
+
+    let applySnapshot (buf: string, cur: int) =
+        st.Buffer.Clear()
+        st.Buffer.AddRange(buf.ToCharArray())
+        st.Cursor <- min cur st.Buffer.Count
+
+    // Keys that modify the buffer — push undo snapshot before dispatching.
+    let isEditKey (k: ConsoleKeyInfo) =
+        not (Char.IsControl k.KeyChar)           // printable insert
+        || k.Key = ConsoleKey.Backspace
+        || k.Key = ConsoleKey.Delete
+        || (k.Key = ConsoleKey.Enter && k.Modifiers.HasFlag ConsoleModifiers.Shift)  // Shift+Enter inserts \n
+        || isCtrl k ConsoleKey.D                 // delete-char-forward (when buffer non-empty)
+        || isCtrl k ConsoleKey.W                 // word delete
+        || (k.Key = ConsoleKey.UpArrow)          // history load replaces buffer
+        || (k.Key = ConsoleKey.DownArrow)        // history load replaces buffer
+
     Console.TreatControlCAsInput <- true
     try
         redraw st
@@ -308,21 +352,39 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
                     writeRaw ("\x1b[" + string st.RowsBelowCursor + "B")
                 eraseLines st.LinesRendered
                 st.RowsBelowCursor <- 0
-            match applyKey k st with
-            | Continue -> redraw st
-            | Wipe     -> redraw st
-            | Submit s ->
-                eraseRendered ()
-                if not (String.IsNullOrWhiteSpace s) then
-                    if historyStore.Count = 0 || historyStore.[historyStore.Count - 1] <> s then
-                        historyStore.Add s
-                st.HistoryIdx <- -1
-                st.SavedBuffer <- None
-                result <- ValueSome (Some s)
-            | Quit ->
-                eraseRendered ()
-                writeRaw "\n"
-                result <- ValueSome None
+            // Handle undo/redo before general key dispatch.
+            if isCtrl k ConsoleKey.Z then
+                match popResizeArray undoStack with
+                | Some snap ->
+                    redoStack.Add(snapshot ())
+                    applySnapshot snap
+                    redraw st
+                | None -> ()
+            elif isCtrl k ConsoleKey.Y then
+                match popResizeArray redoStack with
+                | Some snap ->
+                    undoStack.Add(snapshot ())
+                    applySnapshot snap
+                    redraw st
+                | None -> ()
+            else
+                // Push undo snapshot before any buffer-modifying key.
+                if isEditKey k then pushUndo ()
+                match applyKey k st with
+                | Continue -> redraw st
+                | Wipe     -> redraw st
+                | Submit s ->
+                    eraseRendered ()
+                    if not (String.IsNullOrWhiteSpace s) then
+                        if historyStore.Count = 0 || historyStore.[historyStore.Count - 1] <> s then
+                            historyStore.Add s
+                    st.HistoryIdx <- -1
+                    st.SavedBuffer <- None
+                    result <- ValueSome (Some s)
+                | Quit ->
+                    eraseRendered ()
+                    writeRaw "\n"
+                    result <- ValueSome None
         return
             match result with
             | ValueSome v -> v

--- a/tests/Fugue.Tests/ReadLineTests.fs
+++ b/tests/Fugue.Tests/ReadLineTests.fs
@@ -344,3 +344,48 @@ let ``word_CtrlW_atZero_isNoOp`` () =
     act |> should equal Continue
     String(s.Buffer.ToArray()) |> should equal "hello"
     s.Cursor |> should equal 0
+
+// ── Undo/redo bounded-stack tests ─────────────────────────────────────────────
+
+[<Fact>]
+let ``pushBounded_underLimit_appendsItem`` () =
+    let stack = ResizeArray<int>()
+    for i in 1 .. 5 do pushBounded stack i
+    stack.Count |> should equal 5
+    stack.[stack.Count - 1] |> should equal 5
+
+[<Fact>]
+let ``pushBounded_atLimit_evictsOldest`` () =
+    let stack = ResizeArray<int>()
+    // Fill to exactly 100
+    for i in 1 .. 100 do pushBounded stack i
+    stack.Count |> should equal 100
+    stack.[0] |> should equal 1
+    // Push one more — oldest (1) should be evicted, count stays at 100
+    pushBounded stack 101
+    stack.Count |> should equal 100
+    stack.[0] |> should equal 2
+    stack.[stack.Count - 1] |> should equal 101
+
+[<Fact>]
+let ``pushBounded_101pushes_countStaysAt100`` () =
+    let stack = ResizeArray<string * int>()
+    for i in 1 .. 101 do pushBounded stack ("buf" + string i, i)
+    stack.Count |> should equal 100
+    // Oldest entry (1) is gone; newest (101) is at the top
+    let (buf, cur) = stack.[stack.Count - 1]
+    buf |> should equal "buf101"
+    cur |> should equal 101
+
+[<Fact>]
+let ``pushBounded_push3_undoOnce_stackHas2`` () =
+    let stack = ResizeArray<string * int>()
+    pushBounded stack ("a", 1)
+    pushBounded stack ("ab", 2)
+    pushBounded stack ("abc", 3)
+    stack.Count |> should equal 3
+    // Pop one (simulate undo)
+    let top = stack.[stack.Count - 1]
+    stack.RemoveAt(stack.Count - 1)
+    stack.Count |> should equal 2
+    top |> should equal ("abc", 3)


### PR DESCRIPTION
Closes #449.

## Summary
- Per-keystroke undo/redo of prompt edits using bounded `ResizeArray<string * int>` stacks in `readAsync`
- `pushBounded` helper evicts the oldest entry when the stack reaches 100; exposed as a module-level function for unit testing
- Undo/redo stacks are local to each `readAsync` call — they reset automatically when Enter is pressed or a new prompt starts
- Ctrl+Z undoes the last edit; Ctrl+Y redoes it
- AOT-safe: no reflection, no `Stack<>` generic constraints beyond what `ResizeArray` already satisfies

## Test plan
- [x] `pushBounded` under limit — appends item, count grows
- [x] `pushBounded` at limit (100) — evicts oldest, count stays at 100
- [x] 101 pushes — count stays at 100, oldest gone, newest at top
- [x] Push 3, pop one (simulate undo) — stack has 2 remaining, popped item is correct
- [x] All 110 tests pass: `dotnet test Fugue.slnx` — 0 failures
- [x] `dotnet build Fugue.slnx` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)