### PR TITLE
feat(cli): /todo — scan TODO/FIXME/HACK into agent context

### DIFF
--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -124,13 +124,60 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                 AnsiConsole.WriteLine()
                 let helpItems = [ "/help",  strings.CmdHelpDesc
                                   "/clear", strings.CmdClearDesc
-                                  "/exit",  strings.CmdExitDesc ]
+                                  "/exit",  strings.CmdExitDesc
+                                  "/todo",  strings.CmdTodoDesc ]
                 for (name, desc) in helpItems do
                     AnsiConsole.Write(Markup("  [cyan]" + Markup.Escape name + "[/]  [dim]" + Markup.Escape desc + "[/]"))
                     AnsiConsole.WriteLine()
                 StatusBar.refresh ()
             | Some s when s = "/clear" ->
                 AnsiConsole.Clear()
+                StatusBar.refresh ()
+            | Some s when s = "/todo" ->
+                let tryRun (exe: string) (args: string[]) =
+                    try
+                        let psi = System.Diagnostics.ProcessStartInfo()
+                        psi.FileName <- exe
+                        for a in args do psi.ArgumentList.Add a
+                        psi.UseShellExecute <- false
+                        psi.RedirectStandardOutput <- true
+                        psi.RedirectStandardError <- true
+                        psi.WorkingDirectory <- cwd
+                        use proc = new System.Diagnostics.Process()
+                        proc.StartInfo <- psi
+                        match proc.Start() with
+                        | false -> None
+                        | true ->
+                            let out = proc.StandardOutput.ReadToEnd()
+                            proc.WaitForExit()
+                            if proc.ExitCode = 0 && not (String.IsNullOrWhiteSpace out) then Some out
+                            elif proc.ExitCode = 1 then Some ""  // grep/rg return 1 for no matches
+                            else None
+                    with _ -> None
+                let results =
+                    match tryRun "rg" [| "--line-number"; "--with-filename"; "--no-heading";
+                                         "-e"; "TODO"; "-e"; "FIXME"; "-e"; "HACK"; "." |] with
+                    | Some r -> Some r
+                    | None ->
+                        tryRun "grep" [| "-rn"; "-E"; "TODO|FIXME|HACK"; "." |]
+                match results with
+                | None ->
+                    AnsiConsole.Write(Render.errorLine strings "rg and grep unavailable")
+                    AnsiConsole.WriteLine()
+                | Some "" ->
+                    AnsiConsole.MarkupLine("[dim]" + Markup.Escape strings.TodoNone + "[/]")
+                    AnsiConsole.WriteLine()
+                | Some output ->
+                    let lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                    let truncated, note =
+                        if lines.Length > 200 then
+                            Array.take 200 lines, sprintf "\n\n[truncated — showing 200 of %d matches]" lines.Length
+                        else lines, ""
+                    let body = String.concat "\n" truncated
+                    let summary =
+                        sprintf "Found %d TODO/FIXME/HACK items in workspace:\n\n%s%s\n\nPlease review these and suggest which ones are worth addressing now."
+                            lines.Length body note
+                    do! streamAndRender agent session summary cfg cancelSrc
                 StatusBar.refresh ()
             | Some userInput ->
                 AnsiConsole.Write(Render.userMessage cfg.Ui userInput)

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -28,6 +28,8 @@ type Strings =
       CmdHelpDesc:  string
       CmdClearDesc: string
       CmdExitDesc:  string
+      CmdTodoDesc:  string
+      TodoNone:     string
       HelpHeader:   string }
 
 let en : Strings =
@@ -48,6 +50,8 @@ let en : Strings =
       CmdHelpDesc           = "show this help"
       CmdClearDesc          = "clear the screen"
       CmdExitDesc           = "exit Fugue"
+      CmdTodoDesc           = "scan workspace for TODO/FIXME/HACK comments"
+      TodoNone              = "no TODO/FIXME/HACK comments found in workspace"
       HelpHeader            = "Available slash commands:" }
 
 let ru : Strings =
@@ -68,6 +72,8 @@ let ru : Strings =
       CmdHelpDesc           = "показать эту справку"
       CmdClearDesc          = "очистить экран"
       CmdExitDesc           = "выйти из Fugue"
+      CmdTodoDesc           = "найти TODO/FIXME/HACK комментарии в проекте"
+      TodoNone              = "TODO/FIXME/HACK комментарии не найдены"
       HelpHeader            = "Доступные команды:" }
 
 /// Pick a Strings value by ISO-2 locale code. Unknown locales fall back to en.


### PR DESCRIPTION
Closes #448.

## Summary

- `/todo` runs `rg` (with `grep -rn` fallback) to find `TODO`, `FIXME`, and `HACK` comments in the current working directory
- Results are injected as a user message so the agent can review and suggest fixes
- Truncates at 200 lines with a note when the workspace is large
- `/todo` added to `/help` output with localized description (EN + RU)
- AOT-safe: uses `System.Diagnostics.Process` directly, no reflection, no `JsonSerializer`

## Out of scope

Batch-fix mode (agent automatically applying fixes) is deferred to a follow-up.

## Test plan

- [x] `dotnet build Fugue.slnx` — 0 errors, 0 warnings
- [x] `dotnet test Fugue.slnx` — 106/106 pass
- [ ] Manual: run `/todo` in a workspace with TODOs, verify agent receives and responds to the injected message
- [ ] Manual: run `/todo` in a clean workspace, verify "no TODO/FIXME/HACK comments found" message
- [ ] Manual: run `/todo` without `rg` installed (rename binary), verify grep fallback works