### PR TITLE
feat(cli): @path file injection — expand @file tokens in user input

### DIFF
--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -13,6 +13,54 @@ open Fugue.Core.Localization
 open Fugue.Agent
 open Fugue.Cli
 
+/// Find @path tokens in a string.
+/// Returns list of (startIdx, tokenLength, path) for each @word token that is preceded
+/// by start-of-string or whitespace.
+let private findAtTokens (input: string) : (int * int * string) list =
+    let mutable i = 0
+    let mutable results = []
+    while i < input.Length do
+        if input.[i] = '@' && (i = 0 || Char.IsWhiteSpace input.[i - 1]) then
+            let start = i
+            i <- i + 1
+            let pathStart = i
+            while i < input.Length && not (Char.IsWhiteSpace input.[i]) do
+                i <- i + 1
+            if i > pathStart then
+                results <- (start, i - start, input.[start + 1 .. i - 1]) :: results
+        else
+            i <- i + 1
+    List.rev results
+
+/// Expand @path tokens in user input. Each @word that resolves to an existing file
+/// within cwd is replaced with its contents (up to 200 lines). Skips missing, binary,
+/// or out-of-cwd files silently or with a dim notice.
+let private expandAtFiles (cwd: string) (strings: Fugue.Core.Localization.Strings) (input: string) : string =
+    let tokens = findAtTokens input
+    if tokens.IsEmpty then input
+    else
+        // Process tokens in reverse order so indices stay valid during replacement
+        let mutable result = input
+        for (start, length, pathPart) in List.rev tokens do
+            let atToken = result.[start .. start + length - 1]
+            let fullPath = Fugue.Tools.PathSafety.resolve cwd pathPart
+            if not (Fugue.Tools.PathSafety.isUnder cwd fullPath) then
+                ()  // silently skip paths outside cwd
+            elif not (System.IO.File.Exists fullPath) then
+                AnsiConsole.MarkupLine(sprintf "[dim]%s[/]" (Markup.Escape (System.String.Format(strings.AtFileNotFound, pathPart))))
+            else
+                try
+                    let lines = System.IO.File.ReadAllLines fullPath
+                    let truncated = lines.Length > 200
+                    let content =
+                        (if truncated then Array.take 200 lines else lines)
+                        |> String.concat "\n"
+                    let header = sprintf "[contents of %s — %d lines%s]:\n" pathPart lines.Length (if truncated then " (truncated to 200)" else "")
+                    result <- result.[0 .. start - 1] + header + content + result.[start + length ..]
+                with _ ->
+                    AnsiConsole.MarkupLine(sprintf "[dim]%s[/]" (Markup.Escape (System.String.Format(strings.AtFileNotFound, pathPart))))
+        result
+
 /// Cheap heuristic — does the text contain markdown markers worth re-rendering?
 /// Avoids re-printing pure plain text twice. False positives (e.g. raw `**` in code)
 /// are acceptable; the markdown render still produces readable output.
@@ -133,9 +181,10 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                 AnsiConsole.Clear()
                 StatusBar.refresh ()
             | Some userInput ->
+                let expandedInput = expandAtFiles cwd strings userInput
                 AnsiConsole.Write(Render.userMessage cfg.Ui userInput)
                 AnsiConsole.WriteLine()
-                do! streamAndRender agent session userInput cfg cancelSrc
+                do! streamAndRender agent session expandedInput cfg cancelSrc
                 StatusBar.refresh ()
     finally
         Console.CancelKeyPress.RemoveHandler handler

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -28,7 +28,11 @@ type Strings =
       CmdHelpDesc:  string
       CmdClearDesc: string
       CmdExitDesc:  string
-      HelpHeader:   string }
+      HelpHeader:   string
+
+      // @file injection
+      AtFileNotFound: string
+      AtFileTooBig:   string }
 
 let en : Strings =
     { Cancelled            = "cancelled"
@@ -48,7 +52,9 @@ let en : Strings =
       CmdHelpDesc           = "show this help"
       CmdClearDesc          = "clear the screen"
       CmdExitDesc           = "exit Fugue"
-      HelpHeader            = "Available slash commands:" }
+      HelpHeader            = "Available slash commands:"
+      AtFileNotFound        = "@{0}: file not found, skipping"
+      AtFileTooBig          = "@{0}: file too large (>{1}), skipping" }
 
 let ru : Strings =
     { Cancelled            = "отменено"
@@ -68,7 +74,9 @@ let ru : Strings =
       CmdHelpDesc           = "показать эту справку"
       CmdClearDesc          = "очистить экран"
       CmdExitDesc           = "выйти из Fugue"
-      HelpHeader            = "Доступные команды:" }
+      HelpHeader            = "Доступные команды:"
+      AtFileNotFound        = "@{0}: файл не найден, пропускаем"
+      AtFileTooBig          = "@{0}: файл слишком большой (>{1}), пропускаем" }
 
 /// Pick a Strings value by ISO-2 locale code. Unknown locales fall back to en.
 let pick (locale: string) : Strings =

--- a/tests/Fugue.Tests/AtFileTests.fs
+++ b/tests/Fugue.Tests/AtFileTests.fs
@@ -1,0 +1,67 @@
+module Fugue.Tests.AtFileTests
+
+open Xunit
+open FsUnit.Xunit
+
+// findAtTokens is private in Repl, so we replicate the pure parser logic here
+// to keep the tests self-contained and AOT-safe (no Reflection needed).
+
+/// Replicated pure parser (mirrors Repl.findAtTokens) for unit testing.
+let private findAtTokens (input: string) : (int * int * string) list =
+    let mutable i = 0
+    let mutable results = []
+    while i < input.Length do
+        if input.[i] = '@' && (i = 0 || System.Char.IsWhiteSpace input.[i - 1]) then
+            let start = i
+            i <- i + 1
+            let pathStart = i
+            while i < input.Length && not (System.Char.IsWhiteSpace input.[i]) do
+                i <- i + 1
+            if i > pathStart then
+                results <- (start, i - start, input.[start + 1 .. i - 1]) :: results
+        else
+            i <- i + 1
+    List.rev results
+
+[<Fact>]
+let ``findAtTokens finds single token in middle of string`` () =
+    let tokens = findAtTokens "hello @file.txt world"
+    tokens |> should haveLength 1
+    let (start, len, path) = tokens.[0]
+    path  |> should equal "file.txt"
+    start |> should equal 6
+    len   |> should equal 9  // length of "@file.txt"
+
+[<Fact>]
+let ``findAtTokens returns empty list when no at-tokens present`` () =
+    let tokens = findAtTokens "no at tokens here"
+    tokens |> should be Empty
+
+[<Fact>]
+let ``findAtTokens finds both tokens when two at-file tokens are present`` () =
+    let tokens = findAtTokens "@file1.txt @file2.txt"
+    tokens |> should haveLength 2
+    let (_, _, p1) = tokens.[0]
+    let (_, _, p2) = tokens.[1]
+    p1 |> should equal "file1.txt"
+    p2 |> should equal "file2.txt"
+
+[<Fact>]
+let ``findAtTokens handles token at start of string`` () =
+    let tokens = findAtTokens "@README.md"
+    tokens |> should haveLength 1
+    let (start, _, path) = tokens.[0]
+    start |> should equal 0
+    path  |> should equal "README.md"
+
+[<Fact>]
+let ``findAtTokens ignores at-sign in the middle of a word`` () =
+    let tokens = findAtTokens "user@example.com is an email"
+    tokens |> should be Empty
+
+[<Fact>]
+let ``findAtTokens handles path with directory separators`` () =
+    let tokens = findAtTokens "look at @src/Fugue.Core/Config.fs please"
+    tokens |> should haveLength 1
+    let (_, _, path) = tokens.[0]
+    path |> should equal "src/Fugue.Core/Config.fs"

--- a/tests/Fugue.Tests/Fugue.Tests.fsproj
+++ b/tests/Fugue.Tests/Fugue.Tests.fsproj
@@ -28,6 +28,7 @@
     <Compile Include="GrepToolTests.fs" />
     <Compile Include="DiscoveryTests.fs" />
     <Compile Include="ConversationTests.fs" />
+    <Compile Include="AtFileTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Closes #451. Typing `@path/to/file` in user input is expanded to inline file contents before sending to the agent — enables drag-and-drop file workflow in the terminal.
- Manual token parser (`findAtTokens`) used instead of `Regex` to keep the code AOT-safe (no `IL3050` warnings).
- Paths outside `cwd` are silently blocked via `PathSafety.isUnder`. Missing or unreadable files print a dim notice and skip gracefully. Files over 200 lines are truncated.
- Original (unexpanded) input is shown to the user; the expanded version is sent to the agent.

## Test plan

- [ ] `dotnet build Fugue.slnx` — `Build succeeded. 0 Error(s). 0 Warning(s)` ✓
- [ ] `dotnet test Fugue.slnx` — 112 tests pass (6 new `AtFileTests`) ✓
- [ ] Manual: type `what does @src/Fugue.Core/Config.fs do?` — agent receives file contents inline
- [ ] Manual: type `@/etc/passwd` — silently skipped (outside cwd)
- [ ] Manual: type `@nonexistent.txt` — dim notice printed, input sent without expansion