### PR TITLE
feat(cli): /git-log explain — plain-language commit history

### DIFF
--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -122,11 +122,42 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
             | Some s when s = "/help" ->
                 AnsiConsole.Write(Markup("[bold]" + Markup.Escape strings.HelpHeader + "[/]"))
                 AnsiConsole.WriteLine()
-                let helpItems = [ "/help",  strings.CmdHelpDesc
-                                  "/clear", strings.CmdClearDesc
-                                  "/exit",  strings.CmdExitDesc ]
+                let helpItems = [ "/help",     strings.CmdHelpDesc
+                                  "/clear",    strings.CmdClearDesc
+                                  "/git-log",  strings.CmdGitLogDesc
+                                  "/exit",     strings.CmdExitDesc ]
                 for (name, desc) in helpItems do
                     AnsiConsole.Write(Markup("  [cyan]" + Markup.Escape name + "[/]  [dim]" + Markup.Escape desc + "[/]"))
+                    AnsiConsole.WriteLine()
+                StatusBar.refresh ()
+            | Some s when s = "/git-log" ->
+                let psi = System.Diagnostics.ProcessStartInfo()
+                psi.FileName <- "git"
+                psi.ArgumentList.Add "log"
+                psi.ArgumentList.Add "--oneline"
+                psi.ArgumentList.Add "--decorate"
+                psi.ArgumentList.Add "-20"
+                psi.UseShellExecute <- false
+                psi.RedirectStandardOutput <- true
+                psi.WorkingDirectory <- cwd
+                try
+                    use proc = new System.Diagnostics.Process()
+                    proc.StartInfo <- psi
+                    match proc.Start() with
+                    | false ->
+                        AnsiConsole.Write(Render.errorLine strings strings.GitLogNoRepo)
+                        AnsiConsole.WriteLine()
+                    | true ->
+                        let out = proc.StandardOutput.ReadToEnd()
+                        proc.WaitForExit()
+                        if proc.ExitCode <> 0 || String.IsNullOrWhiteSpace out then
+                            AnsiConsole.Write(Render.errorLine strings strings.GitLogNoRepo)
+                            AnsiConsole.WriteLine()
+                        else
+                            let prompt = sprintf "Here are the last 20 commits from git log:\n\n%s\n\nPlease explain this commit history in plain language. What was the team working on? What were the major changes? Are there any patterns or concerns?" out
+                            do! streamAndRender agent session prompt cfg cancelSrc
+                with ex ->
+                    AnsiConsole.Write(Render.errorLine strings ex.Message)
                     AnsiConsole.WriteLine()
                 StatusBar.refresh ()
             | Some s when s = "/clear" ->

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -25,10 +25,12 @@ type Strings =
       DiscoveryPickProvider:  string
 
       // Slash commands
-      CmdHelpDesc:  string
-      CmdClearDesc: string
-      CmdExitDesc:  string
-      HelpHeader:   string }
+      CmdHelpDesc:    string
+      CmdClearDesc:   string
+      CmdExitDesc:    string
+      CmdGitLogDesc:  string
+      GitLogNoRepo:   string
+      HelpHeader:     string }
 
 let en : Strings =
     { Cancelled            = "cancelled"
@@ -48,6 +50,8 @@ let en : Strings =
       CmdHelpDesc           = "show this help"
       CmdClearDesc          = "clear the screen"
       CmdExitDesc           = "exit Fugue"
+      CmdGitLogDesc         = "explain recent git commit history"
+      GitLogNoRepo          = "not a git repository or git unavailable"
       HelpHeader            = "Available slash commands:" }
 
 let ru : Strings =
@@ -68,6 +72,8 @@ let ru : Strings =
       CmdHelpDesc           = "показать эту справку"
       CmdClearDesc          = "очистить экран"
       CmdExitDesc           = "выйти из Fugue"
+      CmdGitLogDesc         = "объяснить историю git коммитов"
+      GitLogNoRepo          = "не git-репозиторий или git недоступен"
       HelpHeader            = "Доступные команды:" }
 
 /// Pick a Strings value by ISO-2 locale code. Unknown locales fall back to en.


### PR DESCRIPTION
Closes #461.

## Summary
- Adds `/git-log` slash command: runs `git log --oneline --decorate -20` in the current working directory and asks the agent to explain the commit history in plain language
- Adds `CmdGitLogDesc` and `GitLogNoRepo` localization strings in both EN and RU
- `/git-log` is listed in `/help`

## Implementation notes
- AOT-safe: `System.Diagnostics.Process` only, no reflection, no `JsonSerializer`
- stdout read before `WaitForExit` to avoid deadlock; stderr not redirected
- Graceful error path: start failure, non-zero exit code, and empty output all print the localized `GitLogNoRepo` error; any exception surfaces its message

## Test plan
- [x] `dotnet build Fugue.slnx` — 0 errors, 0 warnings
- [x] `dotnet test Fugue.slnx` — 106/106 passed
- [ ] Manual: run `/git-log` inside a git repo → agent explains history
- [ ] Manual: run `/git-log` outside a git repo → error line shown