### PR TITLE
feat(cli): /squash N — AI-generated squash commit message

### DIFF
--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -122,15 +122,61 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
             | Some s when s = "/help" ->
                 AnsiConsole.Write(Markup("[bold]" + Markup.Escape strings.HelpHeader + "[/]"))
                 AnsiConsole.WriteLine()
-                let helpItems = [ "/help",  strings.CmdHelpDesc
-                                  "/clear", strings.CmdClearDesc
-                                  "/exit",  strings.CmdExitDesc ]
+                let helpItems = [ "/help",       strings.CmdHelpDesc
+                                  "/clear",      strings.CmdClearDesc
+                                  "/exit",       strings.CmdExitDesc
+                                  "/squash <N>", strings.CmdSquashDesc ]
                 for (name, desc) in helpItems do
                     AnsiConsole.Write(Markup("  [cyan]" + Markup.Escape name + "[/]  [dim]" + Markup.Escape desc + "[/]"))
                     AnsiConsole.WriteLine()
                 StatusBar.refresh ()
             | Some s when s = "/clear" ->
                 AnsiConsole.Clear()
+                StatusBar.refresh ()
+            | Some s when s = "/squash" || s.StartsWith "/squash " ->
+                let rawArg = if s = "/squash" then "" else s.Substring(8).TrimStart()
+                let n = if String.IsNullOrWhiteSpace rawArg then 0 else (try int rawArg with _ -> 0)
+                if n <= 0 then
+                    AnsiConsole.Write(Markup("[dim]" + Markup.Escape strings.SquashUsage + "[/]"))
+                    AnsiConsole.WriteLine()
+                else
+                    let psi = System.Diagnostics.ProcessStartInfo()
+                    psi.FileName <- "git"
+                    psi.ArgumentList.Add "log"
+                    psi.ArgumentList.Add "--oneline"
+                    psi.ArgumentList.Add (sprintf "-%d" n)
+                    psi.UseShellExecute <- false
+                    psi.RedirectStandardOutput <- true
+                    psi.WorkingDirectory <- cwd
+                    try
+                        use proc = new System.Diagnostics.Process()
+                        proc.StartInfo <- psi
+                        match proc.Start() with
+                        | false ->
+                            AnsiConsole.Write(Render.errorLine strings strings.SquashNoRepo)
+                            AnsiConsole.WriteLine()
+                        | true ->
+                            let out = proc.StandardOutput.ReadToEnd()
+                            proc.WaitForExit()
+                            if proc.ExitCode <> 0 || String.IsNullOrWhiteSpace out then
+                                AnsiConsole.Write(Render.errorLine strings strings.SquashNoRepo)
+                                AnsiConsole.WriteLine()
+                            else
+                                let prompt = sprintf """Here are the last %d commits to be squashed:
+
+%s
+
+Please generate a single conventional commit message that summarizes all these changes.
+Follow the format: type(scope): description
+
+Also show the git command to execute the squash:
+  git reset --soft HEAD~%d && git commit -m "<your message>"
+
+Do NOT run the command — just show it for the user to review and run manually.""" n out n
+                                do! streamAndRender agent session prompt cfg cancelSrc
+                    with ex ->
+                        AnsiConsole.Write(Render.errorLine strings ex.Message)
+                        AnsiConsole.WriteLine()
                 StatusBar.refresh ()
             | Some userInput ->
                 AnsiConsole.Write(Render.userMessage cfg.Ui userInput)

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -25,10 +25,13 @@ type Strings =
       DiscoveryPickProvider:  string
 
       // Slash commands
-      CmdHelpDesc:  string
-      CmdClearDesc: string
-      CmdExitDesc:  string
-      HelpHeader:   string }
+      CmdHelpDesc:    string
+      CmdClearDesc:   string
+      CmdExitDesc:    string
+      CmdSquashDesc:  string
+      SquashUsage:    string
+      SquashNoRepo:   string
+      HelpHeader:     string }
 
 let en : Strings =
     { Cancelled            = "cancelled"
@@ -48,6 +51,9 @@ let en : Strings =
       CmdHelpDesc           = "show this help"
       CmdClearDesc          = "clear the screen"
       CmdExitDesc           = "exit Fugue"
+      CmdSquashDesc         = "generate squash commit message for last N commits"
+      SquashUsage           = "usage: /squash <N>"
+      SquashNoRepo          = "not a git repository or git unavailable"
       HelpHeader            = "Available slash commands:" }
 
 let ru : Strings =
@@ -68,6 +74,9 @@ let ru : Strings =
       CmdHelpDesc           = "показать эту справку"
       CmdClearDesc          = "очистить экран"
       CmdExitDesc           = "выйти из Fugue"
+      CmdSquashDesc         = "сгенерировать сообщение для squash последних N коммитов"
+      SquashUsage           = "использование: /squash <N>"
+      SquashNoRepo          = "не git-репозиторий или git недоступен"
       HelpHeader            = "Доступные команды:" }
 
 /// Pick a Strings value by ISO-2 locale code. Unknown locales fall back to en.


### PR DESCRIPTION
## Summary

- Adds `/squash <N>` slash command that fetches the last N git commits and asks the agent to generate a conventional commit message for a squash
- Shows the suggested message and the git command to run (`git reset --soft HEAD~N && git commit -m "..."`) but does **not** execute the squash — user reviews and runs manually
- Adds `/squash <N>` to `/help` list
- AOT-safe: uses `System.Diagnostics.Process` directly, no reflection, no `JsonSerializer`
- Adds 3 localization strings (EN + RU): `CmdSquashDesc`, `SquashUsage`, `SquashNoRepo`

Closes #465.

## Test plan

- [ ] `dotnet build Fugue.slnx` — 0 errors, 0 warnings ✓ (verified)
- [ ] `dotnet test Fugue.slnx` — 106/106 pass ✓ (verified)
- [ ] `/squash` with no arg shows usage hint
- [ ] `/squash 0` or `/squash abc` shows usage hint
- [ ] `/squash 3` in a git repo fetches last 3 commits and streams a conventional commit suggestion
- [ ] Outside a git repo or git not on PATH shows `SquashNoRepo` error
- [ ] Suggested command includes correct `HEAD~N` count