### PR TITLE
fix(cli): redo pushes use pushBounded to respect undo stack cap

### DIFF
--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -9,6 +9,7 @@ open Fugue.Core.Localization
 // Hardcoded — small list, easier than passing through state.
 let slashCommands : string list = [ "/help"; "/clear"; "/exit" ]
 
+/// Session history (REPL is single-threaded). Not private so tests can seed entries directly.
 let historyStore = ResizeArray<string>()
 
 /// For test isolation only.
@@ -138,12 +139,12 @@ let applyKey (k: ConsoleKeyInfo) (s: S) : Action =
                 s.Buffer.AddRange(historyStore.[s.HistoryIdx].ToCharArray())
                 s.Cursor <- s.Buffer.Count
             Continue
-    elif k.Key = ConsoleKey.LeftArrow && k.Modifiers.HasFlag ConsoleModifiers.Control then
+    elif isCtrl k ConsoleKey.LeftArrow then
         exitHistoryMode ()
         s.ExitArmed <- false
         s.Cursor <- prevWordStart s.Buffer s.Cursor
         Continue
-    elif k.Key = ConsoleKey.RightArrow && k.Modifiers.HasFlag ConsoleModifiers.Control then
+    elif isCtrl k ConsoleKey.RightArrow then
         exitHistoryMode ()
         s.ExitArmed <- false
         s.Cursor <- nextWordEnd s.Buffer s.Cursor
@@ -153,7 +154,8 @@ let applyKey (k: ConsoleKeyInfo) (s: S) : Action =
         s.ExitArmed <- false
         if s.Cursor > 0 then
             let mutable p = prevWordStart s.Buffer s.Cursor
-            // If everything before p is whitespace, consume it too (leading whitespace deletion)
+            // Divergence from GNU readline unix-word-rubout: when only whitespace precedes the
+            // deleted word, also consume it — clears short prompts in one keystroke (matches zsh).
             let mutable j = p - 1
             while j >= 0 && (s.Buffer.[j] = ' ' || s.Buffer.[j] = '\t') do j <- j - 1
             if j < 0 then p <- 0

--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -9,6 +9,11 @@ open Fugue.Core.Localization
 // Hardcoded — small list, easier than passing through state.
 let slashCommands : string list = [ "/help"; "/clear"; "/exit" ]
 
+let historyStore = ResizeArray<string>()
+
+/// For test isolation only.
+let clearHistory () = historyStore.Clear()
+
 /// Internal mutable line state. Public only because tests construct it directly.
 type S = {
     mutable Buffer:          ResizeArray<char>
@@ -16,6 +21,8 @@ type S = {
     mutable LinesRendered:   int
     mutable ExitArmed:       bool
     mutable RowsBelowCursor: int   // # of rows from cursor's final position down to last rendered row
+    mutable HistoryIdx:      int                        // -1 = not browsing; 0..n-1 = browsing
+    mutable SavedBuffer:     ResizeArray<char> option   // snapshot before first Up press
     PromptText:              string
     PromptVisLen:            int
     HintWhenArmed:           string
@@ -36,9 +43,26 @@ let private isCtrl (k: ConsoleKeyInfo) (key: ConsoleKey) : bool =
 let private isShift (k: ConsoleKeyInfo) (key: ConsoleKey) : bool =
     k.Modifiers.HasFlag ConsoleModifiers.Shift && k.Key = key
 
+let private prevWordStart (buf: ResizeArray<char>) (pos: int) : int =
+    let mutable i = pos - 1
+    while i >= 0 && (buf.[i] = ' ' || buf.[i] = '\t') do i <- i - 1
+    while i >= 0 && buf.[i] <> ' ' && buf.[i] <> '\t' do i <- i - 1
+    i + 1
+
+let private nextWordEnd (buf: ResizeArray<char>) (pos: int) : int =
+    let mutable i = pos
+    while i < buf.Count && (buf.[i] = ' ' || buf.[i] = '\t') do i <- i + 1
+    while i < buf.Count && buf.[i] <> ' ' && buf.[i] <> '\t' do i <- i + 1
+    i
+
 /// Pure key dispatch. Mutates `s`; returns Action telling the loop what's next.
 let applyKey (k: ConsoleKeyInfo) (s: S) : Action =
+    let exitHistoryMode () =
+        s.HistoryIdx <- -1
+        s.SavedBuffer <- None
+
     if isCtrl k ConsoleKey.C then
+        exitHistoryMode ()
         if s.Buffer.Count = 0 && s.ExitArmed then
             Quit
         elif s.Buffer.Count = 0 then
@@ -52,39 +76,102 @@ let applyKey (k: ConsoleKeyInfo) (s: S) : Action =
     elif isCtrl k ConsoleKey.D then
         if s.Buffer.Count = 0 then Quit
         else
+            exitHistoryMode ()
             s.ExitArmed <- false
             // delete char at cursor (bash behaviour)
             if s.Cursor < s.Buffer.Count then
                 s.Buffer.RemoveAt s.Cursor
             Continue
     elif isShift k ConsoleKey.Enter then
+        exitHistoryMode ()
         s.ExitArmed <- false
         s.Buffer.Insert(s.Cursor, '\n')
         s.Cursor <- s.Cursor + 1
         Continue
     elif k.Key = ConsoleKey.Enter then
+        exitHistoryMode ()
         s.ExitArmed <- false
         Submit (String(s.Buffer.ToArray()))
     elif k.Key = ConsoleKey.Backspace then
+        exitHistoryMode ()
         s.ExitArmed <- false
         if s.Cursor > 0 then
             s.Buffer.RemoveAt(s.Cursor - 1)
             s.Cursor <- s.Cursor - 1
         Continue
     elif k.Key = ConsoleKey.Delete then
+        exitHistoryMode ()
         s.ExitArmed <- false
         if s.Cursor < s.Buffer.Count then
             s.Buffer.RemoveAt s.Cursor
         Continue
+    elif k.Key = ConsoleKey.UpArrow then
+        s.ExitArmed <- false
+        if historyStore.Count = 0 then
+            Continue
+        else
+            if s.HistoryIdx = -1 then
+                s.SavedBuffer <- Some (ResizeArray<char>(s.Buffer))
+                s.HistoryIdx <- historyStore.Count - 1
+            elif s.HistoryIdx > 0 then
+                s.HistoryIdx <- s.HistoryIdx - 1
+            s.Buffer.Clear()
+            s.Buffer.AddRange(historyStore.[s.HistoryIdx].ToCharArray())
+            s.Cursor <- s.Buffer.Count
+            Continue
+    elif k.Key = ConsoleKey.DownArrow then
+        s.ExitArmed <- false
+        if s.HistoryIdx = -1 then
+            Continue
+        else
+            s.HistoryIdx <- s.HistoryIdx + 1
+            if s.HistoryIdx >= historyStore.Count then
+                s.HistoryIdx <- -1
+                s.Buffer.Clear()
+                match s.SavedBuffer with
+                | Some saved -> s.Buffer.AddRange(saved)
+                | None -> ()
+                s.SavedBuffer <- None
+                s.Cursor <- s.Buffer.Count
+            else
+                s.Buffer.Clear()
+                s.Buffer.AddRange(historyStore.[s.HistoryIdx].ToCharArray())
+                s.Cursor <- s.Buffer.Count
+            Continue
+    elif k.Key = ConsoleKey.LeftArrow && k.Modifiers.HasFlag ConsoleModifiers.Control then
+        exitHistoryMode ()
+        s.ExitArmed <- false
+        s.Cursor <- prevWordStart s.Buffer s.Cursor
+        Continue
+    elif k.Key = ConsoleKey.RightArrow && k.Modifiers.HasFlag ConsoleModifiers.Control then
+        exitHistoryMode ()
+        s.ExitArmed <- false
+        s.Cursor <- nextWordEnd s.Buffer s.Cursor
+        Continue
+    elif isCtrl k ConsoleKey.W then
+        exitHistoryMode ()
+        s.ExitArmed <- false
+        if s.Cursor > 0 then
+            let mutable p = prevWordStart s.Buffer s.Cursor
+            // If everything before p is whitespace, consume it too (leading whitespace deletion)
+            let mutable j = p - 1
+            while j >= 0 && (s.Buffer.[j] = ' ' || s.Buffer.[j] = '\t') do j <- j - 1
+            if j < 0 then p <- 0
+            s.Buffer.RemoveRange(p, s.Cursor - p)
+            s.Cursor <- p
+        Continue
     elif k.Key = ConsoleKey.LeftArrow then
+        exitHistoryMode ()
         s.ExitArmed <- false
         if s.Cursor > 0 then s.Cursor <- s.Cursor - 1
         Continue
     elif k.Key = ConsoleKey.RightArrow then
+        exitHistoryMode ()
         s.ExitArmed <- false
         if s.Cursor < s.Buffer.Count then s.Cursor <- s.Cursor + 1
         Continue
     elif k.Key = ConsoleKey.Home then
+        exitHistoryMode ()
         s.ExitArmed <- false
         // beginning of current visual line (= last \n before cursor + 1, or 0)
         let mutable i = s.Cursor - 1
@@ -92,6 +179,7 @@ let applyKey (k: ConsoleKeyInfo) (s: S) : Action =
         s.Cursor <- i + 1
         Continue
     elif k.Key = ConsoleKey.End then
+        exitHistoryMode ()
         s.ExitArmed <- false
         // end of current visual line
         let mutable i = s.Cursor
@@ -99,6 +187,7 @@ let applyKey (k: ConsoleKeyInfo) (s: S) : Action =
         s.Cursor <- i
         Continue
     elif not (Char.IsControl k.KeyChar) then
+        exitHistoryMode ()
         s.ExitArmed <- false
         s.Buffer.Insert(s.Cursor, k.KeyChar)
         s.Cursor <- s.Cursor + 1
@@ -196,6 +285,8 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
           LinesRendered   = 0
           ExitArmed       = false
           RowsBelowCursor = 0
+          HistoryIdx      = -1
+          SavedBuffer     = None
           PromptText      = prompt
           PromptVisLen    = visLen
           HintWhenArmed   = strings.ExitHint
@@ -220,6 +311,11 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
             | Wipe     -> redraw st
             | Submit s ->
                 eraseRendered ()
+                if not (String.IsNullOrWhiteSpace s) then
+                    if historyStore.Count = 0 || historyStore.[historyStore.Count - 1] <> s then
+                        historyStore.Add s
+                st.HistoryIdx <- -1
+                st.SavedBuffer <- None
                 result <- ValueSome (Some s)
             | Quit ->
                 eraseRendered ()

--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -15,6 +15,21 @@ let historyStore = ResizeArray<string>()
 /// For test isolation only.
 let clearHistory () = historyStore.Clear()
 
+/// Undo/redo stacks — module-level, REPL is single-threaded.
+/// Not private so tests can inspect and seed them directly.
+let undoStack = ResizeArray<ResizeArray<char> * int>()
+let redoStack = ResizeArray<ResizeArray<char> * int>()
+
+/// For test isolation only.
+let clearUndoRedo () =
+    undoStack.Clear()
+    redoStack.Clear()
+
+/// Push item onto stack, evicting the oldest entry when the cap is exceeded.
+let private pushBounded (stack: ResizeArray<_>) item =
+    stack.Add item
+    if stack.Count > 100 then stack.RemoveAt 0
+
 /// Internal mutable line state. Public only because tests construct it directly.
 type S = {
     mutable Buffer:          ResizeArray<char>
@@ -188,9 +203,36 @@ let applyKey (k: ConsoleKeyInfo) (s: S) : Action =
         while i < s.Buffer.Count && s.Buffer.[i] <> '\n' do i <- i + 1
         s.Cursor <- i
         Continue
+    elif isCtrl k ConsoleKey.Z then
+        exitHistoryMode ()
+        s.ExitArmed <- false
+        if undoStack.Count > 0 then
+            let snapshot = ResizeArray<char>(s.Buffer)
+            pushBounded redoStack (snapshot, s.Cursor)
+            let (prevBuf, prevCursor) = undoStack.[undoStack.Count - 1]
+            undoStack.RemoveAt(undoStack.Count - 1)
+            s.Buffer.Clear()
+            s.Buffer.AddRange prevBuf
+            s.Cursor <- prevCursor
+        Continue
+    elif isCtrl k ConsoleKey.Y then
+        exitHistoryMode ()
+        s.ExitArmed <- false
+        if redoStack.Count > 0 then
+            let snapshot = ResizeArray<char>(s.Buffer)
+            pushBounded undoStack (snapshot, s.Cursor)
+            let (nextBuf, nextCursor) = redoStack.[redoStack.Count - 1]
+            redoStack.RemoveAt(redoStack.Count - 1)
+            s.Buffer.Clear()
+            s.Buffer.AddRange nextBuf
+            s.Cursor <- nextCursor
+        Continue
     elif not (Char.IsControl k.KeyChar) then
         exitHistoryMode ()
         s.ExitArmed <- false
+        let snapshot = ResizeArray<char>(s.Buffer)
+        pushBounded undoStack (snapshot, s.Cursor)
+        redoStack.Clear()
         s.Buffer.Insert(s.Cursor, k.KeyChar)
         s.Cursor <- s.Cursor + 1
         Continue

--- a/tests/Fugue.Tests/ReadLineTests.fs
+++ b/tests/Fugue.Tests/ReadLineTests.fs
@@ -12,6 +12,8 @@ let private mkState (text: string) (cursor: int) : S =
       LinesRendered   = 0
       ExitArmed       = false
       RowsBelowCursor = 0
+      HistoryIdx      = -1
+      SavedBuffer     = None
       PromptText      = "> "
       PromptVisLen    = 2
       HintWhenArmed   = "Press Ctrl+C again to exit"
@@ -151,3 +153,194 @@ let ``slash buffer prefix is recognized for hint rendering`` () =
     // No applyKey side effect on the slash-suggestion field — just verify mkState constructs
     s.Buffer.Count |> should equal 1
     s.Buffer.[0] |> should equal '/'
+
+// ── History tests ─────────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``history_UpOnEmptyHistory_isNoOp`` () =
+    clearHistory()
+    let s = mkState "abc" 3
+    let act = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "abc"
+    s.Cursor |> should equal 3
+
+[<Fact>]
+let ``history_firstUp_loadsLatestEntry_savesBuffer`` () =
+    clearHistory()
+    // simulate prior Submit by adding directly
+    historyStore.Add "first"      // index 0
+    historyStore.Add "second"     // index 1 (most recent)
+    let s = mkState "draft" 5
+    let act = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "second"
+    s.Cursor |> should equal 6
+    s.HistoryIdx |> should equal 1
+    s.SavedBuffer |> should not' (equal None)
+
+[<Fact>]
+let ``history_secondUp_loadsOlderEntry`` () =
+    clearHistory()
+    historyStore.Add "first"
+    historyStore.Add "second"
+    let s = mkState "" 0
+    let _ = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s   // → "second"
+    let act = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s   // → "first"
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "first"
+    s.HistoryIdx |> should equal 0
+
+[<Fact>]
+let ``history_UpAtOldest_clamps`` () =
+    clearHistory()
+    historyStore.Add "only"
+    let s = mkState "" 0
+    let _ = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s   // → "only", idx=0
+    let act = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s   // clamped
+    act |> should equal Continue
+    s.HistoryIdx |> should equal 0
+    String(s.Buffer.ToArray()) |> should equal "only"
+
+[<Fact>]
+let ``history_DownFromBrowse_advancesToNewer`` () =
+    clearHistory()
+    historyStore.Add "first"
+    historyStore.Add "second"
+    let s = mkState "" 0
+    let _ = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s   // → "second", idx=1
+    let _ = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s   // → "first", idx=0
+    let act = applyKey (special ConsoleKey.DownArrow ConsoleModifiers.None) s  // → "second", idx=1
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "second"
+    s.HistoryIdx |> should equal 1
+
+[<Fact>]
+let ``history_DownPastEnd_restoresSavedBuffer`` () =
+    clearHistory()
+    historyStore.Add "entry"
+    let s = mkState "draft" 5
+    let _ = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s   // save "draft", load "entry"
+    let act = applyKey (special ConsoleKey.DownArrow ConsoleModifiers.None) s  // past end → restore
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "draft"
+    s.HistoryIdx |> should equal -1
+    s.SavedBuffer |> should equal None
+
+[<Fact>]
+let ``history_DownPastEnd_withEmptySavedBuffer_clears`` () =
+    clearHistory()
+    historyStore.Add "entry"
+    let s = mkState "" 0   // empty buffer before Up
+    let _ = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s
+    let act = applyKey (special ConsoleKey.DownArrow ConsoleModifiers.None) s
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal ""
+    s.Cursor |> should equal 0
+    s.HistoryIdx |> should equal -1
+
+[<Fact>]
+let ``history_DownOnNotBrowsing_isNoOp`` () =
+    clearHistory()
+    let s = mkState "hello" 5
+    let act = applyKey (special ConsoleKey.DownArrow ConsoleModifiers.None) s
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "hello"
+    s.Cursor |> should equal 5
+
+[<Fact>]
+let ``history_Submit_appendsToStore`` () =
+    clearHistory()
+    let s = mkState "foo" 3
+    let act = applyKey (special ConsoleKey.Enter ConsoleModifiers.None) s
+    act |> should equal (Submit "foo")
+    // Note: historyStore is updated in readAsync (Submit branch), not in applyKey.
+    // This test verifies applyKey returns Submit correctly; the readAsync integration
+    // is covered by the Submit + dedup tests that call readAsync or simulate the store.
+    ()
+
+[<Fact>]
+let ``history_dedup_consecutiveDuplicate_notAdded`` () =
+    clearHistory()
+    historyStore.Add "foo"
+    // Simulate what readAsync does on Submit: add if not dup
+    let input = "foo"
+    if historyStore.Count = 0 || historyStore.[historyStore.Count - 1] <> input then
+        historyStore.Add input
+    historyStore.Count |> should equal 1
+
+[<Fact>]
+let ``history_TypeWhileBrowsing_resetsHistoryIdx`` () =
+    clearHistory()
+    historyStore.Add "entry"
+    let s = mkState "" 0
+    let _ = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s
+    s.HistoryIdx |> should equal 0
+    // Type a char — should reset HistoryIdx
+    let act = applyKey (key 'x' ConsoleModifiers.None) s
+    act |> should equal Continue
+    s.HistoryIdx |> should equal -1
+    s.SavedBuffer |> should equal None
+    // Buffer should have "entry" + 'x' inserted at end (cursor was at end of "entry")
+    String(s.Buffer.ToArray()) |> should equal "entryx"
+
+// ── Word movement tests ───────────────────────────────────────────────────────
+
+[<Fact>]
+let ``word_CtrlLeft_fromMidWord_jumpsToWordStart`` () =
+    let s = mkState "hello world" 8   // cursor inside "world"
+    let act = applyKey (special ConsoleKey.LeftArrow ConsoleModifiers.Control) s
+    act |> should equal Continue
+    s.Cursor |> should equal 6   // start of "world"
+
+[<Fact>]
+let ``word_CtrlLeft_fromWordStart_jumpsToPrevWordStart`` () =
+    let s = mkState "hello world" 6   // cursor at start of "world"
+    let act = applyKey (special ConsoleKey.LeftArrow ConsoleModifiers.Control) s
+    act |> should equal Continue
+    s.Cursor |> should equal 0   // start of "hello"
+
+[<Fact>]
+let ``word_CtrlLeft_atZero_isNoOp`` () =
+    let s = mkState "hello" 0
+    let act = applyKey (special ConsoleKey.LeftArrow ConsoleModifiers.Control) s
+    act |> should equal Continue
+    s.Cursor |> should equal 0
+
+[<Fact>]
+let ``word_CtrlRight_fromMidWord_jumpsPastWordEnd`` () =
+    let s = mkState "hello world" 2   // cursor inside "hello"
+    let act = applyKey (special ConsoleKey.RightArrow ConsoleModifiers.Control) s
+    act |> should equal Continue
+    s.Cursor |> should equal 5   // past end of "hello"
+
+[<Fact>]
+let ``word_CtrlRight_atEnd_isNoOp`` () =
+    let s = mkState "hello" 5
+    let act = applyKey (special ConsoleKey.RightArrow ConsoleModifiers.Control) s
+    act |> should equal Continue
+    s.Cursor |> should equal 5
+
+[<Fact>]
+let ``word_CtrlW_deletesWordBackward`` () =
+    let s = mkState "hello world" 11   // cursor at end
+    let act = applyKey (special ConsoleKey.W ConsoleModifiers.Control) s
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "hello "
+    s.Cursor |> should equal 6
+
+[<Fact>]
+let ``word_CtrlW_deletesLeadingWhitespace`` () =
+    let s = mkState "  hello" 7   // cursor at end
+    let act = applyKey (special ConsoleKey.W ConsoleModifiers.Control) s
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal ""
+    s.Cursor |> should equal 0
+
+[<Fact>]
+let ``word_CtrlW_atZero_isNoOp`` () =
+    let s = mkState "hello" 0
+    let act = applyKey (special ConsoleKey.W ConsoleModifiers.Control) s
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "hello"
+    s.Cursor |> should equal 0

--- a/tests/Fugue.Tests/ReadLineTests.fs
+++ b/tests/Fugue.Tests/ReadLineTests.fs
@@ -344,3 +344,100 @@ let ``word_CtrlW_atZero_isNoOp`` () =
     act |> should equal Continue
     String(s.Buffer.ToArray()) |> should equal "hello"
     s.Cursor |> should equal 0
+
+// ── Undo / redo tests ─────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``undo_CtrlZ_onEmptyStack_isNoOp`` () =
+    clearUndoRedo()
+    let s = mkState "hello" 5
+    let act = applyKey (special ConsoleKey.Z ConsoleModifiers.Control) s
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "hello"
+    s.Cursor |> should equal 5
+
+[<Fact>]
+let ``undo_typingChar_pushesSnapshotOntoUndoStack`` () =
+    clearUndoRedo()
+    let s = mkState "ab" 2
+    let _ = applyKey (key 'c' ConsoleModifiers.None) s
+    undoStack.Count |> should equal 1
+    redoStack.Count |> should equal 0
+
+[<Fact>]
+let ``undo_CtrlZ_restoresPreviousBufferAndCursor`` () =
+    clearUndoRedo()
+    let s = mkState "ab" 2
+    let _ = applyKey (key 'c' ConsoleModifiers.None) s   // buffer = "abc", cursor = 3; snapshot "ab"/2 on undoStack
+    let act = applyKey (special ConsoleKey.Z ConsoleModifiers.Control) s
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "ab"
+    s.Cursor |> should equal 2
+    undoStack.Count |> should equal 0
+
+[<Fact>]
+let ``undo_CtrlZ_pushesCurrentStateOntoRedoStack`` () =
+    clearUndoRedo()
+    let s = mkState "ab" 2
+    let _ = applyKey (key 'c' ConsoleModifiers.None) s   // "abc", cursor 3
+    let _ = applyKey (special ConsoleKey.Z ConsoleModifiers.Control) s
+    redoStack.Count |> should equal 1
+    let (redoBuf, redoCursor) = redoStack.[0]
+    String(redoBuf.ToArray()) |> should equal "abc"
+    redoCursor |> should equal 3
+
+[<Fact>]
+let ``redo_CtrlY_onEmptyStack_isNoOp`` () =
+    clearUndoRedo()
+    let s = mkState "hello" 5
+    let act = applyKey (special ConsoleKey.Y ConsoleModifiers.Control) s
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "hello"
+    s.Cursor |> should equal 5
+
+[<Fact>]
+let ``redo_CtrlY_restoresRedoneStateAndPushesUndoViaPushBounded`` () =
+    clearUndoRedo()
+    let s = mkState "ab" 2
+    let _ = applyKey (key 'c' ConsoleModifiers.None) s   // "abc"/3 → undoStack: [("ab",2)]
+    let _ = applyKey (special ConsoleKey.Z ConsoleModifiers.Control) s  // back to "ab"/2 → redoStack: [("abc",3)]
+    let act = applyKey (special ConsoleKey.Y ConsoleModifiers.Control) s  // redo
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "abc"
+    s.Cursor |> should equal 3
+    redoStack.Count |> should equal 0
+    undoStack.Count |> should equal 1
+
+[<Fact>]
+let ``redo_typingAfterUndo_clearsRedoStack`` () =
+    clearUndoRedo()
+    let s = mkState "ab" 2
+    let _ = applyKey (key 'c' ConsoleModifiers.None) s   // "abc"/3
+    let _ = applyKey (special ConsoleKey.Z ConsoleModifiers.Control) s  // back to "ab"/2
+    redoStack.Count |> should equal 1
+    let _ = applyKey (key 'x' ConsoleModifiers.None) s   // typing clears redo
+    redoStack.Count |> should equal 0
+
+[<Fact>]
+let ``undo_pushBounded_capsUndoStackAt100`` () =
+    clearUndoRedo()
+    let s = mkState "" 0
+    // Type 110 characters — each keystroke pushes one snapshot
+    for _ in 1 .. 110 do
+        let _ = applyKey (key 'a' ConsoleModifiers.None) s
+        ()
+    undoStack.Count |> should equal 100
+
+[<Fact>]
+let ``redo_pushBounded_capsRedoStackAt100`` () =
+    clearUndoRedo()
+    let s = mkState "" 0
+    // Build up 110 undo entries
+    for _ in 1 .. 110 do
+        let _ = applyKey (key 'a' ConsoleModifiers.None) s
+        ()
+    // Undo all 100 capped entries; each undo pushes onto redo via pushBounded
+    for _ in 1 .. 110 do
+        let _ = applyKey (special ConsoleKey.Z ConsoleModifiers.Control) s
+        ()
+    redoStack.Count |> should equal 100


### PR DESCRIPTION
## Summary

- Adds undo/redo (Ctrl+Z / Ctrl+Y) to `ReadLine.fs` with module-level `undoStack` and `redoStack`
- Introduces `pushBounded` helper that evicts the oldest entry once either stack exceeds 100 entries, preventing unbounded growth
- Both Ctrl+Z (undo) and Ctrl+Y (redo) save the current state via `pushBounded` before restoring
- Typing a printable character pushes a snapshot onto `undoStack` and clears `redoStack`

## Test plan

- [x] `undo_CtrlZ_onEmptyStack_isNoOp` — no crash, buffer unchanged
- [x] `undo_typingChar_pushesSnapshotOntoUndoStack` — snapshot recorded on keystroke
- [x] `undo_CtrlZ_restoresPreviousBufferAndCursor` — buffer and cursor restored correctly
- [x] `undo_CtrlZ_pushesCurrentStateOntoRedoStack` — redo stack populated via pushBounded
- [x] `redo_CtrlY_onEmptyStack_isNoOp` — no crash, buffer unchanged
- [x] `redo_CtrlY_restoresRedoneStateAndPushesUndoViaPushBounded` — full round-trip undo→redo
- [x] `redo_typingAfterUndo_clearsRedoStack` — redo stack wiped on new input
- [x] `undo_pushBounded_capsUndoStackAt100` — 110 keystrokes → stack stays at 100
- [x] `redo_pushBounded_capsRedoStackAt100` — 110 undos → redo stack stays at 100
- [x] `dotnet build src/Fugue.Cli -c Release` → 0 errors, 0 warnings
- [x] `dotnet test tests/Fugue.Tests` → 115/115 passed

Closes #553