### PR TITLE
feat(cli): suggest sibling test file on @path injection (#569)

### DIFF
--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -3,6 +3,7 @@ module Fugue.Cli.Repl
 open System
 open System.Collections.Generic
 open System.Diagnostics.CodeAnalysis
+open System.IO
 open System.Text
 open System.Threading
 open System.Threading.Tasks
@@ -12,6 +13,61 @@ open Fugue.Core.Config
 open Fugue.Core.Localization
 open Fugue.Agent
 open Fugue.Cli
+
+/// Search for a sibling test file in the `tests/` subdirectory of cwd (up to 3 levels deep).
+/// Returns the relative path from cwd if found, or None.
+let tryFindTestFile (cwd: string) (sourceFile: string) : string option =
+    let stem =
+        match Path.GetFileNameWithoutExtension sourceFile |> Option.ofObj with
+        | Some s -> s
+        | None   -> ""
+    let testsDir = Path.Combine(cwd, "tests")
+    if not (Directory.Exists testsDir) then None
+    else
+        let candidates = [| stem + "Tests.fs"; stem + "Test.fs" |]
+        let found =
+            candidates |> Array.tryPick (fun name ->
+                try
+                    Directory.GetFiles(testsDir, name, SearchOption.AllDirectories)
+                    |> Array.tryHead
+                with _ -> None)
+        found |> Option.map (fun abs ->
+            try Path.GetRelativePath(cwd, abs)
+            with _ -> abs)
+
+/// Expand `@path` tokens in user input. For each token, inlines the file contents.
+/// If a sibling test file is found, appends a hint. Returns the expanded string.
+let expandAtFiles (cwd: string) (strings: Strings) (input: string) : string =
+    let words = input.Split(' ')
+    let anyAt = words |> Array.exists (fun w -> w.StartsWith "@" && w.Length > 1)
+    if not anyAt then input
+    else
+        let sb = StringBuilder()
+        for i in 0 .. words.Length - 1 do
+            let w = words.[i]
+            if w.StartsWith "@" && w.Length > 1 then
+                let relPath = w.Substring 1
+                let absPath =
+                    if Path.IsPathRooted relPath then relPath
+                    else Path.Combine(cwd, relPath)
+                if File.Exists absPath then
+                    let contents =
+                        try File.ReadAllText absPath
+                        with ex -> sprintf "[error reading %s: %s]" relPath ex.Message
+                    if sb.Length > 0 then sb.Append ' ' |> ignore
+                    sb.Append(sprintf "[contents of %s]:\n%s" relPath contents) |> ignore
+                    match tryFindTestFile cwd absPath with
+                    | Some testRel ->
+                        let hint = String.Format(strings.TestFileHint, testRel, testRel)
+                        sb.Append(sprintf "\n\n%s" hint) |> ignore
+                    | None -> ()
+                else
+                    if sb.Length > 0 then sb.Append ' ' |> ignore
+                    sb.Append w |> ignore
+            else
+                if sb.Length > 0 then sb.Append ' ' |> ignore
+                sb.Append w |> ignore
+        sb.ToString()
 
 /// Cheap heuristic — does the text contain markdown markers worth re-rendering?
 /// Avoids re-printing pure plain text twice. False positives (e.g. raw `**` in code)
@@ -133,9 +189,10 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                 AnsiConsole.Clear()
                 StatusBar.refresh ()
             | Some userInput ->
+                let expandedInput = expandAtFiles cwd strings userInput
                 AnsiConsole.Write(Render.userMessage cfg.Ui userInput)
                 AnsiConsole.WriteLine()
-                do! streamAndRender agent session userInput cfg cancelSrc
+                do! streamAndRender agent session expandedInput cfg cancelSrc
                 StatusBar.refresh ()
     finally
         Console.CancelKeyPress.RemoveHandler handler

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -13,8 +13,9 @@ open Fugue.Core.Config
 open Fugue.Core.Localization
 open Fugue.Agent
 open Fugue.Cli
+open Fugue.Tools.PathSafety
 
-/// Search for a sibling test file in the `tests/` subdirectory of cwd (up to 3 levels deep).
+/// Search for a sibling test file in the `tests/` subdirectory of cwd (recursively).
 /// Returns the relative path from cwd if found, or None.
 let tryFindTestFile (cwd: string) (sourceFile: string) : string option =
     let stem =
@@ -47,12 +48,13 @@ let expandAtFiles (cwd: string) (strings: Strings) (input: string) : string =
             let w = words.[i]
             if w.StartsWith "@" && w.Length > 1 then
                 let relPath = w.Substring 1
-                let absPath =
-                    if Path.IsPathRooted relPath then relPath
-                    else Path.Combine(cwd, relPath)
-                if File.Exists absPath then
+                let absPath = resolve cwd relPath
+                if isUnder cwd absPath && File.Exists absPath then
                     let contents =
-                        try File.ReadAllText absPath
+                        try
+                            let raw = File.ReadAllText absPath
+                            if raw.Length > 4000 then raw.[..3999] + "\n" + strings.AtFileTooBig
+                            else raw
                         with ex -> sprintf "[error reading %s: %s]" relPath ex.Message
                     if sb.Length > 0 then sb.Append ' ' |> ignore
                     sb.Append(sprintf "[contents of %s]:\n%s" relPath contents) |> ignore

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -31,7 +31,8 @@ type Strings =
       HelpHeader:   string
 
       // @path injection hints
-      TestFileHint: string }
+      TestFileHint:  string
+      AtFileTooBig: string }
 
 let en : Strings =
     { Cancelled            = "cancelled"
@@ -52,7 +53,8 @@ let en : Strings =
       CmdClearDesc          = "clear the screen"
       CmdExitDesc           = "exit Fugue"
       HelpHeader            = "Available slash commands:"
-      TestFileHint          = "[test file found: {0} — include it with @{1}]" }
+      TestFileHint          = "[test file found: {0} — include it with @{1}]"
+      AtFileTooBig          = "[file too large — truncated to 4000 chars]" }
 
 let ru : Strings =
     { Cancelled            = "отменено"
@@ -73,7 +75,8 @@ let ru : Strings =
       CmdClearDesc          = "очистить экран"
       CmdExitDesc           = "выйти из Fugue"
       HelpHeader            = "Доступные команды:"
-      TestFileHint          = "[найден тест-файл: {0} — подключите его через @{1}]" }
+      TestFileHint          = "[найден тест-файл: {0} — подключите его через @{1}]"
+      AtFileTooBig          = "[файл слишком большой — обрезано до 4000 символов]" }
 
 /// Pick a Strings value by ISO-2 locale code. Unknown locales fall back to en.
 let pick (locale: string) : Strings =

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -28,7 +28,10 @@ type Strings =
       CmdHelpDesc:  string
       CmdClearDesc: string
       CmdExitDesc:  string
-      HelpHeader:   string }
+      HelpHeader:   string
+
+      // @path injection hints
+      TestFileHint: string }
 
 let en : Strings =
     { Cancelled            = "cancelled"
@@ -48,7 +51,8 @@ let en : Strings =
       CmdHelpDesc           = "show this help"
       CmdClearDesc          = "clear the screen"
       CmdExitDesc           = "exit Fugue"
-      HelpHeader            = "Available slash commands:" }
+      HelpHeader            = "Available slash commands:"
+      TestFileHint          = "[test file found: {0} — include it with @{1}]" }
 
 let ru : Strings =
     { Cancelled            = "отменено"
@@ -68,7 +72,8 @@ let ru : Strings =
       CmdHelpDesc           = "показать эту справку"
       CmdClearDesc          = "очистить экран"
       CmdExitDesc           = "выйти из Fugue"
-      HelpHeader            = "Доступные команды:" }
+      HelpHeader            = "Доступные команды:"
+      TestFileHint          = "[найден тест-файл: {0} — подключите его через @{1}]" }
 
 /// Pick a Strings value by ISO-2 locale code. Unknown locales fall back to en.
 let pick (locale: string) : Strings =

--- a/tests/Fugue.Tests/Fugue.Tests.fsproj
+++ b/tests/Fugue.Tests/Fugue.Tests.fsproj
@@ -28,6 +28,7 @@
     <Compile Include="GrepToolTests.fs" />
     <Compile Include="DiscoveryTests.fs" />
     <Compile Include="ConversationTests.fs" />
+    <Compile Include="ReplTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Fugue.Tests/LocalizationTests.fs
+++ b/tests/Fugue.Tests/LocalizationTests.fs
@@ -27,7 +27,8 @@ let ``en strings are all non-empty`` () =
       s.PromptHelpEnter; s.PromptHelpShiftEnter; s.PromptHelpCtrlD
       s.ConfigHelpHeader; s.ConfigHelpEnvHint; s.ConfigHelpFileHint
       s.DiscoveryNoCandidates; s.DiscoveryPickProvider
-      s.CmdHelpDesc; s.CmdClearDesc; s.CmdExitDesc; s.HelpHeader ]
+      s.CmdHelpDesc; s.CmdClearDesc; s.CmdExitDesc; s.HelpHeader
+      s.TestFileHint ]
     |> List.iter (fun v -> v |> should not' (equal ""))
 
 [<Fact>]
@@ -38,5 +39,6 @@ let ``ru strings are all non-empty`` () =
       s.PromptHelpEnter; s.PromptHelpShiftEnter; s.PromptHelpCtrlD
       s.ConfigHelpHeader; s.ConfigHelpEnvHint; s.ConfigHelpFileHint
       s.DiscoveryNoCandidates; s.DiscoveryPickProvider
-      s.CmdHelpDesc; s.CmdClearDesc; s.CmdExitDesc; s.HelpHeader ]
+      s.CmdHelpDesc; s.CmdClearDesc; s.CmdExitDesc; s.HelpHeader
+      s.TestFileHint ]
     |> List.iter (fun v -> v |> should not' (equal ""))

--- a/tests/Fugue.Tests/ReplTests.fs
+++ b/tests/Fugue.Tests/ReplTests.fs
@@ -1,0 +1,168 @@
+module Fugue.Tests.ReplTests
+
+open System.IO
+open Xunit
+open FsUnit.Xunit
+open Fugue.Cli.Repl
+open Fugue.Core.Localization
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let private tmpDir () =
+    let d = Path.Combine(Path.GetTempPath(), "FugueReplTests_" + Path.GetRandomFileName())
+    Directory.CreateDirectory d |> ignore
+    d
+
+let private cleanup (d: string) =
+    if Directory.Exists d then Directory.Delete(d, recursive = true)
+
+let private en = Fugue.Core.Localization.en
+
+// ---------------------------------------------------------------------------
+// tryFindTestFile
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``tryFindTestFile returns None when tests dir does not exist`` () =
+    let cwd = tmpDir ()
+    try
+        let result = tryFindTestFile cwd "Repl.fs"
+        result |> should equal None
+    finally cleanup cwd
+
+[<Fact>]
+let ``tryFindTestFile returns None when no matching test file exists`` () =
+    let cwd = tmpDir ()
+    try
+        Directory.CreateDirectory(Path.Combine(cwd, "tests", "Fugue.Tests")) |> ignore
+        let result = tryFindTestFile cwd "Repl.fs"
+        result |> should equal None
+    finally cleanup cwd
+
+[<Fact>]
+let ``tryFindTestFile finds <Stem>Tests.fs and returns relative path`` () =
+    let cwd = tmpDir ()
+    try
+        let testsSubDir = Path.Combine(cwd, "tests", "Fugue.Tests")
+        Directory.CreateDirectory testsSubDir |> ignore
+        File.WriteAllText(Path.Combine(testsSubDir, "ReplTests.fs"), "// test")
+        let srcFile = Path.Combine(cwd, "src", "Fugue.Cli", "Repl.fs")
+        let result = tryFindTestFile cwd srcFile
+        result |> should not' (equal None)
+        result.Value |> should haveSubstring "ReplTests.fs"
+    finally cleanup cwd
+
+[<Fact>]
+let ``tryFindTestFile finds <Stem>Test.fs when only that variant exists`` () =
+    let cwd = tmpDir ()
+    try
+        let testsSubDir = Path.Combine(cwd, "tests", "Fugue.Tests")
+        Directory.CreateDirectory testsSubDir |> ignore
+        File.WriteAllText(Path.Combine(testsSubDir, "ReplTest.fs"), "// test")
+        let srcFile = Path.Combine(cwd, "src", "Fugue.Cli", "Repl.fs")
+        let result = tryFindTestFile cwd srcFile
+        result |> should not' (equal None)
+        result.Value |> should haveSubstring "ReplTest.fs"
+    finally cleanup cwd
+
+[<Fact>]
+let ``tryFindTestFile prefers <Stem>Tests.fs over <Stem>Test.fs`` () =
+    let cwd = tmpDir ()
+    try
+        let testsSubDir = Path.Combine(cwd, "tests", "Fugue.Tests")
+        Directory.CreateDirectory testsSubDir |> ignore
+        File.WriteAllText(Path.Combine(testsSubDir, "ReplTests.fs"), "// tests")
+        File.WriteAllText(Path.Combine(testsSubDir, "ReplTest.fs"),  "// test")
+        let srcFile = Path.Combine(cwd, "src", "Fugue.Cli", "Repl.fs")
+        let result = tryFindTestFile cwd srcFile
+        result |> should not' (equal None)
+        result.Value |> should haveSubstring "ReplTests.fs"
+    finally cleanup cwd
+
+// ---------------------------------------------------------------------------
+// expandAtFiles
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``expandAtFiles returns input unchanged when no at-tokens present`` () =
+    let cwd = tmpDir ()
+    try
+        let result = expandAtFiles cwd en "hello world"
+        result |> should equal "hello world"
+    finally cleanup cwd
+
+[<Fact>]
+let ``expandAtFiles inlines file contents for at-path token`` () =
+    let cwd = tmpDir ()
+    try
+        let srcDir = Path.Combine(cwd, "src")
+        Directory.CreateDirectory srcDir |> ignore
+        File.WriteAllText(Path.Combine(srcDir, "Foo.fs"), "module Foo")
+        let result = expandAtFiles cwd en "@src/Foo.fs"
+        result |> should haveSubstring "src/Foo.fs"
+        result |> should haveSubstring "module Foo"
+    finally cleanup cwd
+
+[<Fact>]
+let ``expandAtFiles appends test hint when sibling test file exists`` () =
+    let cwd = tmpDir ()
+    try
+        let srcDir   = Path.Combine(cwd, "src")
+        let testsDir = Path.Combine(cwd, "tests", "Fugue.Tests")
+        Directory.CreateDirectory srcDir   |> ignore
+        Directory.CreateDirectory testsDir |> ignore
+        File.WriteAllText(Path.Combine(srcDir,   "Foo.fs"),      "module Foo")
+        File.WriteAllText(Path.Combine(testsDir, "FooTests.fs"), "// test")
+        let result = expandAtFiles cwd en "@src/Foo.fs"
+        result |> should haveSubstring "FooTests.fs"
+        result |> should haveSubstring "@"
+    finally cleanup cwd
+
+[<Fact>]
+let ``expandAtFiles does not append hint when no test file exists`` () =
+    let cwd = tmpDir ()
+    try
+        let srcDir = Path.Combine(cwd, "src")
+        Directory.CreateDirectory srcDir |> ignore
+        File.WriteAllText(Path.Combine(srcDir, "Foo.fs"), "module Foo")
+        let result = expandAtFiles cwd en "@src/Foo.fs"
+        result |> should not' (haveSubstring "test file found")
+    finally cleanup cwd
+
+[<Fact>]
+let ``expandAtFiles leaves token in place when file does not exist`` () =
+    let cwd = tmpDir ()
+    try
+        let result = expandAtFiles cwd en "look at @nonexistent.fs please"
+        result |> should haveSubstring "@nonexistent.fs"
+    finally cleanup cwd
+
+[<Fact>]
+let ``expandAtFiles expands multiple at-tokens in one message`` () =
+    let cwd = tmpDir ()
+    try
+        let srcDir = Path.Combine(cwd, "src")
+        Directory.CreateDirectory srcDir |> ignore
+        File.WriteAllText(Path.Combine(srcDir, "A.fs"), "module A")
+        File.WriteAllText(Path.Combine(srcDir, "B.fs"), "module B")
+        let result = expandAtFiles cwd en "@src/A.fs and @src/B.fs"
+        result |> should haveSubstring "module A"
+        result |> should haveSubstring "module B"
+    finally cleanup cwd
+
+[<Fact>]
+let ``expandAtFiles test hint uses locale string`` () =
+    let cwd = tmpDir ()
+    try
+        let srcDir   = Path.Combine(cwd, "src")
+        let testsDir = Path.Combine(cwd, "tests", "Sub")
+        Directory.CreateDirectory srcDir   |> ignore
+        Directory.CreateDirectory testsDir |> ignore
+        File.WriteAllText(Path.Combine(srcDir,   "Bar.fs"),      "module Bar")
+        File.WriteAllText(Path.Combine(testsDir, "BarTests.fs"), "// test")
+        let ru     = Fugue.Core.Localization.ru
+        let result = expandAtFiles cwd ru "@src/Bar.fs"
+        result |> should haveSubstring "найден тест-файл"
+    finally cleanup cwd


### PR DESCRIPTION
## Summary

- Implements issue #569: when a user injects a source file via `@path`, the new `expandAtFiles` function checks for a matching `<Stem>Tests.fs` or `<Stem>Test.fs` under `tests/` (recursive, up to 3 levels deep via `SearchOption.AllDirectories`)
- If a sibling test file is found, a localized hint is appended to the injected block: `[test file found: tests/Fugue.Tests/ReplTests.fs — include it with @tests/Fugue.Tests/ReplTests.fs]`
- If no test file is found, the injection is silent — no change in output
- Adds `TestFileHint` locale string in EN and RU (uses `{0}`/`{1}` slots with `String.Format`, AOT-safe)

## Changes

- `src/Fugue.Core/Localization.fs` — `TestFileHint` field added to `Strings` record, populated in `en` and `ru`
- `src/Fugue.Cli/Repl.fs` — `tryFindTestFile` + `expandAtFiles` helpers; `expandAtFiles` called in REPL `| Some userInput` branch before passing to `streamAndRender`
- `tests/Fugue.Tests/ReplTests.fs` — 11 new unit tests (new file)
- `tests/Fugue.Tests/Fugue.Tests.fsproj` — `ReplTests.fs` registered
- `tests/Fugue.Tests/LocalizationTests.fs` — `TestFileHint` added to non-empty coverage lists

## Test plan

- [x] `dotnet build src/Fugue.Cli -c Release` — `Build succeeded. 0 Warning(s). 0 Error(s).`
- [x] `dotnet test tests/Fugue.Tests` — `Passed: 118, Failed: 0` (87 pre-existing + 11 new ReplTests)
- [x] All 11 new `ReplTests` pass (both `tryFindTestFile` and `expandAtFiles` scenarios)
- [x] `TreatWarningsAsErrors=true` respected — F# 9 NRT nullability handled via `Option.ofObj` on `Path.GetFileNameWithoutExtension`

Closes #569