### PR TITLE
feat(cli): LaTeX math → Unicode approximation in rendered output

### DIFF
--- a/src/Fugue.Cli/Fugue.Cli.fsproj
+++ b/src/Fugue.Cli/Fugue.Cli.fsproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <Compile Include="ReadLine.fs" />
+    <Compile Include="MathRender.fs" />
     <Compile Include="MarkdownRender.fs" />
     <Compile Include="DiffRender.fs" />
     <Compile Include="Render.fs" />

--- a/src/Fugue.Cli/MarkdownRender.fs
+++ b/src/Fugue.Cli/MarkdownRender.fs
@@ -167,8 +167,9 @@ let rec private renderBlock (block: Block) : IRenderable =
         Markup(escape (block.ToString() |> Option.ofObj |> Option.defaultValue "")) :> IRenderable
 
 /// Convert markdown source text to a single composite Spectre IRenderable.
+/// Math pre-processing runs before Markdig so LaTeX notation renders as Unicode.
 let toRenderable (markdown: string) : IRenderable =
-    let doc = Markdown.Parse(markdown, pipeline)
+    let doc = Markdown.Parse(MathRender.preprocess markdown, pipeline)
     let parts =
         doc
         |> Seq.cast<Block>

--- a/src/Fugue.Cli/MathRender.fs
+++ b/src/Fugue.Cli/MathRender.fs
@@ -1,0 +1,252 @@
+module Fugue.Cli.MathRender
+
+// LaTeX math → Unicode approximation.
+// Best-effort: covers common Greek letters, operators, arrows, sets,
+// superscripts, subscripts, and \frac. No Regex (AOT constraint).
+
+/// Replace all recognised \command sequences with Unicode equivalents.
+let private replaceCommands (s: string) : string =
+    s
+     // Greek lowercase
+     .Replace(@"\alpha",   "α")
+     .Replace(@"\beta",    "β")
+     .Replace(@"\gamma",   "γ")
+     .Replace(@"\delta",   "δ")
+     .Replace(@"\epsilon", "ε")
+     .Replace(@"\zeta",    "ζ")
+     .Replace(@"\eta",     "η")
+     .Replace(@"\theta",   "θ")
+     .Replace(@"\iota",    "ι")
+     .Replace(@"\kappa",   "κ")
+     .Replace(@"\lambda",  "λ")
+     .Replace(@"\mu",      "μ")
+     .Replace(@"\nu",      "ν")
+     .Replace(@"\xi",      "ξ")
+     .Replace(@"\pi",      "π")
+     .Replace(@"\rho",     "ρ")
+     .Replace(@"\sigma",   "σ")
+     .Replace(@"\tau",     "τ")
+     .Replace(@"\upsilon", "υ")
+     .Replace(@"\phi",     "φ")
+     .Replace(@"\chi",     "χ")
+     .Replace(@"\psi",     "ψ")
+     .Replace(@"\omega",   "ω")
+     // Greek uppercase
+     .Replace(@"\Alpha",   "Α")
+     .Replace(@"\Beta",    "Β")
+     .Replace(@"\Gamma",   "Γ")
+     .Replace(@"\Delta",   "Δ")
+     .Replace(@"\Epsilon", "Ε")
+     .Replace(@"\Theta",   "Θ")
+     .Replace(@"\Lambda",  "Λ")
+     .Replace(@"\Xi",      "Ξ")
+     .Replace(@"\Pi",      "Π")
+     .Replace(@"\Sigma",   "Σ")
+     .Replace(@"\Phi",     "Φ")
+     .Replace(@"\Psi",     "Ψ")
+     .Replace(@"\Omega",   "Ω")
+     // Arithmetic / relational operators
+     .Replace(@"\times",   "×")
+     .Replace(@"\div",     "÷")
+     .Replace(@"\pm",      "±")
+     .Replace(@"\leq",     "≤")
+     .Replace(@"\geq",     "≥")
+     .Replace(@"\neq",     "≠")
+     .Replace(@"\approx",  "≈")
+     .Replace(@"\infty",   "∞")
+     .Replace(@"\sum",     "∑")
+     .Replace(@"\prod",    "∏")
+     .Replace(@"\sqrt",    "√")
+     .Replace(@"\int",     "∫")
+     .Replace(@"\partial", "∂")
+     .Replace(@"\nabla",   "∇")
+     .Replace(@"\cdot",    "·")
+     // Arrows
+     .Replace(@"\Leftrightarrow", "⟺")
+     .Replace(@"\Rightarrow",     "⇒")
+     .Replace(@"\Leftarrow",      "⇐")
+     .Replace(@"\leftarrow",      "←")
+     .Replace(@"\rightarrow",     "→")
+     .Replace(@"\to",             "→")
+     .Replace(@"\uparrow",        "↑")
+     .Replace(@"\downarrow",      "↓")
+     // Sets / logic
+     .Replace(@"\emptyset", "∅")
+     .Replace(@"\forall",   "∀")
+     .Replace(@"\exists",   "∃")
+     .Replace(@"\notin",    "∉")
+     .Replace(@"\in",       "∈")
+     .Replace(@"\subset",   "⊂")
+     .Replace(@"\supset",   "⊃")
+     .Replace(@"\subseteq", "⊆")
+     .Replace(@"\supseteq", "⊇")
+     .Replace(@"\cup",      "∪")
+     .Replace(@"\cap",      "∩")
+     .Replace(@"\wedge",    "∧")
+     .Replace(@"\vee",      "∨")
+     .Replace(@"\neg",      "¬")
+     // Miscellaneous
+     .Replace(@"\ldots",    "…")
+     .Replace(@"\cdots",    "⋯")
+     .Replace(@"\equiv",    "≡")
+     .Replace(@"\propto",   "∝")
+
+/// Replace \frac{a}{b} with (a/b).
+/// Uses a simple forward scan — no Regex.
+let private replaceFrac (s: string) : string =
+    let tag = @"\frac{"
+    let rec loop (acc: System.Text.StringBuilder) (i: int) =
+        if i >= s.Length then acc.ToString()
+        else
+            let pos = s.IndexOf(tag, i, System.StringComparison.Ordinal)
+            if pos < 0 then
+                acc.Append(s, i, s.Length - i) |> ignore
+                acc.ToString()
+            else
+                // Copy text before \frac
+                acc.Append(s, i, pos - i) |> ignore
+                // Find closing } for numerator
+                let numStart = pos + tag.Length
+                let mutable depth = 1
+                let mutable j = numStart
+                while j < s.Length && depth > 0 do
+                    if s.[j] = '{' then depth <- depth + 1
+                    elif s.[j] = '}' then depth <- depth - 1
+                    j <- j + 1
+                let numEnd = j - 1  // index of the closing }
+                let numerator = s.[numStart .. numEnd - 1]
+                // Expect next char to be {
+                if j < s.Length && s.[j] = '{' then
+                    let denStart = j + 1
+                    let mutable depth2 = 1
+                    let mutable k = denStart
+                    while k < s.Length && depth2 > 0 do
+                        if s.[k] = '{' then depth2 <- depth2 + 1
+                        elif s.[k] = '}' then depth2 <- depth2 - 1
+                        k <- k + 1
+                    let denEnd = k - 1
+                    let denominator = s.[denStart .. denEnd - 1]
+                    acc.Append(sprintf "(%s/%s)" numerator denominator) |> ignore
+                    loop acc k
+                else
+                    // Malformed — emit as-is starting from numStart
+                    acc.Append(sprintf "(%s/...)" numerator) |> ignore
+                    loop acc j
+    loop (System.Text.StringBuilder()) 0
+
+/// Superscript digit/letter map.
+let private superMap =
+    dict [
+        '0', '⁰'; '1', '¹'; '2', '²'; '3', '³'; '4', '⁴'
+        '5', '⁵'; '6', '⁶'; '7', '⁷'; '8', '⁸'; '9', '⁹'
+        'n', 'ⁿ'; 'i', 'ⁱ'; 'a', 'ᵃ'; 'b', 'ᵇ'; 'c', 'ᶜ'
+        'k', 'ᵏ'; 'm', 'ᵐ'; 'r', 'ʳ'; 's', 'ˢ'; 't', 'ᵗ'
+        'x', 'ˣ'; 'y', 'ʸ'; 'z', 'ᶻ'
+        '+', '⁺'; '-', '⁻'; '=', '⁼'; '(', '⁽'; ')', '⁾'
+    ]
+
+/// Subscript digit map (letters mostly lack Unicode subscript forms).
+let private subMap =
+    dict [
+        '0', '₀'; '1', '₁'; '2', '₂'; '3', '₃'; '4', '₄'
+        '5', '₅'; '6', '₆'; '7', '₇'; '8', '₈'; '9', '₉'
+        'n', 'ₙ'; 'i', 'ᵢ'; 'a', 'ₐ'; 'e', 'ₑ'; 'o', 'ₒ'
+        'k', 'ₖ'; 'm', 'ₘ'; 'r', 'ᵣ'; 's', 'ₛ'; 't', 'ₜ'
+        'x', 'ₓ'
+        '+', '₊'; '-', '₋'; '=', '₌'; '(', '₍'; ')', '₎'
+    ]
+
+/// Replace ^X and _X sequences (single char or {group}) with super/subscript chars.
+/// Only processes single-character targets outside braces; {group} is left as (group)
+/// with a super/sub indicator when no per-char map exists.
+let private replaceScripts (s: string) : string =
+    let sb = System.Text.StringBuilder(s.Length)
+    let mutable i = 0
+    while i < s.Length do
+        let c = s.[i]
+        if (c = '^' || c = '_') && i + 1 < s.Length then
+            let isSup = c = '^'
+            let map = if isSup then superMap else subMap
+            let next = s.[i + 1]
+            if next = '{' then
+                // Collect everything up to matching }
+                let mutable depth = 1
+                let mutable j = i + 2
+                while j < s.Length && depth > 0 do
+                    if s.[j] = '{' then depth <- depth + 1
+                    elif s.[j] = '}' then depth <- depth - 1
+                    j <- j + 1
+                let inner = s.[i + 2 .. j - 2]
+                // Try to map every char; if all map, emit directly; else wrap
+                let allMap = inner |> Seq.forall (fun ch -> map.ContainsKey(ch))
+                if allMap then
+                    for ch in inner do sb.Append(map.[ch]) |> ignore
+                else
+                    sb.Append(inner) |> ignore
+                i <- j
+            else
+                let mutable found = false
+                let mutable m = Unchecked.defaultof<char>
+                if map.TryGetValue(next, &m) then
+                    sb.Append(m) |> ignore
+                    found <- true
+                if not found then
+                    sb.Append(c) |> ignore
+                    sb.Append(next) |> ignore
+                i <- i + 2
+        else
+            sb.Append(c) |> ignore
+            i <- i + 1
+    sb.ToString()
+
+/// Strip $$ and $ delimiters, leaving the content (already converted).
+/// Processes $$...$$ first, then $...$.
+let private stripDelimiters (s: string) : string =
+    // Strip $$...$$
+    let mutable result = System.Text.StringBuilder()
+    let mutable i = 0
+    while i < s.Length do
+        if i + 1 < s.Length && s.[i] = '$' && s.[i + 1] = '$' then
+            // Find closing $$
+            let start = i + 2
+            let close = s.IndexOf("$$", start, System.StringComparison.Ordinal)
+            if close >= 0 then
+                result.Append(' ') |> ignore
+                result.Append(s, start, close - start) |> ignore
+                result.Append(' ') |> ignore
+                i <- close + 2
+            else
+                // No closing $$ — emit as-is
+                result.Append(s.[i]) |> ignore
+                i <- i + 1
+        else
+            result.Append(s.[i]) |> ignore
+            i <- i + 1
+    let s2 = result.ToString()
+    // Strip $...$
+    let result2 = System.Text.StringBuilder()
+    let mutable j = 0
+    while j < s2.Length do
+        if s2.[j] = '$' then
+            let start = j + 1
+            let close = s2.IndexOf('$', start)
+            if close >= 0 then
+                result2.Append(s2, start, close - start) |> ignore
+                j <- close + 1
+            else
+                result2.Append(s2.[j]) |> ignore
+                j <- j + 1
+        else
+            result2.Append(s2.[j]) |> ignore
+            j <- j + 1
+    result2.ToString()
+
+/// Pre-process a string, converting common LaTeX math to Unicode approximations.
+/// Call this before passing text to Markdig so the rendered output contains
+/// readable Unicode rather than raw LaTeX commands.
+let preprocess (s: string) : string =
+    s
+    |> replaceFrac
+    |> replaceCommands
+    |> replaceScripts
+    |> stripDelimiters

--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -9,6 +9,7 @@ open Fugue.Core.Localization
 // Hardcoded — small list, easier than passing through state.
 let slashCommands : string list = [ "/help"; "/clear"; "/exit" ]
 
+/// Session history (REPL is single-threaded). Not private so tests can seed entries directly.
 let historyStore = ResizeArray<string>()
 
 /// For test isolation only.
@@ -138,12 +139,12 @@ let applyKey (k: ConsoleKeyInfo) (s: S) : Action =
                 s.Buffer.AddRange(historyStore.[s.HistoryIdx].ToCharArray())
                 s.Cursor <- s.Buffer.Count
             Continue
-    elif k.Key = ConsoleKey.LeftArrow && k.Modifiers.HasFlag ConsoleModifiers.Control then
+    elif isCtrl k ConsoleKey.LeftArrow then
         exitHistoryMode ()
         s.ExitArmed <- false
         s.Cursor <- prevWordStart s.Buffer s.Cursor
         Continue
-    elif k.Key = ConsoleKey.RightArrow && k.Modifiers.HasFlag ConsoleModifiers.Control then
+    elif isCtrl k ConsoleKey.RightArrow then
         exitHistoryMode ()
         s.ExitArmed <- false
         s.Cursor <- nextWordEnd s.Buffer s.Cursor
@@ -153,7 +154,8 @@ let applyKey (k: ConsoleKeyInfo) (s: S) : Action =
         s.ExitArmed <- false
         if s.Cursor > 0 then
             let mutable p = prevWordStart s.Buffer s.Cursor
-            // If everything before p is whitespace, consume it too (leading whitespace deletion)
+            // Divergence from GNU readline unix-word-rubout: when only whitespace precedes the
+            // deleted word, also consume it — clears short prompts in one keystroke (matches zsh).
             let mutable j = p - 1
             while j >= 0 && (s.Buffer.[j] = ' ' || s.Buffer.[j] = '\t') do j <- j - 1
             if j < 0 then p <- 0

--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -9,6 +9,11 @@ open Fugue.Core.Localization
 // Hardcoded — small list, easier than passing through state.
 let slashCommands : string list = [ "/help"; "/clear"; "/exit" ]
 
+let historyStore = ResizeArray<string>()
+
+/// For test isolation only.
+let clearHistory () = historyStore.Clear()
+
 /// Internal mutable line state. Public only because tests construct it directly.
 type S = {
     mutable Buffer:          ResizeArray<char>
@@ -16,6 +21,8 @@ type S = {
     mutable LinesRendered:   int
     mutable ExitArmed:       bool
     mutable RowsBelowCursor: int   // # of rows from cursor's final position down to last rendered row
+    mutable HistoryIdx:      int                        // -1 = not browsing; 0..n-1 = browsing
+    mutable SavedBuffer:     ResizeArray<char> option   // snapshot before first Up press
     PromptText:              string
     PromptVisLen:            int
     HintWhenArmed:           string
@@ -36,9 +43,26 @@ let private isCtrl (k: ConsoleKeyInfo) (key: ConsoleKey) : bool =
 let private isShift (k: ConsoleKeyInfo) (key: ConsoleKey) : bool =
     k.Modifiers.HasFlag ConsoleModifiers.Shift && k.Key = key
 
+let private prevWordStart (buf: ResizeArray<char>) (pos: int) : int =
+    let mutable i = pos - 1
+    while i >= 0 && (buf.[i] = ' ' || buf.[i] = '\t') do i <- i - 1
+    while i >= 0 && buf.[i] <> ' ' && buf.[i] <> '\t' do i <- i - 1
+    i + 1
+
+let private nextWordEnd (buf: ResizeArray<char>) (pos: int) : int =
+    let mutable i = pos
+    while i < buf.Count && (buf.[i] = ' ' || buf.[i] = '\t') do i <- i + 1
+    while i < buf.Count && buf.[i] <> ' ' && buf.[i] <> '\t' do i <- i + 1
+    i
+
 /// Pure key dispatch. Mutates `s`; returns Action telling the loop what's next.
 let applyKey (k: ConsoleKeyInfo) (s: S) : Action =
+    let exitHistoryMode () =
+        s.HistoryIdx <- -1
+        s.SavedBuffer <- None
+
     if isCtrl k ConsoleKey.C then
+        exitHistoryMode ()
         if s.Buffer.Count = 0 && s.ExitArmed then
             Quit
         elif s.Buffer.Count = 0 then
@@ -52,39 +76,102 @@ let applyKey (k: ConsoleKeyInfo) (s: S) : Action =
     elif isCtrl k ConsoleKey.D then
         if s.Buffer.Count = 0 then Quit
         else
+            exitHistoryMode ()
             s.ExitArmed <- false
             // delete char at cursor (bash behaviour)
             if s.Cursor < s.Buffer.Count then
                 s.Buffer.RemoveAt s.Cursor
             Continue
     elif isShift k ConsoleKey.Enter then
+        exitHistoryMode ()
         s.ExitArmed <- false
         s.Buffer.Insert(s.Cursor, '\n')
         s.Cursor <- s.Cursor + 1
         Continue
     elif k.Key = ConsoleKey.Enter then
+        exitHistoryMode ()
         s.ExitArmed <- false
         Submit (String(s.Buffer.ToArray()))
     elif k.Key = ConsoleKey.Backspace then
+        exitHistoryMode ()
         s.ExitArmed <- false
         if s.Cursor > 0 then
             s.Buffer.RemoveAt(s.Cursor - 1)
             s.Cursor <- s.Cursor - 1
         Continue
     elif k.Key = ConsoleKey.Delete then
+        exitHistoryMode ()
         s.ExitArmed <- false
         if s.Cursor < s.Buffer.Count then
             s.Buffer.RemoveAt s.Cursor
         Continue
+    elif k.Key = ConsoleKey.UpArrow then
+        s.ExitArmed <- false
+        if historyStore.Count = 0 then
+            Continue
+        else
+            if s.HistoryIdx = -1 then
+                s.SavedBuffer <- Some (ResizeArray<char>(s.Buffer))
+                s.HistoryIdx <- historyStore.Count - 1
+            elif s.HistoryIdx > 0 then
+                s.HistoryIdx <- s.HistoryIdx - 1
+            s.Buffer.Clear()
+            s.Buffer.AddRange(historyStore.[s.HistoryIdx].ToCharArray())
+            s.Cursor <- s.Buffer.Count
+            Continue
+    elif k.Key = ConsoleKey.DownArrow then
+        s.ExitArmed <- false
+        if s.HistoryIdx = -1 then
+            Continue
+        else
+            s.HistoryIdx <- s.HistoryIdx + 1
+            if s.HistoryIdx >= historyStore.Count then
+                s.HistoryIdx <- -1
+                s.Buffer.Clear()
+                match s.SavedBuffer with
+                | Some saved -> s.Buffer.AddRange(saved)
+                | None -> ()
+                s.SavedBuffer <- None
+                s.Cursor <- s.Buffer.Count
+            else
+                s.Buffer.Clear()
+                s.Buffer.AddRange(historyStore.[s.HistoryIdx].ToCharArray())
+                s.Cursor <- s.Buffer.Count
+            Continue
+    elif k.Key = ConsoleKey.LeftArrow && k.Modifiers.HasFlag ConsoleModifiers.Control then
+        exitHistoryMode ()
+        s.ExitArmed <- false
+        s.Cursor <- prevWordStart s.Buffer s.Cursor
+        Continue
+    elif k.Key = ConsoleKey.RightArrow && k.Modifiers.HasFlag ConsoleModifiers.Control then
+        exitHistoryMode ()
+        s.ExitArmed <- false
+        s.Cursor <- nextWordEnd s.Buffer s.Cursor
+        Continue
+    elif isCtrl k ConsoleKey.W then
+        exitHistoryMode ()
+        s.ExitArmed <- false
+        if s.Cursor > 0 then
+            let mutable p = prevWordStart s.Buffer s.Cursor
+            // If everything before p is whitespace, consume it too (leading whitespace deletion)
+            let mutable j = p - 1
+            while j >= 0 && (s.Buffer.[j] = ' ' || s.Buffer.[j] = '\t') do j <- j - 1
+            if j < 0 then p <- 0
+            s.Buffer.RemoveRange(p, s.Cursor - p)
+            s.Cursor <- p
+        Continue
     elif k.Key = ConsoleKey.LeftArrow then
+        exitHistoryMode ()
         s.ExitArmed <- false
         if s.Cursor > 0 then s.Cursor <- s.Cursor - 1
         Continue
     elif k.Key = ConsoleKey.RightArrow then
+        exitHistoryMode ()
         s.ExitArmed <- false
         if s.Cursor < s.Buffer.Count then s.Cursor <- s.Cursor + 1
         Continue
     elif k.Key = ConsoleKey.Home then
+        exitHistoryMode ()
         s.ExitArmed <- false
         // beginning of current visual line (= last \n before cursor + 1, or 0)
         let mutable i = s.Cursor - 1
@@ -92,6 +179,7 @@ let applyKey (k: ConsoleKeyInfo) (s: S) : Action =
         s.Cursor <- i + 1
         Continue
     elif k.Key = ConsoleKey.End then
+        exitHistoryMode ()
         s.ExitArmed <- false
         // end of current visual line
         let mutable i = s.Cursor
@@ -99,6 +187,7 @@ let applyKey (k: ConsoleKeyInfo) (s: S) : Action =
         s.Cursor <- i
         Continue
     elif not (Char.IsControl k.KeyChar) then
+        exitHistoryMode ()
         s.ExitArmed <- false
         s.Buffer.Insert(s.Cursor, k.KeyChar)
         s.Cursor <- s.Cursor + 1
@@ -196,6 +285,8 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
           LinesRendered   = 0
           ExitArmed       = false
           RowsBelowCursor = 0
+          HistoryIdx      = -1
+          SavedBuffer     = None
           PromptText      = prompt
           PromptVisLen    = visLen
           HintWhenArmed   = strings.ExitHint
@@ -220,6 +311,11 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
             | Wipe     -> redraw st
             | Submit s ->
                 eraseRendered ()
+                if not (String.IsNullOrWhiteSpace s) then
+                    if historyStore.Count = 0 || historyStore.[historyStore.Count - 1] <> s then
+                        historyStore.Add s
+                st.HistoryIdx <- -1
+                st.SavedBuffer <- None
                 result <- ValueSome (Some s)
             | Quit ->
                 eraseRendered ()

--- a/tests/Fugue.Tests/Fugue.Tests.fsproj
+++ b/tests/Fugue.Tests/Fugue.Tests.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="LocalizationTests.fs" />
     <Compile Include="ReadLineTests.fs" />
     <Compile Include="MarkdownRenderTests.fs" />
+    <Compile Include="MathRenderTests.fs" />
     <Compile Include="DiffRenderTests.fs" />
     <Compile Include="RenderTests.fs" />
     <Compile Include="ReadToolTests.fs" />

--- a/tests/Fugue.Tests/MathRenderTests.fs
+++ b/tests/Fugue.Tests/MathRenderTests.fs
@@ -1,0 +1,289 @@
+module Fugue.Tests.MathRenderTests
+
+open Xunit
+open FsUnit.Xunit
+open Fugue.Cli
+
+// ---------------------------------------------------------------------------
+// Greek letters
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``alpha replaced`` () =
+    MathRender.preprocess @"$\alpha$" |> should equal "α"
+
+[<Fact>]
+let ``beta replaced`` () =
+    MathRender.preprocess @"$\beta$" |> should equal "β"
+
+[<Fact>]
+let ``gamma replaced`` () =
+    MathRender.preprocess @"$\gamma$" |> should equal "γ"
+
+[<Fact>]
+let ``delta replaced`` () =
+    MathRender.preprocess @"$\delta$" |> should equal "δ"
+
+[<Fact>]
+let ``epsilon replaced`` () =
+    MathRender.preprocess @"$\epsilon$" |> should equal "ε"
+
+[<Fact>]
+let ``pi replaced`` () =
+    MathRender.preprocess @"$\pi$" |> should equal "π"
+
+[<Fact>]
+let ``sigma replaced`` () =
+    MathRender.preprocess @"$\sigma$" |> should equal "σ"
+
+[<Fact>]
+let ``theta replaced`` () =
+    MathRender.preprocess @"$\theta$" |> should equal "θ"
+
+[<Fact>]
+let ``lambda replaced`` () =
+    MathRender.preprocess @"$\lambda$" |> should equal "λ"
+
+[<Fact>]
+let ``mu replaced`` () =
+    MathRender.preprocess @"$\mu$" |> should equal "μ"
+
+[<Fact>]
+let ``phi replaced`` () =
+    MathRender.preprocess @"$\phi$" |> should equal "φ"
+
+[<Fact>]
+let ``psi replaced`` () =
+    MathRender.preprocess @"$\psi$" |> should equal "ψ"
+
+[<Fact>]
+let ``omega replaced`` () =
+    MathRender.preprocess @"$\omega$" |> should equal "ω"
+
+[<Fact>]
+let ``uppercase Alpha replaced`` () =
+    MathRender.preprocess @"$\Alpha$" |> should equal "Α"
+
+[<Fact>]
+let ``uppercase Pi replaced`` () =
+    MathRender.preprocess @"$\Pi$" |> should equal "Π"
+
+[<Fact>]
+let ``uppercase Sigma replaced`` () =
+    MathRender.preprocess @"$\Sigma$" |> should equal "Σ"
+
+[<Fact>]
+let ``uppercase Omega replaced`` () =
+    MathRender.preprocess @"$\Omega$" |> should equal "Ω"
+
+// ---------------------------------------------------------------------------
+// Operators
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``times replaced`` () =
+    MathRender.preprocess @"$\times$" |> should equal "×"
+
+[<Fact>]
+let ``div replaced`` () =
+    MathRender.preprocess @"$\div$" |> should equal "÷"
+
+[<Fact>]
+let ``pm replaced`` () =
+    MathRender.preprocess @"$\pm$" |> should equal "±"
+
+[<Fact>]
+let ``leq replaced`` () =
+    MathRender.preprocess @"$\leq$" |> should equal "≤"
+
+[<Fact>]
+let ``geq replaced`` () =
+    MathRender.preprocess @"$\geq$" |> should equal "≥"
+
+[<Fact>]
+let ``neq replaced`` () =
+    MathRender.preprocess @"$\neq$" |> should equal "≠"
+
+[<Fact>]
+let ``approx replaced`` () =
+    MathRender.preprocess @"$\approx$" |> should equal "≈"
+
+[<Fact>]
+let ``infty replaced`` () =
+    MathRender.preprocess @"$\infty$" |> should equal "∞"
+
+[<Fact>]
+let ``sum replaced`` () =
+    MathRender.preprocess @"$\sum$" |> should equal "∑"
+
+[<Fact>]
+let ``prod replaced`` () =
+    MathRender.preprocess @"$\prod$" |> should equal "∏"
+
+[<Fact>]
+let ``sqrt replaced`` () =
+    MathRender.preprocess @"$\sqrt$" |> should equal "√"
+
+[<Fact>]
+let ``int replaced`` () =
+    MathRender.preprocess @"$\int$" |> should equal "∫"
+
+// ---------------------------------------------------------------------------
+// Arrows
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``to replaced`` () =
+    MathRender.preprocess @"$\to$" |> should equal "→"
+
+[<Fact>]
+let ``leftarrow replaced`` () =
+    MathRender.preprocess @"$\leftarrow$" |> should equal "←"
+
+[<Fact>]
+let ``Rightarrow replaced`` () =
+    MathRender.preprocess @"$\Rightarrow$" |> should equal "⇒"
+
+[<Fact>]
+let ``Leftrightarrow replaced`` () =
+    MathRender.preprocess @"$\Leftrightarrow$" |> should equal "⟺"
+
+// ---------------------------------------------------------------------------
+// Sets / logic
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``in replaced`` () =
+    MathRender.preprocess @"$\in$" |> should equal "∈"
+
+[<Fact>]
+let ``notin replaced`` () =
+    MathRender.preprocess @"$\notin$" |> should equal "∉"
+
+[<Fact>]
+let ``subset replaced`` () =
+    MathRender.preprocess @"$\subset$" |> should equal "⊂"
+
+[<Fact>]
+let ``cup replaced`` () =
+    MathRender.preprocess @"$\cup$" |> should equal "∪"
+
+[<Fact>]
+let ``cap replaced`` () =
+    MathRender.preprocess @"$\cap$" |> should equal "∩"
+
+[<Fact>]
+let ``emptyset replaced`` () =
+    MathRender.preprocess @"$\emptyset$" |> should equal "∅"
+
+[<Fact>]
+let ``forall replaced`` () =
+    MathRender.preprocess @"$\forall$" |> should equal "∀"
+
+[<Fact>]
+let ``exists replaced`` () =
+    MathRender.preprocess @"$\exists$" |> should equal "∃"
+
+// ---------------------------------------------------------------------------
+// Superscripts
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``superscript digit 2`` () =
+    MathRender.preprocess @"$x^2$" |> should equal "x²"
+
+[<Fact>]
+let ``superscript digit 0`` () =
+    MathRender.preprocess @"$x^0$" |> should equal "x⁰"
+
+[<Fact>]
+let ``superscript n`` () =
+    MathRender.preprocess @"$x^n$" |> should equal "xⁿ"
+
+[<Fact>]
+let ``superscript i`` () =
+    MathRender.preprocess @"$x^i$" |> should equal "xⁱ"
+
+[<Fact>]
+let ``superscript braced digits`` () =
+    MathRender.preprocess @"$x^{10}$" |> should equal "x¹⁰"
+
+// ---------------------------------------------------------------------------
+// Subscripts
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``subscript digit 0`` () =
+    MathRender.preprocess @"$x_0$" |> should equal "x₀"
+
+[<Fact>]
+let ``subscript digit 1`` () =
+    MathRender.preprocess @"$x_1$" |> should equal "x₁"
+
+[<Fact>]
+let ``subscript n`` () =
+    MathRender.preprocess @"$x_n$" |> should equal "xₙ"
+
+[<Fact>]
+let ``subscript braced`` () =
+    MathRender.preprocess @"$x_{00}$" |> should equal "x₀₀"
+
+// ---------------------------------------------------------------------------
+// Delimiter stripping
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``inline dollar delimiters stripped`` () =
+    MathRender.preprocess "$hello$" |> should equal "hello"
+
+[<Fact>]
+let ``display dollar delimiters stripped with spaces`` () =
+    let result = MathRender.preprocess "$$hello$$"
+    result.Trim() |> should equal "hello"
+
+[<Fact>]
+let ``text outside dollars is unchanged`` () =
+    MathRender.preprocess "The value is $x$ units." |> should equal "The value is x units."
+
+// ---------------------------------------------------------------------------
+// \frac approximation
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``frac simple`` () =
+    MathRender.preprocess @"$\frac{1}{2}$" |> should equal "(1/2)"
+
+[<Fact>]
+let ``frac with expressions`` () =
+    MathRender.preprocess @"$\frac{a+b}{c}$" |> should equal "(a+b/c)"
+
+[<Fact>]
+let ``frac nested with commands`` () =
+    // Commands are replaced before frac is scanned — but frac runs first.
+    // After frac: (\alpha/\beta), then command replace: (α/β), then strip $.
+    MathRender.preprocess @"$\frac{\alpha}{\beta}$" |> should equal "(α/β)"
+
+// ---------------------------------------------------------------------------
+// Combined expressions
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``combined expression E=mc^2`` () =
+    let result = MathRender.preprocess @"$E = mc^2$"
+    result |> should haveSubstring "mc²"
+
+[<Fact>]
+let ``combined expression sigma_i^2`` () =
+    let result = MathRender.preprocess @"$\sigma_i^2$"
+    result |> should haveSubstring "σ"
+    result |> should haveSubstring "ᵢ"
+    result |> should haveSubstring "²"
+
+[<Fact>]
+let ``plain text without math is unchanged`` () =
+    let s = "Hello, world! No math here."
+    MathRender.preprocess s |> should equal s
+
+[<Fact>]
+let ``empty string is unchanged`` () =
+    MathRender.preprocess "" |> should equal ""

--- a/tests/Fugue.Tests/ReadLineTests.fs
+++ b/tests/Fugue.Tests/ReadLineTests.fs
@@ -12,6 +12,8 @@ let private mkState (text: string) (cursor: int) : S =
       LinesRendered   = 0
       ExitArmed       = false
       RowsBelowCursor = 0
+      HistoryIdx      = -1
+      SavedBuffer     = None
       PromptText      = "> "
       PromptVisLen    = 2
       HintWhenArmed   = "Press Ctrl+C again to exit"
@@ -151,3 +153,194 @@ let ``slash buffer prefix is recognized for hint rendering`` () =
     // No applyKey side effect on the slash-suggestion field — just verify mkState constructs
     s.Buffer.Count |> should equal 1
     s.Buffer.[0] |> should equal '/'
+
+// ── History tests ─────────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``history_UpOnEmptyHistory_isNoOp`` () =
+    clearHistory()
+    let s = mkState "abc" 3
+    let act = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "abc"
+    s.Cursor |> should equal 3
+
+[<Fact>]
+let ``history_firstUp_loadsLatestEntry_savesBuffer`` () =
+    clearHistory()
+    // simulate prior Submit by adding directly
+    historyStore.Add "first"      // index 0
+    historyStore.Add "second"     // index 1 (most recent)
+    let s = mkState "draft" 5
+    let act = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "second"
+    s.Cursor |> should equal 6
+    s.HistoryIdx |> should equal 1
+    s.SavedBuffer |> should not' (equal None)
+
+[<Fact>]
+let ``history_secondUp_loadsOlderEntry`` () =
+    clearHistory()
+    historyStore.Add "first"
+    historyStore.Add "second"
+    let s = mkState "" 0
+    let _ = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s   // → "second"
+    let act = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s   // → "first"
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "first"
+    s.HistoryIdx |> should equal 0
+
+[<Fact>]
+let ``history_UpAtOldest_clamps`` () =
+    clearHistory()
+    historyStore.Add "only"
+    let s = mkState "" 0
+    let _ = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s   // → "only", idx=0
+    let act = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s   // clamped
+    act |> should equal Continue
+    s.HistoryIdx |> should equal 0
+    String(s.Buffer.ToArray()) |> should equal "only"
+
+[<Fact>]
+let ``history_DownFromBrowse_advancesToNewer`` () =
+    clearHistory()
+    historyStore.Add "first"
+    historyStore.Add "second"
+    let s = mkState "" 0
+    let _ = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s   // → "second", idx=1
+    let _ = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s   // → "first", idx=0
+    let act = applyKey (special ConsoleKey.DownArrow ConsoleModifiers.None) s  // → "second", idx=1
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "second"
+    s.HistoryIdx |> should equal 1
+
+[<Fact>]
+let ``history_DownPastEnd_restoresSavedBuffer`` () =
+    clearHistory()
+    historyStore.Add "entry"
+    let s = mkState "draft" 5
+    let _ = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s   // save "draft", load "entry"
+    let act = applyKey (special ConsoleKey.DownArrow ConsoleModifiers.None) s  // past end → restore
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "draft"
+    s.HistoryIdx |> should equal -1
+    s.SavedBuffer |> should equal None
+
+[<Fact>]
+let ``history_DownPastEnd_withEmptySavedBuffer_clears`` () =
+    clearHistory()
+    historyStore.Add "entry"
+    let s = mkState "" 0   // empty buffer before Up
+    let _ = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s
+    let act = applyKey (special ConsoleKey.DownArrow ConsoleModifiers.None) s
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal ""
+    s.Cursor |> should equal 0
+    s.HistoryIdx |> should equal -1
+
+[<Fact>]
+let ``history_DownOnNotBrowsing_isNoOp`` () =
+    clearHistory()
+    let s = mkState "hello" 5
+    let act = applyKey (special ConsoleKey.DownArrow ConsoleModifiers.None) s
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "hello"
+    s.Cursor |> should equal 5
+
+[<Fact>]
+let ``history_Submit_appendsToStore`` () =
+    clearHistory()
+    let s = mkState "foo" 3
+    let act = applyKey (special ConsoleKey.Enter ConsoleModifiers.None) s
+    act |> should equal (Submit "foo")
+    // Note: historyStore is updated in readAsync (Submit branch), not in applyKey.
+    // This test verifies applyKey returns Submit correctly; the readAsync integration
+    // is covered by the Submit + dedup tests that call readAsync or simulate the store.
+    ()
+
+[<Fact>]
+let ``history_dedup_consecutiveDuplicate_notAdded`` () =
+    clearHistory()
+    historyStore.Add "foo"
+    // Simulate what readAsync does on Submit: add if not dup
+    let input = "foo"
+    if historyStore.Count = 0 || historyStore.[historyStore.Count - 1] <> input then
+        historyStore.Add input
+    historyStore.Count |> should equal 1
+
+[<Fact>]
+let ``history_TypeWhileBrowsing_resetsHistoryIdx`` () =
+    clearHistory()
+    historyStore.Add "entry"
+    let s = mkState "" 0
+    let _ = applyKey (special ConsoleKey.UpArrow ConsoleModifiers.None) s
+    s.HistoryIdx |> should equal 0
+    // Type a char — should reset HistoryIdx
+    let act = applyKey (key 'x' ConsoleModifiers.None) s
+    act |> should equal Continue
+    s.HistoryIdx |> should equal -1
+    s.SavedBuffer |> should equal None
+    // Buffer should have "entry" + 'x' inserted at end (cursor was at end of "entry")
+    String(s.Buffer.ToArray()) |> should equal "entryx"
+
+// ── Word movement tests ───────────────────────────────────────────────────────
+
+[<Fact>]
+let ``word_CtrlLeft_fromMidWord_jumpsToWordStart`` () =
+    let s = mkState "hello world" 8   // cursor inside "world"
+    let act = applyKey (special ConsoleKey.LeftArrow ConsoleModifiers.Control) s
+    act |> should equal Continue
+    s.Cursor |> should equal 6   // start of "world"
+
+[<Fact>]
+let ``word_CtrlLeft_fromWordStart_jumpsToPrevWordStart`` () =
+    let s = mkState "hello world" 6   // cursor at start of "world"
+    let act = applyKey (special ConsoleKey.LeftArrow ConsoleModifiers.Control) s
+    act |> should equal Continue
+    s.Cursor |> should equal 0   // start of "hello"
+
+[<Fact>]
+let ``word_CtrlLeft_atZero_isNoOp`` () =
+    let s = mkState "hello" 0
+    let act = applyKey (special ConsoleKey.LeftArrow ConsoleModifiers.Control) s
+    act |> should equal Continue
+    s.Cursor |> should equal 0
+
+[<Fact>]
+let ``word_CtrlRight_fromMidWord_jumpsPastWordEnd`` () =
+    let s = mkState "hello world" 2   // cursor inside "hello"
+    let act = applyKey (special ConsoleKey.RightArrow ConsoleModifiers.Control) s
+    act |> should equal Continue
+    s.Cursor |> should equal 5   // past end of "hello"
+
+[<Fact>]
+let ``word_CtrlRight_atEnd_isNoOp`` () =
+    let s = mkState "hello" 5
+    let act = applyKey (special ConsoleKey.RightArrow ConsoleModifiers.Control) s
+    act |> should equal Continue
+    s.Cursor |> should equal 5
+
+[<Fact>]
+let ``word_CtrlW_deletesWordBackward`` () =
+    let s = mkState "hello world" 11   // cursor at end
+    let act = applyKey (special ConsoleKey.W ConsoleModifiers.Control) s
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "hello "
+    s.Cursor |> should equal 6
+
+[<Fact>]
+let ``word_CtrlW_deletesLeadingWhitespace`` () =
+    let s = mkState "  hello" 7   // cursor at end
+    let act = applyKey (special ConsoleKey.W ConsoleModifiers.Control) s
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal ""
+    s.Cursor |> should equal 0
+
+[<Fact>]
+let ``word_CtrlW_atZero_isNoOp`` () =
+    let s = mkState "hello" 0
+    let act = applyKey (special ConsoleKey.W ConsoleModifiers.Control) s
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "hello"
+    s.Cursor |> should equal 0


### PR DESCRIPTION
## Summary

- Add `MathRender.fs` with `MathRender.preprocess` that converts common LaTeX notation to Unicode approximations before Markdig processes text
- Covers: Greek letters (lower + upper), arithmetic/relational operators, arrows, set/logic symbols, superscripts (`^`), subscripts (`_`), and `\frac{a}{b}` → `(a/b)`
- Wire `MathRender.preprocess` into `MarkdownRender.toRenderable` (single call site)
- **AOT-safe:** zero Regex — all replacements use `String.Replace` chains and manual char scans

## Test plan

- [ ] 60 new unit tests in `MathRenderTests.fs` — all pass (`Passed: 60, Failed: 0`)
- [ ] `dotnet build src/Fugue.Cli -c Release` → `Build succeeded. 0 Warning(s). 0 Error(s).`
- [ ] Full suite: `Passed: 165, Failed: 1` — the 1 failure is the pre-existing `DiscoveryTests` env-var isolation issue, unrelated to this PR
- [ ] Spot-check: `$E = mc^2$` → `E = mc²`, `$\alpha + \beta$` → `α + β`, `$\frac{1}{2}$` → `(1/2)`

Closes #563