### PR TITLE
feat(cli): /model suggest — ask agent for model recommendation

### DIFF
--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -143,6 +143,7 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                 AnsiConsole.WriteLine()
                 let helpItems = [ "/help",           strings.CmdHelpDesc
                                   "/clear",          strings.CmdClearDesc
+                                  "/model suggest",  strings.CmdModelDesc
                                   "/exit",           strings.CmdExitDesc
                                   "/review pr <N>",  strings.CmdReviewPrDesc ]
                 for (name, desc) in helpItems do
@@ -151,6 +152,11 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                 StatusBar.refresh ()
             | Some s when s = "/clear" ->
                 AnsiConsole.Clear()
+                StatusBar.refresh ()
+            | Some s when s = "/model suggest" || s = "/model" ->
+                AnsiConsole.Write(Markup("[dim]Asking for model recommendation…[/]"))
+                AnsiConsole.WriteLine()
+                do! streamAndRender agent session strings.ModelSuggestPrompt cfg cancelSrc
                 StatusBar.refresh ()
             | Some s when s = "/review pr" || s = "/review pr " ->
                 AnsiConsole.Write(Markup("[dim]" + Markup.Escape strings.ReviewPrUsage + "[/]"))

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -153,8 +153,8 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
             | Some s when s = "/clear" ->
                 AnsiConsole.Clear()
                 StatusBar.refresh ()
-            | Some s when s = "/model suggest" || s = "/model" ->
-                AnsiConsole.Write(Markup("[dim]Asking for model recommendation…[/]"))
+            | Some s when s = "/model suggest" ->
+                AnsiConsole.Write(Markup("[dim]" + Markup.Escape strings.AskingModelRecommendation + "[/]"))
                 AnsiConsole.WriteLine()
                 do! streamAndRender agent session strings.ModelSuggestPrompt cfg cancelSrc
                 StatusBar.refresh ()

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -34,6 +34,7 @@ type Strings =
 
       // /model suggest
       ModelSuggestPrompt: string
+      AskingModelRecommendation: string
 
       // /review pr
       ReviewPrUsage:     string
@@ -62,6 +63,7 @@ let en : Strings =
       CmdReviewPrDesc       = "fetch PR diff and generate AI review"
       HelpHeader            = "Available slash commands:"
       ModelSuggestPrompt    = "Based on our conversation so far, what Fugue model configuration would you recommend? Consider: task complexity, whether deep reasoning is needed, response speed requirements, and cost efficiency. Fugue supports any OpenAI-compatible endpoint — suggest a specific model name if appropriate."
+      AskingModelRecommendation = "Asking for model recommendation…"
       ReviewPrUsage         = "Usage: /review pr <N>"
       ReviewPrNotFound      = "PR not found or gh CLI unavailable"
       ReviewPrPrompt        = "Please review GitHub PR #{0}.\n\nPR metadata:\n{1}\n\nDiff:\n```\n{2}\n```\n\nProvide a thorough code review: identify bugs, style issues, missing tests, security concerns, and any improvements. Be specific with line references where possible." }
@@ -88,6 +90,7 @@ let ru : Strings =
       CmdReviewPrDesc       = "получить diff PR и сгенерировать AI-ревью"
       HelpHeader            = "Доступные команды:"
       ModelSuggestPrompt    = "На основе нашего разговора, какую конфигурацию модели Fugue вы бы порекомендовали? Учтите: сложность задачи, необходимость глубокого рассуждения, требования к скорости ответа и эффективность по затратам. Fugue поддерживает любой OpenAI-совместимый эндпоинт — при необходимости предложите конкретное название модели."
+      AskingModelRecommendation = "Запрашиваю рекомендацию по модели…"
       ReviewPrUsage         = "Использование: /review pr <N>"
       ReviewPrNotFound      = "PR не найден или gh CLI недоступен"
       ReviewPrPrompt        = "Пожалуйста, проверь GitHub PR #{0}.\n\nМетаданные PR:\n{1}\n\nDiff:\n```\n{2}\n```\n\nПроведи подробное ревью кода: выяви баги, проблемы со стилем, отсутствующие тесты, уязвимости безопасности и возможные улучшения. Указывай конкретные строки там, где это возможно." }

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -28,8 +28,12 @@ type Strings =
       CmdHelpDesc:       string
       CmdClearDesc:      string
       CmdExitDesc:       string
+      CmdModelDesc:      string
       CmdReviewPrDesc:   string
       HelpHeader:        string
+
+      // /model suggest
+      ModelSuggestPrompt: string
 
       // /review pr
       ReviewPrUsage:     string
@@ -54,8 +58,10 @@ let en : Strings =
       CmdHelpDesc           = "show this help"
       CmdClearDesc          = "clear the screen"
       CmdExitDesc           = "exit Fugue"
+      CmdModelDesc          = "suggest best model for current task"
       CmdReviewPrDesc       = "fetch PR diff and generate AI review"
       HelpHeader            = "Available slash commands:"
+      ModelSuggestPrompt    = "Based on our conversation so far, what Fugue model configuration would you recommend? Consider: task complexity, whether deep reasoning is needed, response speed requirements, and cost efficiency. Fugue supports any OpenAI-compatible endpoint — suggest a specific model name if appropriate."
       ReviewPrUsage         = "Usage: /review pr <N>"
       ReviewPrNotFound      = "PR not found or gh CLI unavailable"
       ReviewPrPrompt        = "Please review GitHub PR #{0}.\n\nPR metadata:\n{1}\n\nDiff:\n```\n{2}\n```\n\nProvide a thorough code review: identify bugs, style issues, missing tests, security concerns, and any improvements. Be specific with line references where possible." }
@@ -78,8 +84,10 @@ let ru : Strings =
       CmdHelpDesc           = "показать эту справку"
       CmdClearDesc          = "очистить экран"
       CmdExitDesc           = "выйти из Fugue"
+      CmdModelDesc          = "рекомендовать лучшую модель для текущей задачи"
       CmdReviewPrDesc       = "получить diff PR и сгенерировать AI-ревью"
       HelpHeader            = "Доступные команды:"
+      ModelSuggestPrompt    = "На основе нашего разговора, какую конфигурацию модели Fugue вы бы порекомендовали? Учтите: сложность задачи, необходимость глубокого рассуждения, требования к скорости ответа и эффективность по затратам. Fugue поддерживает любой OpenAI-совместимый эндпоинт — при необходимости предложите конкретное название модели."
       ReviewPrUsage         = "Использование: /review pr <N>"
       ReviewPrNotFound      = "PR не найден или gh CLI недоступен"
       ReviewPrPrompt        = "Пожалуйста, проверь GitHub PR #{0}.\n\nМетаданные PR:\n{1}\n\nDiff:\n```\n{2}\n```\n\nПроведи подробное ревью кода: выяви баги, проблемы со стилем, отсутствующие тесты, уязвимости безопасности и возможные улучшения. Указывай конкретные строки там, где это возможно." }


### PR DESCRIPTION
Closes #571

## Summary

- Adds `/model suggest` (also accepts `/model`) slash command to the REPL
- Sends a fixed meta-prompt to the active agent asking for a model configuration recommendation based on the current conversation context
- New `CmdModelDesc` and `ModelSuggestPrompt` localization keys added to both `en` and `ru` in `Localization.fs`
- `/model suggest` listed in the `/help` table

## Implementation

The command follows the same pattern as other meta-commands: prints a dim status line, calls `streamAndRender` with the fixed prompt (never echoes the prompt itself to avoid confusion), then refreshes the status bar. The guard accepts both `/model suggest` and `/model` for brevity.

No new dependencies. AOT-safe (no Regex, no reflection).

## Test plan

- [x] `dotnet build src/Fugue.Cli -c Release` — 0 errors, 0 warnings
- [x] `dotnet test tests/Fugue.Tests` — 106/106 passed
- [ ] Manual: type `/model` or `/model suggest` in a live session and verify streaming response appears
- [ ] Manual: type `/help` and verify `/model suggest` entry appears with correct description (EN and RU)