### PR TITLE
feat(ux): honour NO_COLOR / FUGUE_NO_COLOR / TERM=dumb (#666)

### DIFF
--- a/src/Fugue.Cli/Program.fs
+++ b/src/Fugue.Cli/Program.fs
@@ -6,6 +6,11 @@ open Microsoft.Agents.AI
 open Fugue.Core.Config
 open Fugue.Agent
 
+let private noColor () =
+    let isSet name = Environment.GetEnvironmentVariable name |> isNull |> not
+    isSet "NO_COLOR" || isSet "FUGUE_NO_COLOR"
+    || Environment.GetEnvironmentVariable "TERM" = "dumb"
+
 let private buildAgent (cfg: AppConfig) : AIAgent =
     let cwd = Environment.CurrentDirectory
     let tools = Fugue.Tools.ToolRegistry.buildAll cwd
@@ -18,6 +23,7 @@ let private buildAgent (cfg: AppConfig) : AIAgent =
 [<RequiresUnreferencedCode("Calls Repl.run and Config.saveToFile which use STJ reflection; System.Text.Json is TrimmerRootAssembly")>]
 [<RequiresDynamicCode("Calls Repl.run and Config.saveToFile which use STJ reflection; System.Text.Json is TrimmerRootAssembly")>]
 let private runWithCfg (cfg: AppConfig) : int =
+    Render.initColor (not (noColor ()))
     let agent = buildAgent cfg
     let cwd = Environment.CurrentDirectory
     let t = Repl.run agent cfg cwd

--- a/src/Fugue.Cli/Render.fs
+++ b/src/Fugue.Cli/Render.fs
@@ -10,18 +10,28 @@ type ToolState =
     | Completed of name: string * args: string * output: string
     | Failed    of name: string * args: string * err: string
 
+let mutable private colorEnabled = true
+
+let initColor (enabled: bool) =
+    colorEnabled <- enabled
+
+let isColorEnabled () = colorEnabled
+
 /// Path-aware prompt string for ReadLine. Just visible chars; ANSI not added here
 /// because Console.WriteLine inside ReadLine doesn't go through Spectre.
 let prompt (_cwd: string) : string = "› "
 
 let userMessage (ui: UiConfig) (text: string) : IRenderable =
-    let escaped = Markup.Escape text
-    match ui.UserAlignment with
-    | Left ->
-        Markup(sprintf "[grey]›[/] %s" escaped) :> _
-    | Right ->
-        let bubble = Padder(Markup(escaped)).PadLeft(2).PadRight(2) :> IRenderable
-        Align(bubble, HorizontalAlignment.Right) :> _
+    if colorEnabled then
+        let escaped = Markup.Escape text
+        match ui.UserAlignment with
+        | Left ->
+            Markup(sprintf "[grey]›[/] %s" escaped) :> _
+        | Right ->
+            let bubble = Padder(Markup(escaped)).PadLeft(2).PadRight(2) :> IRenderable
+            Align(bubble, HorizontalAlignment.Right) :> _
+    else
+        Text(sprintf "> %s" text) :> _
 
 /// Plain assistant text during streaming (no markdown parse — buffer is partial).
 let assistantLive (text: string) : IRenderable =
@@ -29,50 +39,78 @@ let assistantLive (text: string) : IRenderable =
 
 /// Final assistant text rendered as markdown.
 let assistantFinal (text: string) : IRenderable =
-    MarkdownRender.toRenderable text
+    if colorEnabled then MarkdownRender.toRenderable text
+    else Text(text) :> _
 
 let cancelled (s: Strings) : IRenderable =
-    Markup(sprintf "[yellow]⚠ %s[/]" (Markup.Escape s.Cancelled)) :> _
+    if colorEnabled then
+        Markup(sprintf "[yellow]⚠ %s[/]" (Markup.Escape s.Cancelled)) :> _
+    else
+        Text(s.Cancelled) :> _
 
 let errorLine (s: Strings) (msg: string) : IRenderable =
-    Markup(sprintf "[red]⚠ %s:[/] %s" (Markup.Escape s.ErrorPrefix) (Markup.Escape msg)) :> _
+    if colorEnabled then
+        Markup(sprintf "[red]⚠ %s:[/] %s" (Markup.Escape s.ErrorPrefix) (Markup.Escape msg)) :> _
+    else
+        Text(sprintf "%s: %s" s.ErrorPrefix msg) :> _
 
 let private renderToolBody (output: string) : IRenderable =
-    if DiffRender.looksLikeDiff output then DiffRender.toRenderable output
-    elif output.Contains "```" || output.Contains "**" || output.StartsWith "#" then
-        MarkdownRender.toRenderable output
+    if colorEnabled then
+        if DiffRender.looksLikeDiff output then DiffRender.toRenderable output
+        elif output.Contains "```" || output.Contains "**" || output.StartsWith "#" then
+            MarkdownRender.toRenderable output
+        else
+            // dim plain text, indented
+            let lines = output.Split('\n')
+            let trimmed =
+                if lines.Length > 12 then
+                    Array.append (Array.truncate 12 lines)
+                        [| "+ " + string (lines.Length - 12) + " more lines" |]
+                else lines
+            let rows =
+                trimmed
+                |> Array.map (fun l ->
+                    Markup(sprintf "[dim]%s[/]" (Markup.Escape l)) :> IRenderable)
+            Padder(Rows(rows)).PadLeft(2) :> _
     else
-        // dim plain text, indented
         let lines = output.Split('\n')
         let trimmed =
             if lines.Length > 12 then
                 Array.append (Array.truncate 12 lines)
                     [| "+ " + string (lines.Length - 12) + " more lines" |]
             else lines
-        let rows =
-            trimmed
-            |> Array.map (fun l ->
-                Markup(sprintf "[dim]%s[/]" (Markup.Escape l)) :> IRenderable)
-        Padder(Rows(rows)).PadLeft(2) :> _
+        Padder(Rows(trimmed |> Array.map (fun l -> Text(l) :> IRenderable))).PadLeft(2) :> _
 
 let toolBullet (s: Strings) (state: ToolState) : IRenderable =
-    match state with
-    | Running(name, args) ->
-        let header =
-            sprintf "[yellow]●[/] [bold]%s[/]([dim]%s[/])"
-                (Markup.Escape name) (Markup.Escape args)
-        let body =
-            Padder(Markup(sprintf "[dim]%s[/]" (Markup.Escape s.ToolRunning))).PadLeft(2)
-        Rows([ Markup(header) :> IRenderable; body :> _ ]) :> _
-    | Completed(name, args, output) ->
-        let header =
-            sprintf "[green]●[/] [bold]%s[/]([dim]%s[/])"
-                (Markup.Escape name) (Markup.Escape args)
-        Rows([ Markup(header) :> IRenderable; renderToolBody output ]) :> _
-    | Failed(name, args, err) ->
-        let header =
-            sprintf "[red]●[/] [bold]%s[/]([dim]%s[/])"
-                (Markup.Escape name) (Markup.Escape args)
-        let body =
-            Padder(Markup(sprintf "[red]%s[/]" (Markup.Escape err))).PadLeft(2)
-        Rows([ Markup(header) :> IRenderable; body :> _ ]) :> _
+    if colorEnabled then
+        match state with
+        | Running(name, args) ->
+            let header =
+                sprintf "[yellow]●[/] [bold]%s[/]([dim]%s[/])"
+                    (Markup.Escape name) (Markup.Escape args)
+            let body =
+                Padder(Markup(sprintf "[dim]%s[/]" (Markup.Escape s.ToolRunning))).PadLeft(2)
+            Rows([ Markup(header) :> IRenderable; body :> _ ]) :> _
+        | Completed(name, args, output) ->
+            let header =
+                sprintf "[green]●[/] [bold]%s[/]([dim]%s[/])"
+                    (Markup.Escape name) (Markup.Escape args)
+            Rows([ Markup(header) :> IRenderable; renderToolBody output ]) :> _
+        | Failed(name, args, err) ->
+            let header =
+                sprintf "[red]●[/] [bold]%s[/]([dim]%s[/])"
+                    (Markup.Escape name) (Markup.Escape args)
+            let body =
+                Padder(Markup(sprintf "[red]%s[/]" (Markup.Escape err))).PadLeft(2)
+            Rows([ Markup(header) :> IRenderable; body :> _ ]) :> _
+    else
+        match state with
+        | Running(name, args) ->
+            Rows([ Text(sprintf "* %s(%s)" name args) :> IRenderable
+                   Padder(Text(s.ToolRunning)).PadLeft(2) :> _ ]) :> _
+        | Completed(name, args, output) ->
+            Rows([ Text(sprintf "* %s(%s)" name args) :> IRenderable
+                   renderToolBody output ]) :> _
+        | Failed(name, args, err) ->
+            Rows([ Text(sprintf "* %s(%s)" name args) :> IRenderable
+                   Padder(Text(sprintf "Error: %s" err)).PadLeft(2) :> _ ]) :> _

--- a/src/Fugue.Cli/StatusBar.fs
+++ b/src/Fugue.Cli/StatusBar.fs
@@ -57,7 +57,7 @@ let private providerLabel (cfg: AppConfig) : string =
     | Ollama(_, m)    -> "ollama:" + shortModel m
 
 let refresh () =
-    if not active then () else
+    if not active || not (Render.isColorEnabled ()) then () else
     let height = Console.WindowHeight
     let strings =
         match cfg with
@@ -80,7 +80,7 @@ let refresh () =
     writeRaw "\x1b[u"
 
 let start (initialCwd: string) (initialCfg: AppConfig) : unit =
-    if active then () else
+    if active || not (Render.isColorEnabled ()) then () else
     cwd <- initialCwd
     cfg <- Some initialCfg
     active <- true
@@ -93,7 +93,7 @@ let start (initialCwd: string) (initialCfg: AppConfig) : unit =
     refresh ()
 
 let stop () : unit =
-    if not active then () else
+    if not active || not (Render.isColorEnabled ()) then () else
     let height = Console.WindowHeight
     writeRaw "\x1b[r"          // reset scroll region
     writeRaw ("\x1b[" + string (height - 1) + ";1H")


### PR DESCRIPTION
Closes #666

Checks `NO_COLOR`, `FUGUE_NO_COLOR`, and `TERM=dumb` at startup. When any is set, `Render.initColor false` disables all Spectre Markup tags in tool bullets, user messages, errors, and prompts. StatusBar becomes a no-op (scroll region needs ANSI).

Follows the no-color.org spec: presence of `NO_COLOR` (any value) disables colour.

## Changes

- `Program.fs`: `noColor ()` helper checks the three env vars; calls `Render.initColor (not (noColor ()))` before entering the REPL
- `Render.fs`: `mutable private colorEnabled`, `initColor`, and `isColorEnabled ()` added; all render functions branch on `colorEnabled` — coloured path unchanged, plain-text path emits clean ASCII with no markup tags
- `StatusBar.fs`: `start`/`stop`/`refresh` guard on `Render.isColorEnabled ()` — when false, the scroll-region ANSI widget is skipped silently

## Verification

- `dotnet build`: 0 errors, 0 warnings
- `dotnet test`: 106/106 passed