### PR TITLE
feat(config): maxTokens field to cap completion tokens (#659)

### DIFF
--- a/src/Fugue.Agent/AgentFactory.fs
+++ b/src/Fugue.Agent/AgentFactory.fs
@@ -10,7 +10,8 @@ open global.Anthropic
 
 /// Build an AIAgent (with system prompt and tools wired in) for the given provider.
 /// `configBaseUrl` is from ~/.fugue/config.json; env vars win if both are set.
-let create (provider: ProviderConfig) (configBaseUrl: string option) (systemPrompt: string) (tools: AIFunction list) : AIAgent =
+/// `maxTokens` caps completion tokens per request (None = provider default).
+let create (provider: ProviderConfig) (configBaseUrl: string option) (maxTokens: int option) (systemPrompt: string) (tools: AIFunction list) : AIAgent =
     let toolList : System.Collections.Generic.IList<AITool> =
         ResizeArray<AITool>(tools |> List.map (fun t -> t :> AITool))
 
@@ -18,6 +19,12 @@ let create (provider: ProviderConfig) (configBaseUrl: string option) (systemProm
         match Environment.GetEnvironmentVariable envVar with
         | null | "" -> configBaseUrl
         | url       -> Some url
+
+    // Build ChatClientAgentOptions with optional MaxOutputTokens for providers that use IChatClient.AsAIAgent.
+    let makeAgentOpts () : ChatClientAgentOptions =
+        let chatOpts = ChatOptions(Instructions = systemPrompt, Tools = toolList)
+        maxTokens |> Option.iter (fun t -> chatOpts.MaxOutputTokens <- Nullable t)
+        ChatClientAgentOptions(Name = "Fugue", ChatOptions = chatOpts)
 
     match provider with
     | Anthropic(apiKey, model) ->
@@ -32,7 +39,8 @@ let create (provider: ProviderConfig) (configBaseUrl: string option) (systemProm
             instructions = systemPrompt,
             name = "Fugue",
             description = null,
-            tools = toolList)
+            tools = toolList,
+            defaultMaxTokens = (maxTokens |> Option.map Nullable |> Option.defaultValue (Nullable())))
 
     | OpenAI(apiKey, model) ->
         // OPENAI_BASE_URL (env) or config baseUrl allows pointing at OpenAI-compat servers.
@@ -41,17 +49,8 @@ let create (provider: ProviderConfig) (configBaseUrl: string option) (systemProm
             match resolvedBase "OPENAI_BASE_URL" with
             | None     -> new OpenAI.OpenAIClient(cred)
             | Some url -> new OpenAI.OpenAIClient(cred, OpenAI.OpenAIClientOptions(Endpoint = Uri url))
-        let chatClient = openAi.GetChatClient(model).AsIChatClient()
-        chatClient.AsAIAgent(
-            instructions = systemPrompt,
-            name = "Fugue",
-            description = null,
-            tools = toolList)
+        openAi.GetChatClient(model).AsIChatClient().AsAIAgent(makeAgentOpts ())
 
     | Ollama(endpoint, model) ->
         let ollama = new OllamaSharp.OllamaApiClient(endpoint, model)
-        (ollama :> IChatClient).AsAIAgent(
-            instructions = systemPrompt,
-            name = "Fugue",
-            description = null,
-            tools = toolList)
+        (ollama :> IChatClient).AsAIAgent(makeAgentOpts ())

--- a/src/Fugue.Cli/Program.fs
+++ b/src/Fugue.Cli/Program.fs
@@ -13,7 +13,7 @@ let private buildAgent (cfg: AppConfig) : AIAgent =
         match cfg.SystemPrompt with
         | Some s -> s
         | None -> Fugue.Core.SystemPrompt.render cwd Fugue.Tools.ToolRegistry.names
-    AgentFactory.create cfg.Provider cfg.BaseUrl sysPrompt tools
+    AgentFactory.create cfg.Provider cfg.BaseUrl cfg.MaxTokens sysPrompt tools
 
 [<RequiresUnreferencedCode("Calls Repl.run and Config.saveToFile which use STJ reflection; System.Text.Json is TrimmerRootAssembly")>]
 [<RequiresDynamicCode("Calls Repl.run and Config.saveToFile which use STJ reflection; System.Text.Json is TrimmerRootAssembly")>]
@@ -51,7 +51,7 @@ let main argv =
                     let m = if List.isEmpty models then "llama3.1" else List.head models
                     Ollama(ep, m)
                 | _ -> failwith "unsupported candidate"
-            let cfg = { Provider = provider; SystemPrompt = None; MaxIterations = 30; Ui = Fugue.Core.Config.defaultUi (); BaseUrl = None }
+            let cfg = { Provider = provider; SystemPrompt = None; MaxIterations = 30; MaxTokens = None; Ui = Fugue.Core.Config.defaultUi (); BaseUrl = None }
             Fugue.Core.Config.saveToFile cfg
             runWithCfg cfg
         | None ->

--- a/src/Fugue.Core/Config.fs
+++ b/src/Fugue.Core/Config.fs
@@ -38,6 +38,7 @@ type AppConfig =
     { Provider: ProviderConfig
       SystemPrompt: string option
       MaxIterations: int
+      MaxTokens: int option
       Ui: UiConfig
       BaseUrl: string option }
 
@@ -90,7 +91,7 @@ let private fromImplicitEnv () : ProviderConfig option =
 
 [<RequiresUnreferencedCode("Uses STJ reflection; AppConfigDto is preserved via TrimmerRootDescriptor")>]
 [<RequiresDynamicCode("Uses STJ reflection; System.Text.Json is TrimmerRootAssembly")>]
-let private fromFile (path: string) : Result<ProviderConfig * int * UiConfig * string option, string> =
+let private fromFile (path: string) : Result<ProviderConfig * int * int option * UiConfig * string option, string> =
     try
         let json = File.ReadAllText path
         let dtoOrNull =
@@ -124,7 +125,8 @@ let private fromFile (path: string) : Result<ProviderConfig * int * UiConfig * s
                     | _         -> defaultLocale ()
                 let ui = { UserAlignment = alignment; Locale = locale }
                 let baseUrl = dto.baseUrl |> Option.ofObj |> Option.filter (fun s -> not (String.IsNullOrEmpty s))
-                p, dto.maxIterations, ui, baseUrl)
+                let maxTokens = if dto.maxTokens > 0 then Some dto.maxTokens else None
+                p, dto.maxIterations, maxTokens, ui, baseUrl)
     with ex -> Error ex.Message
 
 let private helpText () =
@@ -147,19 +149,19 @@ Set environment variables:
 let load (_argv: string[]) : Result<AppConfig, ConfigError> =
     match fromExplicitEnv () with
     | Some provider ->
-        Ok { Provider = provider; SystemPrompt = None; MaxIterations = 30; Ui = defaultUi (); BaseUrl = None }
+        Ok { Provider = provider; SystemPrompt = None; MaxIterations = 30; MaxTokens = None; Ui = defaultUi (); BaseUrl = None }
     | None ->
         let path = configPath ()
         if File.Exists path then
             match fromFile path with
-            | Ok (p, mi, ui, baseUrl) ->
+            | Ok (p, mi, maxTokens, ui, baseUrl) ->
                 let mi = if mi <= 0 then 30 else mi
-                Ok { Provider = p; SystemPrompt = None; MaxIterations = mi; Ui = ui; BaseUrl = baseUrl }
+                Ok { Provider = p; SystemPrompt = None; MaxIterations = mi; MaxTokens = maxTokens; Ui = ui; BaseUrl = baseUrl }
             | Error e -> Error(InvalidConfig e)
         else
             match fromImplicitEnv () with
             | Some provider ->
-                Ok { Provider = provider; SystemPrompt = None; MaxIterations = 30; Ui = defaultUi (); BaseUrl = None }
+                Ok { Provider = provider; SystemPrompt = None; MaxIterations = 30; MaxTokens = None; Ui = defaultUi (); BaseUrl = None }
             | None ->
                 Error(NoConfigFound (helpText ()))
 
@@ -173,10 +175,11 @@ let saveToFile (cfg: AppConfig) : unit =
         { userAlignment = (match cfg.Ui.UserAlignment with Left -> "left" | Right -> "right")
           locale        = cfg.Ui.Locale }
     let baseUrlVal = cfg.BaseUrl |> Option.toObj
+    let maxTokensVal = cfg.MaxTokens |> Option.defaultValue 0
     let dto =
         match cfg.Provider with
-        | Anthropic(k, m) -> { provider = "anthropic"; model = m; apiKey = k; ollamaEndpoint = ""; baseUrl = baseUrlVal; maxIterations = cfg.MaxIterations; ui = uiDto }
-        | OpenAI(k, m)    -> { provider = "openai";    model = m; apiKey = k; ollamaEndpoint = ""; baseUrl = baseUrlVal; maxIterations = cfg.MaxIterations; ui = uiDto }
-        | Ollama(e, m)    -> { provider = "ollama";    model = m; apiKey = ""; ollamaEndpoint = string e; baseUrl = baseUrlVal; maxIterations = cfg.MaxIterations; ui = uiDto }
+        | Anthropic(k, m) -> { provider = "anthropic"; model = m; apiKey = k; ollamaEndpoint = ""; baseUrl = baseUrlVal; maxIterations = cfg.MaxIterations; maxTokens = maxTokensVal; ui = uiDto }
+        | OpenAI(k, m)    -> { provider = "openai";    model = m; apiKey = k; ollamaEndpoint = ""; baseUrl = baseUrlVal; maxIterations = cfg.MaxIterations; maxTokens = maxTokensVal; ui = uiDto }
+        | Ollama(e, m)    -> { provider = "ollama";    model = m; apiKey = ""; ollamaEndpoint = string e; baseUrl = baseUrlVal; maxIterations = cfg.MaxIterations; maxTokens = maxTokensVal; ui = uiDto }
     let json = JsonSerializer.Serialize<AppConfigDto>(dto, appConfigOptions)
     File.WriteAllText(path, json)

--- a/src/Fugue.Core/JsonContext.fs
+++ b/src/Fugue.Core/JsonContext.fs
@@ -20,6 +20,7 @@ type AppConfigDto =
       ollamaEndpoint: string
       baseUrl: string | null
       maxIterations: int
+      maxTokens: int
       ui: UiConfigDto | null }
 
 /// Shared JsonSerializerOptions for AppConfigDto serialization.


### PR DESCRIPTION
Closes #659

Adds `maxTokens: int` to `~/.fugue/config.json` (0 = use provider default). When set, forwards to `ChatOptions.MaxOutputTokens` in AgentFactory. Useful for cost control with verbose models and for capping Ollama responses.

## Changes

- `JsonContext.fs`: added `maxTokens: int` field to `AppConfigDto`
- `Config.fs`: added `MaxTokens: int option` to `AppConfig`; deserialized from DTO (`0` → `None`, `> 0` → `Some n`); propagated through `fromFile`, `load`, and `saveToFile`
- `AgentFactory.fs`: `create` now takes `maxTokens: int option`; Anthropic passes it as `defaultMaxTokens`; OpenAI/Ollama build `ChatClientAgentOptions` with `ChatOptions.MaxOutputTokens` set
- `Program.fs`: threads `cfg.MaxTokens` through to `AgentFactory.create`

Example config:
```json
{ "maxTokens": 2048 }
```