### PR TITLE
feat(ux): soft-wrap long tool output lines with ↩ continuation marker (#660)

### DIFF
--- a/src/Fugue.Cli/Render.fs
+++ b/src/Fugue.Cli/Render.fs
@@ -40,7 +40,7 @@ let errorLine (s: Strings) (msg: string) : IRenderable =
 
 let private termWidth () =
     let w = Console.WindowWidth
-    if w > 0 then w else 120
+    if w >= 20 then w else 120
 
 /// Soft-wrap a single line to `width` columns, appending "↩" at each break.
 let private softWrap (width: int) (line: string) : string list =

--- a/src/Fugue.Cli/Render.fs
+++ b/src/Fugue.Cli/Render.fs
@@ -1,5 +1,6 @@
 module Fugue.Cli.Render
 
+open System
 open Spectre.Console
 open Spectre.Console.Rendering
 open Fugue.Core.Config
@@ -37,6 +38,24 @@ let cancelled (s: Strings) : IRenderable =
 let errorLine (s: Strings) (msg: string) : IRenderable =
     Markup(sprintf "[red]⚠ %s:[/] %s" (Markup.Escape s.ErrorPrefix) (Markup.Escape msg)) :> _
 
+let private termWidth () =
+    let w = Console.WindowWidth
+    if w > 0 then w else 120
+
+/// Soft-wrap a single line to `width` columns, appending "↩" at each break.
+let private softWrap (width: int) (line: string) : string list =
+    if line.Length <= width then [ line ]
+    else
+        let usable = width - 1  // reserve 1 col for ↩
+        let mutable result = []
+        let mutable i = 0
+        while i < line.Length do
+            let chunkEnd = min line.Length (i + usable)
+            let chunk = line.[i .. chunkEnd - 1]
+            result <- result @ [ if chunkEnd < line.Length then chunk + "↩" else chunk ]
+            i <- chunkEnd
+        result
+
 let private renderToolBody (output: string) : IRenderable =
     if DiffRender.looksLikeDiff output then DiffRender.toRenderable output
     elif output.Contains "```" || output.Contains "**" || output.StartsWith "#" then
@@ -49,8 +68,10 @@ let private renderToolBody (output: string) : IRenderable =
                 Array.append (Array.truncate 12 lines)
                     [| "+ " + string (lines.Length - 12) + " more lines" |]
             else lines
+        let w = termWidth ()
         let rows =
             trimmed
+            |> Array.collect (fun l -> softWrap w l |> List.toArray)
             |> Array.map (fun l ->
                 Markup(sprintf "[dim]%s[/]" (Markup.Escape l)) :> IRenderable)
         Padder(Rows(rows)).PadLeft(2) :> _


### PR DESCRIPTION
Closes #660

Long tool output lines (Gradle logs, JSON, Java stack traces) are now soft-wrapped at terminal width with a `↩` marker at each break point. Falls back to 120 columns when terminal width is unavailable (piped output). Pure rendering change in Render.fs — no Repl.fs or localization impact.

## Changes

- `termWidth ()` — reads `Console.WindowWidth`, falls back to 120 for piped/headless output
- `softWrap width line` — splits a single string into chunks of `width - 1` chars, appending `↩` at every continuation break; the final segment is left as-is
- `renderToolBody` — applies `softWrap (termWidth())` via `Array.collect` before building the dim `Markup` rows; diff and markdown paths are unchanged

## Verification

- `dotnet build` — 0 errors, 0 warnings
- `dotnet test` — 106/106 passed