### PR TITLE
feat(ux): show elapsed time per tool call in result header (#664)

### DIFF
--- a/src/Fugue.Cli/Render.fs
+++ b/src/Fugue.Cli/Render.fs
@@ -1,5 +1,6 @@
 module Fugue.Cli.Render
 
+open System
 open Spectre.Console
 open Spectre.Console.Rendering
 open Fugue.Core.Config
@@ -7,8 +8,8 @@ open Fugue.Core.Localization
 
 type ToolState =
     | Running   of name: string * args: string
-    | Completed of name: string * args: string * output: string
-    | Failed    of name: string * args: string * err: string
+    | Completed of name: string * args: string * output: string * elapsed: TimeSpan
+    | Failed    of name: string * args: string * err: string   * elapsed: TimeSpan
 
 let mutable private colorEnabled = true
 
@@ -54,6 +55,12 @@ let errorLine (s: Strings) (msg: string) : IRenderable =
     else
         Text(sprintf "%s: %s" s.ErrorPrefix msg) :> _
 
+let private formatElapsed (e: TimeSpan) =
+    if e.TotalMilliseconds >= 1000.0 then
+        sprintf "%.1fs" e.TotalSeconds
+    else
+        sprintf "%dms" (int e.TotalMilliseconds)
+
 let private renderToolBody (output: string) : IRenderable =
     if colorEnabled then
         if DiffRender.looksLikeDiff output then DiffRender.toRenderable output
@@ -91,15 +98,15 @@ let toolBullet (s: Strings) (state: ToolState) : IRenderable =
             let body =
                 Padder(Markup(sprintf "[dim]%s[/]" (Markup.Escape s.ToolRunning))).PadLeft(2)
             Rows([ Markup(header) :> IRenderable; body :> _ ]) :> _
-        | Completed(name, args, output) ->
+        | Completed(name, args, output, elapsed) ->
             let header =
-                sprintf "[green]●[/] [bold]%s[/]([dim]%s[/])"
-                    (Markup.Escape name) (Markup.Escape args)
+                sprintf "[green]●[/] [bold]%s[/]([dim]%s[/]) [dim]%s[/]"
+                    (Markup.Escape name) (Markup.Escape args) (formatElapsed elapsed)
             Rows([ Markup(header) :> IRenderable; renderToolBody output ]) :> _
-        | Failed(name, args, err) ->
+        | Failed(name, args, err, elapsed) ->
             let header =
-                sprintf "[red]●[/] [bold]%s[/]([dim]%s[/])"
-                    (Markup.Escape name) (Markup.Escape args)
+                sprintf "[red]●[/] [bold]%s[/]([dim]%s[/]) [dim]%s[/]"
+                    (Markup.Escape name) (Markup.Escape args) (formatElapsed elapsed)
             let body =
                 Padder(Markup(sprintf "[red]%s[/]" (Markup.Escape err))).PadLeft(2)
             Rows([ Markup(header) :> IRenderable; body :> _ ]) :> _
@@ -108,9 +115,9 @@ let toolBullet (s: Strings) (state: ToolState) : IRenderable =
         | Running(name, args) ->
             Rows([ Text(sprintf "* %s(%s)" name args) :> IRenderable
                    Padder(Text(s.ToolRunning)).PadLeft(2) :> _ ]) :> _
-        | Completed(name, args, output) ->
-            Rows([ Text(sprintf "* %s(%s)" name args) :> IRenderable
+        | Completed(name, args, output, elapsed) ->
+            Rows([ Text(sprintf "* %s(%s) %s" name args (formatElapsed elapsed)) :> IRenderable
                    renderToolBody output ]) :> _
-        | Failed(name, args, err) ->
-            Rows([ Text(sprintf "* %s(%s)" name args) :> IRenderable
+        | Failed(name, args, err, elapsed) ->
+            Rows([ Text(sprintf "* %s(%s) %s" name args (formatElapsed elapsed)) :> IRenderable
                    Padder(Text(sprintf "Error: %s" err)).PadLeft(2) :> _ ]) :> _

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -2,6 +2,7 @@ module Fugue.Cli.Repl
 
 open System
 open System.Collections.Generic
+open System.Diagnostics
 open System.Diagnostics.CodeAnalysis
 open System.Text
 open System.Threading
@@ -71,16 +72,15 @@ let private streamAndRender
                     Console.Out.Flush()
                     assistantStreaming <- true
                 | Conversation.ToolStarted(id, name, args) ->
-                    toolMeta.[id] <- (name, args, System.Diagnostics.Stopwatch.GetTimestamp())
+                    toolMeta.[id] <- (name, args, Stopwatch.GetTimestamp())
                     if assistantStreaming then
                         Console.Out.WriteLine ()
                         assistantStreaming <- false
                 | Conversation.ToolCompleted(id, output, isErr) ->
-                    let name, args, startTick =
+                    let name, args, elapsed =
                         match toolMeta.TryGetValue id with
-                        | true, v -> v
-                        | false, _ -> "?", "?", System.Diagnostics.Stopwatch.GetTimestamp()
-                    let elapsed = System.Diagnostics.Stopwatch.GetElapsedTime(startTick)
+                        | true, (n, a, tick) -> n, a, Stopwatch.GetElapsedTime(tick)
+                        | false, _ -> "?", "?", TimeSpan.Zero
                     let state =
                         if isErr then Render.Failed(name, args, output, elapsed)
                         else Render.Completed(name, args, output, elapsed)

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -55,7 +55,7 @@ let private streamAndRender
         (cfg: AppConfig) (cancelSrc: CancelSource) : Task<unit> = task {
     use streamCts = cancelSrc.NewStreamCts()
     let strings = pick cfg.Ui.Locale
-    let toolMeta = Dictionary<string, string * string>()
+    let toolMeta = Dictionary<string, string * string * int64>()
     let mutable assistantStreaming = false   // are we mid-line in the plain-text stream
 
     try
@@ -71,18 +71,19 @@ let private streamAndRender
                     Console.Out.Flush()
                     assistantStreaming <- true
                 | Conversation.ToolStarted(id, name, args) ->
-                    toolMeta.[id] <- (name, args)
+                    toolMeta.[id] <- (name, args, System.Diagnostics.Stopwatch.GetTimestamp())
                     if assistantStreaming then
                         Console.Out.WriteLine ()
                         assistantStreaming <- false
                 | Conversation.ToolCompleted(id, output, isErr) ->
-                    let name, args =
+                    let name, args, startTick =
                         match toolMeta.TryGetValue id with
                         | true, v -> v
-                        | false, _ -> "?", "?"
+                        | false, _ -> "?", "?", System.Diagnostics.Stopwatch.GetTimestamp()
+                    let elapsed = System.Diagnostics.Stopwatch.GetElapsedTime(startTick)
                     let state =
-                        if isErr then Render.Failed(name, args, output)
-                        else Render.Completed(name, args, output)
+                        if isErr then Render.Failed(name, args, output, elapsed)
+                        else Render.Completed(name, args, output, elapsed)
                     AnsiConsole.Write(Render.toolBullet strings state)
                     AnsiConsole.WriteLine ()
                 | Conversation.Finished -> ()

--- a/tests/Fugue.Tests/RenderTests.fs
+++ b/tests/Fugue.Tests/RenderTests.fs
@@ -58,3 +58,20 @@ let ``toolBullet completed plain output renders without diff`` () =
     let out = toolBullet s state |> toStr
     out |> should haveSubstring "Read"
     out |> should haveSubstring "alpha"
+    out |> should haveSubstring "12ms"
+
+[<Fact>]
+let ``toolBullet completed shows seconds for long tools`` () =
+    let strings = pick "en"
+    let state = Completed("Bash", "ls", "file.txt", TimeSpan.FromSeconds 2.3)
+    let out = toolBullet strings state |> toStr
+    out |> should haveSubstring "Bash"
+    out |> should haveSubstring "2.3s"
+
+[<Fact>]
+let ``toolBullet failed shows elapsed`` () =
+    let strings = pick "en"
+    let state = Failed("Bash", "rm -rf", "Permission denied", TimeSpan.FromMilliseconds 5.0)
+    let out = toolBullet strings state |> toStr
+    out |> should haveSubstring "Bash"
+    out |> should haveSubstring "5ms"

--- a/tests/Fugue.Tests/RenderTests.fs
+++ b/tests/Fugue.Tests/RenderTests.fs
@@ -1,5 +1,6 @@
 module Fugue.Tests.RenderTests
 
+open System
 open Spectre.Console.Testing
 open Xunit
 open FsUnit.Xunit
@@ -53,7 +54,7 @@ let ``toolBullet running shows yellow circle and tool name`` () =
 [<Fact>]
 let ``toolBullet completed plain output renders without diff`` () =
     let s = pick "en"
-    let state = Completed("Read", "{}", "alpha\nbeta")
+    let state = Completed("Read", "{}", "alpha\nbeta", TimeSpan.FromMilliseconds 12.0)
     let out = toolBullet s state |> toStr
     out |> should haveSubstring "Read"
     out |> should haveSubstring "alpha"


### PR DESCRIPTION
Closes #664

Records `Stopwatch.GetTimestamp()` on ToolStarted; computes `GetElapsedTime` on ToolCompleted. Renders as dim suffix: `12ms` for sub-second, `2.3s` for longer. Makes slow Bash/Gradle build steps immediately visible without external profiling.

AOT-safe: `System.Diagnostics.Stopwatch` is fully AOT-compatible.