### PR TITLE
feat(safety): normalize CRLF/Unicode whitespace, warn on zero-width chars (#648)

### DIFF
--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -6,6 +6,26 @@ open System.Threading
 open System.Threading.Tasks
 open Fugue.Core.Localization
 
+module private InputSanitize =
+
+    let private zeroWidthCodePoints =
+        [| 0x200B; 0x200C; 0x200D; 0xFEFF; 0x2060; 0x00AD |]
+
+    /// True if the string contains any zero-width character.
+    let hasZeroWidth (s: string) =
+        zeroWidthCodePoints |> Array.exists (fun cp -> s.IndexOf(char cp) >= 0)
+
+    /// Normalize a pasted/submitted string:
+    /// CRLF → LF, standalone CR → LF, Unicode paragraph/line separators → LF.
+    let normalize (s: string) : string =
+        s.Replace("\r\n", "\n")
+         .Replace("\r", "\n")
+         .Replace(" ", "\n")   // LINE SEPARATOR
+         .Replace(" ", "\n")   // PARAGRAPH SEPARATOR
+
+/// True if the string contains any zero-width character (U+200B/C/D, U+FEFF, U+2060, U+00AD).
+let hasZeroWidth (s: string) = InputSanitize.hasZeroWidth s
+
 // Hardcoded — small list, easier than passing through state.
 let slashCommands : string list = [ "/help"; "/clear"; "/exit" ]
 
@@ -313,12 +333,13 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
             | Wipe     -> redraw st
             | Submit s ->
                 eraseRendered ()
-                if not (String.IsNullOrWhiteSpace s) then
-                    if historyStore.Count = 0 || historyStore.[historyStore.Count - 1] <> s then
-                        historyStore.Add s
+                let normalized = InputSanitize.normalize s
+                if not (String.IsNullOrWhiteSpace normalized) then
+                    if historyStore.Count = 0 || historyStore.[historyStore.Count - 1] <> normalized then
+                        historyStore.Add normalized
                 st.HistoryIdx <- -1
                 st.SavedBuffer <- None
-                result <- ValueSome (Some s)
+                result <- ValueSome (Some normalized)
             | Quit ->
                 eraseRendered ()
                 writeRaw "\n"

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -193,6 +193,9 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                         do! streamAndRender agent session prompt cfg cancelSrc
                 StatusBar.refresh ()
             | Some userInput ->
+                if ReadLine.hasZeroWidth userInput then
+                    AnsiConsole.Write(Markup("[dim yellow]" + Markup.Escape strings.ZeroWidthWarning + "[/]"))
+                    AnsiConsole.WriteLine()
                 AnsiConsole.Write(Render.userMessage cfg.Ui userInput)
                 AnsiConsole.WriteLine()
                 do! streamAndRender agent session userInput cfg cancelSrc

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -39,7 +39,10 @@ type Strings =
       // /review pr
       ReviewPrUsage:     string
       ReviewPrNotFound:  string
-      ReviewPrPrompt:    string }
+      ReviewPrPrompt:    string
+
+      // Input safety
+      ZeroWidthWarning: string }
 
 let en : Strings =
     { Cancelled            = "cancelled"
@@ -66,7 +69,8 @@ let en : Strings =
       AskingModelRecommendation = "Asking for model recommendation…"
       ReviewPrUsage         = "Usage: /review pr <N>"
       ReviewPrNotFound      = "PR not found or gh CLI unavailable"
-      ReviewPrPrompt        = "Please review GitHub PR #{0}.\n\nPR metadata:\n{1}\n\nDiff:\n```\n{2}\n```\n\nProvide a thorough code review: identify bugs, style issues, missing tests, security concerns, and any improvements. Be specific with line references where possible." }
+      ReviewPrPrompt        = "Please review GitHub PR #{0}.\n\nPR metadata:\n{1}\n\nDiff:\n```\n{2}\n```\n\nProvide a thorough code review: identify bugs, style issues, missing tests, security concerns, and any improvements. Be specific with line references where possible."
+      ZeroWidthWarning      = "Warning: input contains invisible zero-width characters — these may cause Edit tool diff mismatches" }
 
 let ru : Strings =
     { Cancelled            = "отменено"
@@ -93,7 +97,8 @@ let ru : Strings =
       AskingModelRecommendation = "Запрашиваю рекомендацию по модели…"
       ReviewPrUsage         = "Использование: /review pr <N>"
       ReviewPrNotFound      = "PR не найден или gh CLI недоступен"
-      ReviewPrPrompt        = "Пожалуйста, проверь GitHub PR #{0}.\n\nМетаданные PR:\n{1}\n\nDiff:\n```\n{2}\n```\n\nПроведи подробное ревью кода: выяви баги, проблемы со стилем, отсутствующие тесты, уязвимости безопасности и возможные улучшения. Указывай конкретные строки там, где это возможно." }
+      ReviewPrPrompt        = "Пожалуйста, проверь GitHub PR #{0}.\n\nМетаданные PR:\n{1}\n\nDiff:\n```\n{2}\n```\n\nПроведи подробное ревью кода: выяви баги, проблемы со стилем, отсутствующие тесты, уязвимости безопасности и возможные улучшения. Указывай конкретные строки там, где это возможно."
+      ZeroWidthWarning      = "Предупреждение: ввод содержит невидимые символы нулевой ширины — они могут нарушить работу инструмента Edit" }
 
 /// Pick a Strings value by ISO-2 locale code. Unknown locales fall back to en.
 let pick (locale: string) : Strings =


### PR DESCRIPTION
Closes #648

Normalizes pasted input at submit time: CRLF→LF, CR→LF, Unicode line/paragraph separators→LF. Warns (dim yellow) when input contains invisible zero-width characters (U+200B, U+200C, U+200D, U+FEFF, U+2060, U+00AD) that can silently break Edit tool diff matching.

AOT-safe: String.Replace chains + IndexOf, no Regex. Both en/ru localized.