### PR TITLE
feat(ux): number conversation turns [N] next to user messages (#661)

### DIFF
--- a/src/Fugue.Cli/Render.fs
+++ b/src/Fugue.Cli/Render.fs
@@ -21,17 +21,19 @@ let isColorEnabled () = colorEnabled
 /// because Console.WriteLine inside ReadLine doesn't go through Spectre.
 let prompt (_cwd: string) : string = "› "
 
-let userMessage (ui: UiConfig) (text: string) : IRenderable =
+let userMessage (ui: UiConfig) (text: string) (turn: int) : IRenderable =
     if colorEnabled then
         let escaped = Markup.Escape text
+        let prefix = sprintf "[dim][[%d]][/] " turn
         match ui.UserAlignment with
         | Left ->
-            Markup(sprintf "[grey]›[/] %s" escaped) :> _
+            Markup(sprintf "[grey]›[/] %s%s" prefix escaped) :> _
         | Right ->
-            let bubble = Padder(Markup(escaped)).PadLeft(2).PadRight(2) :> IRenderable
+            let bubble = Padder(Markup(sprintf "%s%s" prefix escaped)).PadLeft(2).PadRight(2) :> IRenderable
             Align(bubble, HorizontalAlignment.Right) :> _
     else
-        Text(sprintf "> %s" text) :> _
+        let prefix = sprintf "[%d] " turn
+        Text(sprintf "> %s%s" prefix text) :> _
 
 /// Plain assistant text during streaming (no markdown parse — buffer is partial).
 let assistantLive (text: string) : IRenderable =

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -110,6 +110,7 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
     StatusBar.start cwd cfg
 
     let strings = pick cfg.Ui.Locale
+    let mutable turnNumber = 0
     try
         while not cancelSrc.QuitRequested do
             let! lineOpt = ReadLine.readAsync (Render.prompt cwd) strings cancelSrc.Token
@@ -132,8 +133,12 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
             | Some s when s = "/clear" ->
                 AnsiConsole.Clear()
                 StatusBar.refresh ()
+            | Some s when s = "/new" ->
+                turnNumber <- 0
+                StatusBar.refresh ()
             | Some userInput ->
-                AnsiConsole.Write(Render.userMessage cfg.Ui userInput)
+                turnNumber <- turnNumber + 1
+                AnsiConsole.Write(Render.userMessage cfg.Ui userInput turnNumber)
                 AnsiConsole.WriteLine()
                 do! streamAndRender agent session userInput cfg cancelSrc
                 StatusBar.refresh ()

--- a/tests/Fugue.Tests/RenderTests.fs
+++ b/tests/Fugue.Tests/RenderTests.fs
@@ -19,14 +19,14 @@ let private toStr (r: Spectre.Console.Rendering.IRenderable) : string =
 
 [<Fact>]
 let ``userMessage Left contains '> ' prefix`` () =
-    let out = userMessage uiLeft "hello" |> toStr
+    let out = userMessage uiLeft "hello" 1 |> toStr
     out |> should haveSubstring "›"
     out |> should haveSubstring "hello"
 
 [<Fact>]
 let ``userMessage Right does not have left-edge prefix`` () =
     // Right-aligned: text is right-justified within terminal width, no '>' prefix
-    let out = userMessage uiRight "hello" |> toStr
+    let out = userMessage uiRight "hello" 1 |> toStr
     out |> should haveSubstring "hello"
 
 [<Fact>]


### PR DESCRIPTION
Closes #661

Adds a mutable `turnNumber` counter to the REPL loop. Each submitted user message increments the counter and renders a dim `[N]` prefix (using Spectre markup `[[N]]`). Counter resets to 0 on `/new` (session reset). Lets users reference earlier turns by number in follow-ups.

## Changes

- `Render.fs`: `userMessage` signature gains `turn: int`; color path renders `[dim][[N]][/]` prefix; no-color path renders `[N] ` plain prefix
- `Repl.fs`: `let mutable turnNumber = 0` in `run`; incremented before each `userMessage` render; reset in `/new` handler
- `RenderTests.fs`: updated two `userMessage` call sites to pass `turn = 1`

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 106/106 pass
- [ ] Manual: launch fugue, type a few messages, confirm `[1]`, `[2]`, `[3]` appear dim before each prompt; type `/new`, confirm counter restarts at `[1]`

No localization needed (numbers are universal). No new dependencies.