### PR TITLE
feat(ux): structured tool error formatting, suppress stack traces (#650)

### DIFF
--- a/src/Fugue.Cli/Render.fs
+++ b/src/Fugue.Cli/Render.fs
@@ -90,6 +90,22 @@ let private renderToolBody (output: string) : IRenderable =
             else lines
         Padder(Rows(trimmed |> Array.map (fun l -> Text(l) :> IRenderable))).PadLeft(2) :> _
 
+/// Extract the first readable line from a raw error string, suppressing .NET stack frames.
+let private summarizeToolError (raw: string) : string =
+    let lines = raw.Split('\n')
+    let headline =
+        lines
+        |> Array.tryFind (fun l ->
+            let t = l.TrimStart()
+            t.Length > 0
+            && not (t.StartsWith("at "))
+            && not (t.StartsWith("--- End of"))
+            && not (t.StartsWith("System."))
+            && not (t.StartsWith("Microsoft.")))
+        |> Option.defaultWith (fun () ->
+            lines |> Array.tryFind (fun l -> l.TrimStart().Length > 0) |> Option.defaultValue raw)
+    if headline.Length > 120 then headline.[..116] + " …" else headline
+
 let toolBullet (s: Strings) (state: ToolState) : IRenderable =
     if colorEnabled then
         match state with
@@ -110,7 +126,7 @@ let toolBullet (s: Strings) (state: ToolState) : IRenderable =
                 sprintf "[red]●[/] [bold]%s[/]([dim]%s[/]) [dim]%s[/]"
                     (Markup.Escape name) (Markup.Escape args) (formatElapsed elapsed)
             let body =
-                Padder(Markup(sprintf "[red]%s[/]" (Markup.Escape err))).PadLeft(2)
+                Padder(Markup(sprintf "[red]%s[/]" (Markup.Escape (summarizeToolError err)))).PadLeft(2)
             Rows([ Markup(header) :> IRenderable; body :> _ ]) :> _
     else
         match state with
@@ -122,4 +138,4 @@ let toolBullet (s: Strings) (state: ToolState) : IRenderable =
                    renderToolBody output ]) :> _
         | Failed(name, args, err, elapsed) ->
             Rows([ Text(sprintf "* %s(%s) %s" name args (formatElapsed elapsed)) :> IRenderable
-                   Padder(Text(sprintf "Error: %s" err)).PadLeft(2) :> _ ]) :> _
+                   Padder(Text(sprintf "Error: %s" (summarizeToolError err))).PadLeft(2) :> _ ]) :> _

--- a/tests/Fugue.Tests/RenderTests.fs
+++ b/tests/Fugue.Tests/RenderTests.fs
@@ -75,3 +75,12 @@ let ``toolBullet failed shows elapsed`` () =
     let out = toolBullet strings state |> toStr
     out |> should haveSubstring "Bash"
     out |> should haveSubstring "5ms"
+
+[<Fact>]
+let ``toolBullet failed suppresses stack trace`` () =
+    let s = pick "en"
+    let raw = "File not found: foo.txt\n   at System.IO.File.ReadAllText(String path)\n   at Fugue.Tools.ReadTool.run()"
+    let state = Failed("Read", "foo.txt", raw, System.TimeSpan.FromMilliseconds 1.0)
+    let out = toolBullet s state |> toStr
+    out |> should haveSubstring "File not found"
+    out |> should not' (haveSubstring "at System.IO")


### PR DESCRIPTION
Closes #650

Adds `summarizeToolError` to Render.fs: extracts the first readable headline from a raw error string, filtering out .NET stack frames (`at ...`), inner exception delimiters, and namespace headers. Truncates to 120 chars. Test confirms stack traces are suppressed. AOT-safe (String.Split + Array.tryFind, no Regex).

Also extends `ToolState.Failed` with an `elapsed: TimeSpan` field (wire-value set to `TimeSpan.Zero` in Repl.fs for now; ready for elapsed-time display in a follow-up).