### PR TITLE
feat(ux): dim placeholder text in empty input prompt (#663)

### DIFF
--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -27,6 +27,8 @@ type S = {
     PromptText:              string
     PromptVisLen:            int
     HintWhenArmed:           string
+    Placeholder:             string
+    ColorEnabled:            bool
     Width:                   int
     SlashHelp:               (string * string) list  // (name, dim description) pairs
 }
@@ -229,6 +231,11 @@ let private redraw (st: S) =
     writeRaw st.PromptText
     let bufStr = String(st.Buffer.ToArray())
     writeRaw bufStr
+    // 2b. if buffer is empty and color is on, write dim placeholder then move cursor back
+    if st.Buffer.Count = 0 && st.Placeholder <> "" && st.ColorEnabled then
+        writeRaw ("\x1b[2m" + st.Placeholder + "\x1b[0m")
+        // move cursor back to right after the prompt (col = PromptVisLen)
+        writeRaw ("\r\x1b[" + string st.PromptVisLen + "C")
     // 3. count rendered terminal lines (= 1 + number of '\n' in buffer)
     let newlines = bufStr |> Seq.filter (fun c -> c = '\n') |> Seq.length
     st.LinesRendered <- 1 + newlines
@@ -264,7 +271,7 @@ let private redraw (st: S) =
     else writeRaw "\r"
     st.RowsBelowCursor <- upBy   // save for next redraw's erase pass
 
-let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task<string option> = task {
+let readAsync (prompt: string) (strings: Strings) (colorEnabled: bool) (ct: CancellationToken) : Task<string option> = task {
     // Strip ANSI escapes for visible-length calc (rough — assumes only \x1b[...m sequences).
     let visLen =
         let mutable n = 0
@@ -292,6 +299,8 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
           PromptText      = prompt
           PromptVisLen    = visLen
           HintWhenArmed   = strings.ExitHint
+          Placeholder     = strings.InputPlaceholder
+          ColorEnabled    = colorEnabled
           Width           = max 40 Console.WindowWidth
           SlashHelp       = slashHelp }
 

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -114,7 +114,7 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
     let mutable turnNumber = 0
     try
         while not cancelSrc.QuitRequested do
-            let! lineOpt = ReadLine.readAsync (Render.prompt cwd) strings cancelSrc.Token
+            let! lineOpt = ReadLine.readAsync (Render.prompt cwd) strings (Render.isColorEnabled ()) cancelSrc.Token
             match lineOpt with
             | None ->
                 cancelSrc.RequestQuit()

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -28,7 +28,10 @@ type Strings =
       CmdHelpDesc:  string
       CmdClearDesc: string
       CmdExitDesc:  string
-      HelpHeader:   string }
+      HelpHeader:   string
+
+      // Input prompt
+      InputPlaceholder: string }
 
 let en : Strings =
     { Cancelled            = "cancelled"
@@ -48,7 +51,8 @@ let en : Strings =
       CmdHelpDesc           = "show this help"
       CmdClearDesc          = "clear the screen"
       CmdExitDesc           = "exit Fugue"
-      HelpHeader            = "Available slash commands:" }
+      HelpHeader            = "Available slash commands:"
+      InputPlaceholder      = "Type a message or /help" }
 
 let ru : Strings =
     { Cancelled            = "отменено"
@@ -68,7 +72,8 @@ let ru : Strings =
       CmdHelpDesc           = "показать эту справку"
       CmdClearDesc          = "очистить экран"
       CmdExitDesc           = "выйти из Fugue"
-      HelpHeader            = "Доступные команды:" }
+      HelpHeader            = "Доступные команды:"
+      InputPlaceholder      = "Введите сообщение или /help" }
 
 /// Pick a Strings value by ISO-2 locale code. Unknown locales fall back to en.
 let pick (locale: string) : Strings =

--- a/tests/Fugue.Tests/ReadLineTests.fs
+++ b/tests/Fugue.Tests/ReadLineTests.fs
@@ -17,6 +17,8 @@ let private mkState (text: string) (cursor: int) : S =
       PromptText      = "> "
       PromptVisLen    = 2
       HintWhenArmed   = "Press Ctrl+C again to exit"
+      Placeholder     = ""
+      ColorEnabled    = false
       Width           = 80
       SlashHelp       = [] }
 


### PR DESCRIPTION
Closes #663

Shows `Type a message or /help` (en) / `Введите сообщение или /help` (ru) as dim ANSI text in the empty prompt. Disappears immediately on first keystroke (non-empty buffer suppresses it). Skipped in no-color mode. No new deps.

## Changes

- `Localization.fs`: adds `InputPlaceholder` field to `Strings` record, populated in both `en` and `ru`
- `ReadLine.fs`: adds `Placeholder: string` and `ColorEnabled: bool` fields to state `S`; `redraw` emits dim placeholder + cursor-back-to-prompt when buffer is empty and color is on
- `Repl.fs`: passes `Render.isColorEnabled ()` to updated `readAsync` signature
- `ReadLineTests.fs`: updates `mkState` helper with new fields (`Placeholder = ""`, `ColorEnabled = false`)

## Verification

- `dotnet build`: 0 errors, 0 warnings
- `dotnet test`: 105/106 pass (1 pre-existing env failure in ConfigTests unrelated to this change — `~/.fugue/config.json` present on machine)