### PR TITLE
fix(cli): undo/redo (Ctrl+Z/Y) with pushBounded 100-entry cap (#553)

### DIFF
--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -37,6 +37,21 @@ let historyStore = ResizeArray<string>()
 /// For test isolation only.
 let clearHistory () = historyStore.Clear()
 
+/// Undo/redo stacks — module-level, REPL is single-threaded.
+/// Not private so tests can inspect and seed them directly.
+let undoStack = ResizeArray<ResizeArray<char> * int>()
+let redoStack = ResizeArray<ResizeArray<char> * int>()
+
+/// For test isolation only.
+let clearUndoRedo () =
+    undoStack.Clear()
+    redoStack.Clear()
+
+/// Push item onto stack, evicting the oldest entry when the cap is exceeded.
+let private pushBounded (stack: ResizeArray<_>) item =
+    stack.Add item
+    if stack.Count > 100 then stack.RemoveAt 0
+
 /// Internal mutable line state. Public only because tests construct it directly.
 type S = {
     mutable Buffer:          ResizeArray<char>
@@ -210,9 +225,36 @@ let applyKey (k: ConsoleKeyInfo) (s: S) : Action =
         while i < s.Buffer.Count && s.Buffer.[i] <> '\n' do i <- i + 1
         s.Cursor <- i
         Continue
+    elif isCtrl k ConsoleKey.Z then
+        exitHistoryMode ()
+        s.ExitArmed <- false
+        if undoStack.Count > 0 then
+            let snapshot = ResizeArray<char>(s.Buffer)
+            pushBounded redoStack (snapshot, s.Cursor)
+            let (prevBuf, prevCursor) = undoStack.[undoStack.Count - 1]
+            undoStack.RemoveAt(undoStack.Count - 1)
+            s.Buffer.Clear()
+            s.Buffer.AddRange prevBuf
+            s.Cursor <- prevCursor
+        Continue
+    elif isCtrl k ConsoleKey.Y then
+        exitHistoryMode ()
+        s.ExitArmed <- false
+        if redoStack.Count > 0 then
+            let snapshot = ResizeArray<char>(s.Buffer)
+            pushBounded undoStack (snapshot, s.Cursor)
+            let (nextBuf, nextCursor) = redoStack.[redoStack.Count - 1]
+            redoStack.RemoveAt(redoStack.Count - 1)
+            s.Buffer.Clear()
+            s.Buffer.AddRange nextBuf
+            s.Cursor <- nextCursor
+        Continue
     elif not (Char.IsControl k.KeyChar) then
         exitHistoryMode ()
         s.ExitArmed <- false
+        let snapshot = ResizeArray<char>(s.Buffer)
+        pushBounded undoStack (snapshot, s.Cursor)
+        redoStack.Clear()
         s.Buffer.Insert(s.Cursor, k.KeyChar)
         s.Cursor <- s.Cursor + 1
         Continue

--- a/tests/Fugue.Tests/ReadLineTests.fs
+++ b/tests/Fugue.Tests/ReadLineTests.fs
@@ -344,3 +344,100 @@ let ``word_CtrlW_atZero_isNoOp`` () =
     act |> should equal Continue
     String(s.Buffer.ToArray()) |> should equal "hello"
     s.Cursor |> should equal 0
+
+// ── Undo / redo tests ─────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``undo_CtrlZ_onEmptyStack_isNoOp`` () =
+    clearUndoRedo()
+    let s = mkState "hello" 5
+    let act = applyKey (special ConsoleKey.Z ConsoleModifiers.Control) s
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "hello"
+    s.Cursor |> should equal 5
+
+[<Fact>]
+let ``undo_typingChar_pushesSnapshotOntoUndoStack`` () =
+    clearUndoRedo()
+    let s = mkState "ab" 2
+    let _ = applyKey (key 'c' ConsoleModifiers.None) s
+    undoStack.Count |> should equal 1
+    redoStack.Count |> should equal 0
+
+[<Fact>]
+let ``undo_CtrlZ_restoresPreviousBufferAndCursor`` () =
+    clearUndoRedo()
+    let s = mkState "ab" 2
+    let _ = applyKey (key 'c' ConsoleModifiers.None) s   // buffer = "abc", cursor = 3; snapshot "ab"/2 on undoStack
+    let act = applyKey (special ConsoleKey.Z ConsoleModifiers.Control) s
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "ab"
+    s.Cursor |> should equal 2
+    undoStack.Count |> should equal 0
+
+[<Fact>]
+let ``undo_CtrlZ_pushesCurrentStateOntoRedoStack`` () =
+    clearUndoRedo()
+    let s = mkState "ab" 2
+    let _ = applyKey (key 'c' ConsoleModifiers.None) s   // "abc", cursor 3
+    let _ = applyKey (special ConsoleKey.Z ConsoleModifiers.Control) s
+    redoStack.Count |> should equal 1
+    let (redoBuf, redoCursor) = redoStack.[0]
+    String(redoBuf.ToArray()) |> should equal "abc"
+    redoCursor |> should equal 3
+
+[<Fact>]
+let ``redo_CtrlY_onEmptyStack_isNoOp`` () =
+    clearUndoRedo()
+    let s = mkState "hello" 5
+    let act = applyKey (special ConsoleKey.Y ConsoleModifiers.Control) s
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "hello"
+    s.Cursor |> should equal 5
+
+[<Fact>]
+let ``redo_CtrlY_restoresRedoneStateAndPushesUndoViaPushBounded`` () =
+    clearUndoRedo()
+    let s = mkState "ab" 2
+    let _ = applyKey (key 'c' ConsoleModifiers.None) s   // "abc"/3 → undoStack: [("ab",2)]
+    let _ = applyKey (special ConsoleKey.Z ConsoleModifiers.Control) s  // back to "ab"/2 → redoStack: [("abc",3)]
+    let act = applyKey (special ConsoleKey.Y ConsoleModifiers.Control) s  // redo
+    act |> should equal Continue
+    String(s.Buffer.ToArray()) |> should equal "abc"
+    s.Cursor |> should equal 3
+    redoStack.Count |> should equal 0
+    undoStack.Count |> should equal 1
+
+[<Fact>]
+let ``redo_typingAfterUndo_clearsRedoStack`` () =
+    clearUndoRedo()
+    let s = mkState "ab" 2
+    let _ = applyKey (key 'c' ConsoleModifiers.None) s   // "abc"/3
+    let _ = applyKey (special ConsoleKey.Z ConsoleModifiers.Control) s  // back to "ab"/2
+    redoStack.Count |> should equal 1
+    let _ = applyKey (key 'x' ConsoleModifiers.None) s   // typing clears redo
+    redoStack.Count |> should equal 0
+
+[<Fact>]
+let ``undo_pushBounded_capsUndoStackAt100`` () =
+    clearUndoRedo()
+    let s = mkState "" 0
+    // Type 110 characters — each keystroke pushes one snapshot
+    for _ in 1 .. 110 do
+        let _ = applyKey (key 'a' ConsoleModifiers.None) s
+        ()
+    undoStack.Count |> should equal 100
+
+[<Fact>]
+let ``redo_pushBounded_capsRedoStackAt100`` () =
+    clearUndoRedo()
+    let s = mkState "" 0
+    // Build up 110 undo entries
+    for _ in 1 .. 110 do
+        let _ = applyKey (key 'a' ConsoleModifiers.None) s
+        ()
+    // Undo all 100 capped entries; each undo pushes onto redo via pushBounded
+    for _ in 1 .. 110 do
+        let _ = applyKey (special ConsoleKey.Z ConsoleModifiers.Control) s
+        ()
+    redoStack.Count |> should equal 100


### PR DESCRIPTION
Cherry-pick of 97bca1b onto current main. Adds Ctrl+Z undo / Ctrl+Y redo with pushBounded on both stacks so neither exceeds 100 entries. Typing clears redoStack. 9 unit tests cover basic undo/redo, no-op on empty stack, redo-clear-on-type, and the cap. Closes #553.