### PR TITLE
feat(cli): @path file injection with locale strings (#564)

### DIFF
--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -39,6 +39,51 @@ let private findGitRoot (startDir: string) : string option =
         else None
     with _ -> None
 
+/// Find @path tokens in a string.
+/// Returns list of (startIdx, tokenLength, path) for each @word token that is preceded
+/// by start-of-string or whitespace.
+let private findAtTokens (input: string) : (int * int * string) list =
+    let mutable i = 0
+    let mutable results = []
+    while i < input.Length do
+        if input.[i] = '@' && (i = 0 || Char.IsWhiteSpace input.[i - 1]) then
+            let start = i
+            i <- i + 1
+            let pathStart = i
+            while i < input.Length && not (Char.IsWhiteSpace input.[i]) do
+                i <- i + 1
+            if i > pathStart then
+                results <- (start, i - start, input.[start + 1 .. i - 1]) :: results
+        else
+            i <- i + 1
+    List.rev results
+
+/// Expand @path tokens in user input. Each @word that resolves to an existing file
+/// within cwd is replaced with its contents (up to 4000 chars). Skips missing, binary,
+/// or out-of-cwd files silently or with a dim notice.
+let private expandAtFiles (cwd: string) (strings: Fugue.Core.Localization.Strings) (input: string) : string =
+    let tokens = findAtTokens input
+    if tokens.IsEmpty then input
+    else
+        // Process tokens in reverse order so indices stay valid during replacement
+        let mutable result = input
+        for (start, length, pathPart) in List.rev tokens do
+            let fullPath = Fugue.Tools.PathSafety.resolve cwd pathPart
+            if not (Fugue.Tools.PathSafety.isUnder cwd fullPath) then
+                ()  // silently skip paths outside cwd
+            elif not (System.IO.File.Exists fullPath) then
+                AnsiConsole.MarkupLine(sprintf "[dim]%s[/]" (Markup.Escape (System.String.Format(strings.AtFileNotFound, pathPart))))
+            else
+                try
+                    let content = System.IO.File.ReadAllText fullPath
+                    let truncated = content.Length > 4000
+                    let body = if truncated then content.[..3999] else content
+                    let header = sprintf "[contents of %s]%s:\n" pathPart (if truncated then " " + strings.AtFileTooBig else "")
+                    result <- result.[0 .. start - 1] + header + body + result.[start + length ..]
+                with _ ->
+                    AnsiConsole.MarkupLine(sprintf "[dim]%s[/]" (Markup.Escape (System.String.Format(strings.AtFileNotFound, pathPart))))
+        result
+
 /// Cheap heuristic — does the text contain markdown markers worth re-rendering?
 /// Avoids re-printing pure plain text twice. False positives (e.g. raw `**` in code)
 /// are acceptable; the markdown render still produces readable output.
@@ -394,9 +439,10 @@ Please generate a clear, actionable onboarding checklist.""" (String.concat "\n\
                 if ReadLine.hasZeroWidth userInput then
                     AnsiConsole.Write(Markup("[dim yellow]" + Markup.Escape strings.ZeroWidthWarning + "[/]"))
                     AnsiConsole.WriteLine()
+                let expandedInput = expandAtFiles cwd strings userInput
                 AnsiConsole.Write(Render.userMessage cfg.Ui userInput)
                 AnsiConsole.WriteLine()
-                do! streamAndRender agent session userInput cfg cancelSrc
+                do! streamAndRender agent session expandedInput cfg cancelSrc
                 StatusBar.refresh ()
     finally
         Console.CancelKeyPress.RemoveHandler handler

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -49,7 +49,11 @@ type Strings =
       ReviewPrPrompt:    string
 
       // Input safety
-      ZeroWidthWarning: string }
+      ZeroWidthWarning: string
+
+      // @file injection
+      AtFileNotFound: string
+      AtFileTooBig:   string }
 
 let en : Strings =
     { Cancelled            = "cancelled"
@@ -82,7 +86,9 @@ let en : Strings =
       ReviewPrUsage         = "Usage: /review pr <N>"
       ReviewPrNotFound      = "PR not found or gh CLI unavailable"
       ReviewPrPrompt        = "Please review GitHub PR #{0}.\n\nPR metadata:\n{1}\n\nDiff:\n```\n{2}\n```\n\nProvide a thorough code review: identify bugs, style issues, missing tests, security concerns, and any improvements. Be specific with line references where possible."
-      ZeroWidthWarning      = "Warning: input contains invisible zero-width characters — these may cause Edit tool diff mismatches" }
+      ZeroWidthWarning      = "Warning: input contains invisible zero-width characters — these may cause Edit tool diff mismatches"
+      AtFileNotFound        = "@{0}: file not found, skipping"
+      AtFileTooBig          = "[file too large — truncated to 4000 chars]" }
 
 let ru : Strings =
     { Cancelled            = "отменено"
@@ -115,7 +121,9 @@ let ru : Strings =
       ReviewPrUsage         = "Использование: /review pr <N>"
       ReviewPrNotFound      = "PR не найден или gh CLI недоступен"
       ReviewPrPrompt        = "Пожалуйста, проверь GitHub PR #{0}.\n\nМетаданные PR:\n{1}\n\nDiff:\n```\n{2}\n```\n\nПроведи подробное ревью кода: выяви баги, проблемы со стилем, отсутствующие тесты, уязвимости безопасности и возможные улучшения. Указывай конкретные строки там, где это возможно."
-      ZeroWidthWarning      = "Предупреждение: ввод содержит невидимые символы нулевой ширины — они могут нарушить работу инструмента Edit" }
+      ZeroWidthWarning      = "Предупреждение: ввод содержит невидимые символы нулевой ширины — они могут нарушить работу инструмента Edit"
+      AtFileNotFound        = "@{0}: файл не найден, пропускаем"
+      AtFileTooBig          = "[файл слишком большой — обрезано до 4000 символов]" }
 
 /// Pick a Strings value by ISO-2 locale code. Unknown locales fall back to en.
 let pick (locale: string) : Strings =

--- a/tests/Fugue.Tests/AtFileTests.fs
+++ b/tests/Fugue.Tests/AtFileTests.fs
@@ -1,0 +1,67 @@
+module Fugue.Tests.AtFileTests
+
+open Xunit
+open FsUnit.Xunit
+
+// findAtTokens is private in Repl, so we replicate the pure parser logic here
+// to keep the tests self-contained and AOT-safe (no Reflection needed).
+
+/// Replicated pure parser (mirrors Repl.findAtTokens) for unit testing.
+let private findAtTokens (input: string) : (int * int * string) list =
+    let mutable i = 0
+    let mutable results = []
+    while i < input.Length do
+        if input.[i] = '@' && (i = 0 || System.Char.IsWhiteSpace input.[i - 1]) then
+            let start = i
+            i <- i + 1
+            let pathStart = i
+            while i < input.Length && not (System.Char.IsWhiteSpace input.[i]) do
+                i <- i + 1
+            if i > pathStart then
+                results <- (start, i - start, input.[start + 1 .. i - 1]) :: results
+        else
+            i <- i + 1
+    List.rev results
+
+[<Fact>]
+let ``findAtTokens finds single token in middle of string`` () =
+    let tokens = findAtTokens "hello @file.txt world"
+    tokens |> should haveLength 1
+    let (start, len, path) = tokens.[0]
+    path  |> should equal "file.txt"
+    start |> should equal 6
+    len   |> should equal 9  // length of "@file.txt"
+
+[<Fact>]
+let ``findAtTokens returns empty list when no at-tokens present`` () =
+    let tokens = findAtTokens "no at tokens here"
+    tokens |> should be Empty
+
+[<Fact>]
+let ``findAtTokens finds both tokens when two at-file tokens are present`` () =
+    let tokens = findAtTokens "@file1.txt @file2.txt"
+    tokens |> should haveLength 2
+    let (_, _, p1) = tokens.[0]
+    let (_, _, p2) = tokens.[1]
+    p1 |> should equal "file1.txt"
+    p2 |> should equal "file2.txt"
+
+[<Fact>]
+let ``findAtTokens handles token at start of string`` () =
+    let tokens = findAtTokens "@README.md"
+    tokens |> should haveLength 1
+    let (start, _, path) = tokens.[0]
+    start |> should equal 0
+    path  |> should equal "README.md"
+
+[<Fact>]
+let ``findAtTokens ignores at-sign in the middle of a word`` () =
+    let tokens = findAtTokens "user@example.com is an email"
+    tokens |> should be Empty
+
+[<Fact>]
+let ``findAtTokens handles path with directory separators`` () =
+    let tokens = findAtTokens "look at @src/Fugue.Core/Config.fs please"
+    tokens |> should haveLength 1
+    let (_, _, path) = tokens.[0]
+    path |> should equal "src/Fugue.Core/Config.fs"

--- a/tests/Fugue.Tests/Fugue.Tests.fsproj
+++ b/tests/Fugue.Tests/Fugue.Tests.fsproj
@@ -31,6 +31,7 @@
     <Compile Include="GrepToolTests.fs" />
     <Compile Include="DiscoveryTests.fs" />
     <Compile Include="ConversationTests.fs" />
+    <Compile Include="AtFileTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Cherry-pick of d147adf onto current main. Adds findAtTokens + expandAtFiles for @file token expansion in user input, AtFileNotFound + AtFileTooBig locale keys (EN+RU), and AtFileTests.fs covering the pure token parser. Closes #564.