### PR TITLE
fix(i18n): extract /git-log LLM prompt to Localization (en+ru)

### DIFF
--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -257,6 +257,7 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                 AnsiConsole.WriteLine()
                 let helpItems = [ "/help",           strings.CmdHelpDesc
                                   "/clear",          strings.CmdClearDesc
+                                  "/git-log",        strings.CmdGitLogDesc
                                   "/issue <N>",      strings.CmdIssueDesc
                                   "/model suggest",  strings.CmdModelDesc
                                   "/onboard",        strings.CmdOnboardDesc
@@ -264,6 +265,36 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                                   "/review pr <N>",  strings.CmdReviewPrDesc ]
                 for (name, desc) in helpItems do
                     AnsiConsole.Write(Markup("  [cyan]" + Markup.Escape name + "[/]  [dim]" + Markup.Escape desc + "[/]"))
+                    AnsiConsole.WriteLine()
+                StatusBar.refresh ()
+            | Some s when s = "/git-log" ->
+                let psi = System.Diagnostics.ProcessStartInfo()
+                psi.FileName <- "git"
+                psi.ArgumentList.Add "log"
+                psi.ArgumentList.Add "--oneline"
+                psi.ArgumentList.Add "--decorate"
+                psi.ArgumentList.Add "-20"
+                psi.UseShellExecute <- false
+                psi.RedirectStandardOutput <- true
+                psi.WorkingDirectory <- cwd
+                try
+                    use proc = new System.Diagnostics.Process()
+                    proc.StartInfo <- psi
+                    match proc.Start() with
+                    | false ->
+                        AnsiConsole.Write(Render.errorLine strings strings.GitLogNoRepo)
+                        AnsiConsole.WriteLine()
+                    | true ->
+                        let out = proc.StandardOutput.ReadToEnd()
+                        proc.WaitForExit()
+                        if proc.ExitCode <> 0 || String.IsNullOrWhiteSpace out then
+                            AnsiConsole.Write(Render.errorLine strings strings.GitLogNoRepo)
+                            AnsiConsole.WriteLine()
+                        else
+                            let prompt = strings.GitLogPrompt.Replace("%s", out)
+                            do! streamAndRender agent session prompt cfg cancelSrc
+                with ex ->
+                    AnsiConsole.Write(Render.errorLine strings ex.Message)
                     AnsiConsole.WriteLine()
                 StatusBar.refresh ()
             | Some s when s = "/clear" ->

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -48,6 +48,11 @@ type Strings =
       ReviewPrNotFound:  string
       ReviewPrPrompt:    string
 
+      // /git-log
+      CmdGitLogDesc: string
+      GitLogNoRepo:  string
+      GitLogPrompt:  string
+
       // Input safety
       ZeroWidthWarning: string
 
@@ -86,6 +91,9 @@ let en : Strings =
       ReviewPrUsage         = "Usage: /review pr <N>"
       ReviewPrNotFound      = "PR not found or gh CLI unavailable"
       ReviewPrPrompt        = "Please review GitHub PR #{0}.\n\nPR metadata:\n{1}\n\nDiff:\n```\n{2}\n```\n\nProvide a thorough code review: identify bugs, style issues, missing tests, security concerns, and any improvements. Be specific with line references where possible."
+      CmdGitLogDesc         = "explain recent git commit history"
+      GitLogNoRepo          = "not a git repository or git unavailable"
+      GitLogPrompt          = "Here are the last 20 commits from git log:\n\n%s\n\nPlease explain these commits in plain language — what changed, in what order, and what the overall direction seems to be."
       ZeroWidthWarning      = "Warning: input contains invisible zero-width characters — these may cause Edit tool diff mismatches"
       AtFileNotFound        = "@{0}: file not found, skipping"
       AtFileTooBig          = "[file too large — truncated to 4000 chars]" }
@@ -121,6 +129,9 @@ let ru : Strings =
       ReviewPrUsage         = "Использование: /review pr <N>"
       ReviewPrNotFound      = "PR не найден или gh CLI недоступен"
       ReviewPrPrompt        = "Пожалуйста, проверь GitHub PR #{0}.\n\nМетаданные PR:\n{1}\n\nDiff:\n```\n{2}\n```\n\nПроведи подробное ревью кода: выяви баги, проблемы со стилем, отсутствующие тесты, уязвимости безопасности и возможные улучшения. Указывай конкретные строки там, где это возможно."
+      CmdGitLogDesc         = "объяснить историю git коммитов"
+      GitLogNoRepo          = "не git-репозиторий или git недоступен"
+      GitLogPrompt          = "Вот последние 20 коммитов из git log:\n\n%s\n\nОбъясни эти коммиты простым языком — что изменилось, в каком порядке, и каково общее направление разработки."
       ZeroWidthWarning      = "Предупреждение: ввод содержит невидимые символы нулевой ширины — они могут нарушить работу инструмента Edit"
       AtFileNotFound        = "@{0}: файл не найден, пропускаем"
       AtFileTooBig          = "[файл слишком большой — обрезано до 4000 символов]" }


### PR DESCRIPTION
Adds CmdGitLogDesc, GitLogNoRepo, GitLogPrompt locale keys (en+ru) and wires /git-log into the /help table. 224/224 tests pass.