### PR TITLE
feat(cli): /ask command for tools-disabled Q&A mode

### DIFF
--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -256,6 +256,7 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                 AnsiConsole.Write(Markup("[bold]" + Markup.Escape strings.HelpHeader + "[/]"))
                 AnsiConsole.WriteLine()
                 let helpItems = [ "/help",           strings.CmdHelpDesc
+                                  "/ask <q>",        strings.CmdAskDesc
                                   "/clear",          strings.CmdClearDesc
                                   "/git-log",        strings.CmdGitLogDesc
                                   "/issue <N>",      strings.CmdIssueDesc
@@ -474,6 +475,21 @@ Please generate a clear, actionable onboarding checklist.""" (String.concat "\n\
                         AnsiConsole.Write(Render.userMessage cfg.Ui (sprintf "Reviewing PR #%d…" prNum))
                         AnsiConsole.WriteLine()
                         do! streamAndRender agent session prompt cfg cancelSrc
+                StatusBar.refresh ()
+            | Some s when s.StartsWith "/ask " ->
+                let question = s.Substring(5).Trim()
+                if String.IsNullOrWhiteSpace question then
+                    AnsiConsole.Write(Markup("[dim]" + Markup.Escape strings.AskUsage + "[/]"))
+                    AnsiConsole.WriteLine()
+                else
+                    let augmented = sprintf "[System: answer from your training knowledge only — do not invoke any tools, do not read files, do not run commands]\n\nUser: %s" question
+                    AnsiConsole.Write(Render.userMessage cfg.Ui question)
+                    AnsiConsole.WriteLine()
+                    do! streamAndRender agent session augmented cfg cancelSrc
+                StatusBar.refresh ()
+            | Some s when s = "/ask" ->
+                AnsiConsole.Write(Markup("[dim]" + Markup.Escape strings.AskUsage + "[/]"))
+                AnsiConsole.WriteLine()
                 StatusBar.refresh ()
             | Some userInput ->
                 if ReadLine.hasZeroWidth userInput then

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -53,6 +53,10 @@ type Strings =
       GitLogNoRepo:  string
       GitLogPrompt:  string
 
+      // /ask
+      CmdAskDesc: string
+      AskUsage:   string
+
       // Input safety
       ZeroWidthWarning: string
 
@@ -94,6 +98,8 @@ let en : Strings =
       CmdGitLogDesc         = "explain recent git commit history"
       GitLogNoRepo          = "not a git repository or git unavailable"
       GitLogPrompt          = "Here are the last 20 commits from git log:\n\n%s\n\nPlease explain these commits in plain language — what changed, in what order, and what the overall direction seems to be."
+      CmdAskDesc            = "ask a question without tool access (pure Q&A)"
+      AskUsage              = "Usage: /ask <question>"
       ZeroWidthWarning      = "Warning: input contains invisible zero-width characters — these may cause Edit tool diff mismatches"
       AtFileNotFound        = "@{0}: file not found, skipping"
       AtFileTooBig          = "[file too large — truncated to 4000 chars]" }
@@ -132,6 +138,8 @@ let ru : Strings =
       CmdGitLogDesc         = "объяснить историю git коммитов"
       GitLogNoRepo          = "не git-репозиторий или git недоступен"
       GitLogPrompt          = "Вот последние 20 коммитов из git log:\n\n%s\n\nОбъясни эти коммиты простым языком — что изменилось, в каком порядке, и каково общее направление разработки."
+      CmdAskDesc            = "задать вопрос без использования инструментов (чистый Q&A)"
+      AskUsage              = "Использование: /ask <вопрос>"
       ZeroWidthWarning      = "Предупреждение: ввод содержит невидимые символы нулевой ширины — они могут нарушить работу инструмента Edit"
       AtFileNotFound        = "@{0}: файл не найден, пропускаем"
       AtFileTooBig          = "[файл слишком большой — обрезано до 4000 символов]" }


### PR DESCRIPTION
Adds /ask <question> slash command that suppresses tool invocations and answers from training knowledge only. Adds CmdAskDesc+AskUsage locale keys (en+ru).