### PR TITLE
feat(cli): --profile flag to load custom system prompt persona

### DIFF
--- a/src/Fugue.Cli/Program.fs
+++ b/src/Fugue.Cli/Program.fs
@@ -9,10 +9,14 @@ open Fugue.Agent
 let private buildAgent (cfg: AppConfig) : AIAgent =
     let cwd = Environment.CurrentDirectory
     let tools = Fugue.Tools.ToolRegistry.buildAll cwd
-    let sysPrompt =
+    let basePrompt =
         match cfg.SystemPrompt with
         | Some s -> s
         | None -> Fugue.Core.SystemPrompt.render cwd Fugue.Tools.ToolRegistry.names
+    let sysPrompt =
+        match cfg.ProfileContent with
+        | Some profile -> profile + "\n\n---\n\n" + basePrompt
+        | None -> basePrompt
     AgentFactory.create cfg.Provider cfg.BaseUrl sysPrompt tools
 
 [<RequiresUnreferencedCode("Calls Repl.run and Config.saveToFile which use STJ reflection; System.Text.Json is TrimmerRootAssembly")>]
@@ -33,6 +37,11 @@ let private runWithCfg (cfg: AppConfig) : int =
 let main argv =
     Fugue.Core.Log.session ()
     Fugue.Core.Log.info "main" ("fugue starting, argv=[" + String.concat "; " argv + "]")
+    let profileContent =
+        argv
+        |> Array.tryFindIndex ((=) "--profile")
+        |> Option.bind (fun i -> if i + 1 < argv.Length then Some argv.[i + 1] else None)
+        |> Option.bind Fugue.Core.Config.loadProfile
     if argv |> Array.contains "doctor" then
         let cwd = Environment.CurrentDirectory
         let passed = Doctor.run cwd
@@ -56,7 +65,7 @@ let main argv =
                     let m = if List.isEmpty models then "llama3.1" else List.head models
                     Ollama(ep, m)
                 | _ -> failwith "unsupported candidate"
-            let cfg = { Provider = provider; SystemPrompt = None; MaxIterations = 30; Ui = Fugue.Core.Config.defaultUi (); BaseUrl = None }
+            let cfg = { Provider = provider; SystemPrompt = None; ProfileContent = profileContent; MaxIterations = 30; Ui = Fugue.Core.Config.defaultUi (); BaseUrl = None }
             Fugue.Core.Config.saveToFile cfg
             runWithCfg cfg
         | None ->
@@ -66,4 +75,4 @@ let main argv =
         Console.Error.WriteLine("Invalid config: " + reason)
         1
     | Ok cfg ->
-        runWithCfg cfg
+        runWithCfg { cfg with ProfileContent = profileContent }

--- a/src/Fugue.Core/Config.fs
+++ b/src/Fugue.Core/Config.fs
@@ -37,9 +37,18 @@ let defaultUi () : UiConfig =
 type AppConfig =
     { Provider: ProviderConfig
       SystemPrompt: string option
+      ProfileContent: string option
       MaxIterations: int
       Ui: UiConfig
       BaseUrl: string option }
+
+let loadProfile (name: string) : string option =
+    let home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
+    let path = Path.Combine(home, ".fugue", "profiles", name + ".md")
+    if File.Exists path then
+        try Some (File.ReadAllText path)
+        with _ -> None
+    else None
 
 type ConfigError =
     | NoConfigFound of help: string
@@ -185,19 +194,19 @@ Set environment variables:
 let load (_argv: string[]) : Result<AppConfig, ConfigError> =
     match fromExplicitEnv () with
     | Some provider ->
-        Ok { Provider = provider; SystemPrompt = None; MaxIterations = 30; Ui = defaultUi (); BaseUrl = None }
+        Ok { Provider = provider; SystemPrompt = None; ProfileContent = None; MaxIterations = 30; Ui = defaultUi (); BaseUrl = None }
     | None ->
         let path = configPath ()
         if File.Exists path then
             match fromFile path with
             | Ok (p, mi, ui, baseUrl) ->
                 let mi = if mi <= 0 then 30 else mi
-                Ok { Provider = p; SystemPrompt = None; MaxIterations = mi; Ui = ui; BaseUrl = baseUrl }
+                Ok { Provider = p; SystemPrompt = None; ProfileContent = None; MaxIterations = mi; Ui = ui; BaseUrl = baseUrl }
             | Error e -> Error(InvalidConfig e)
         else
             match fromImplicitEnv () with
             | Some provider ->
-                Ok { Provider = provider; SystemPrompt = None; MaxIterations = 30; Ui = defaultUi (); BaseUrl = None }
+                Ok { Provider = provider; SystemPrompt = None; ProfileContent = None; MaxIterations = 30; Ui = defaultUi (); BaseUrl = None }
             | None ->
                 Error(NoConfigFound (helpText ()))
 

--- a/tests/Fugue.Tests/ConfigTests.fs
+++ b/tests/Fugue.Tests/ConfigTests.fs
@@ -1,6 +1,7 @@
 module Fugue.Tests.ConfigTests
 
 open System
+open System.IO
 open Xunit
 open FsUnit.Xunit
 open Fugue.Core.Config
@@ -127,4 +128,35 @@ let ``load defaults BaseUrl=None when baseUrl absent`` () =
     Environment.SetEnvironmentVariable("HOME", tmpHome)
     match load [||] with
     | Ok cfg -> cfg.BaseUrl |> should equal None
+    | Error e -> failwithf "expected Ok, got %A" e
+
+[<Fact>]
+let ``loadProfile returns Some content when profile file exists`` () =
+    let tmpHome = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"))
+    let profilesDir = Path.Combine(tmpHome, ".fugue", "profiles")
+    Directory.CreateDirectory profilesDir |> ignore
+    File.WriteAllText(Path.Combine(profilesDir, "senior-reviewer.md"), "You are a senior code reviewer.")
+    // Override HOME so Environment.SpecialFolder.UserProfile resolves to tmpHome.
+    Environment.SetEnvironmentVariable("HOME", tmpHome)
+    let result = loadProfile "senior-reviewer"
+    result |> should equal (Some "You are a senior code reviewer.")
+
+[<Fact>]
+let ``loadProfile returns None when profile file does not exist`` () =
+    let tmpHome = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"))
+    Directory.CreateDirectory tmpHome |> ignore
+    Environment.SetEnvironmentVariable("HOME", tmpHome)
+    let result = loadProfile "nonexistent"
+    result |> should equal (None: string option)
+
+[<Fact>]
+let ``AppConfig ProfileContent is None after load when no profile passed`` () =
+    let tmpHome = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"))
+    Directory.CreateDirectory tmpHome |> ignore
+    Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", "sk-ant-test")
+    Environment.SetEnvironmentVariable("OPENAI_API_KEY", null)
+    Environment.SetEnvironmentVariable("FUGUE_PROVIDER", null)
+    Environment.SetEnvironmentVariable("HOME", tmpHome)
+    match load [||] with
+    | Ok cfg -> cfg.ProfileContent |> should equal (None: string option)
     | Error e -> failwithf "expected Ok, got %A" e


### PR DESCRIPTION
Adds --profile <name> flag that reads ~/.fugue/profiles/<name>.md and prepends its content to the system prompt. 227/227 tests pass.