### PR TITLE
feat(cli): @clipboard token expansion in REPL input

### DIFF
--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -153,6 +153,47 @@ let private unescapeJson (s: string) : string =
             sb.Append(s.[i]) |> ignore
             i <- i + 1
     sb.ToString()
+let private tryReadClipboard () : string option =
+    let tryCmd prog (args: string[]) =
+        try
+            let psi = System.Diagnostics.ProcessStartInfo()
+            psi.FileName <- prog
+            for a in args do psi.ArgumentList.Add a
+            psi.RedirectStandardOutput <- true
+            psi.UseShellExecute <- false
+            psi.CreateNoWindow <- true
+            use proc = new System.Diagnostics.Process()
+            proc.StartInfo <- psi
+            proc.Start() |> ignore
+            let out = proc.StandardOutput.ReadToEnd()
+            proc.WaitForExit()
+            if proc.ExitCode = 0 && not (System.String.IsNullOrEmpty out) then Some out
+            else None
+        with _ -> None
+    // macOS
+    match tryCmd "pbpaste" [||] with
+    | Some s -> Some s
+    | None ->
+    // Linux (X11)
+    match tryCmd "xclip" [| "-o"; "-sel"; "clipboard" |] with
+    | Some s -> Some s
+    | None ->
+    // Linux (Wayland)
+    match tryCmd "wl-paste" [||] with
+    | Some s -> Some s
+    | None -> None
+
+let private expandClipboard (input: string) (strings: Strings) : string =
+    if not (input.Contains "@clipboard") then input
+    else
+        match tryReadClipboard() with
+        | None ->
+            input.Replace("@clipboard", "[" + strings.ClipboardUnavailable + "]")
+        | Some content ->
+            let truncated =
+                if content.Length > 4000 then content.[..3999] + " " + strings.AtFileTooBig
+                else content
+            input.Replace("@clipboard", truncated)
 
 /// Holder for the currently active stream's CancellationTokenSource.
 /// Console.CancelKeyPress handler uses this to cancel mid-stream Ctrl+C.
@@ -496,6 +537,7 @@ Please generate a clear, actionable onboarding checklist.""" (String.concat "\n\
                     AnsiConsole.Write(Markup("[dim yellow]" + Markup.Escape strings.ZeroWidthWarning + "[/]"))
                     AnsiConsole.WriteLine()
                 let expandedInput = expandAtFiles cwd strings userInput
+                let expandedInput = expandClipboard expandedInput strings
                 AnsiConsole.Write(Render.userMessage cfg.Ui userInput)
                 AnsiConsole.WriteLine()
                 let sw = System.Diagnostics.Stopwatch.StartNew()

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -62,7 +62,10 @@ type Strings =
 
       // @file injection
       AtFileNotFound: string
-      AtFileTooBig:   string }
+      AtFileTooBig:   string
+
+      // @clipboard expansion
+      ClipboardUnavailable: string }
 
 let en : Strings =
     { Cancelled            = "cancelled"
@@ -102,7 +105,8 @@ let en : Strings =
       AskUsage              = "Usage: /ask <question>"
       ZeroWidthWarning      = "Warning: input contains invisible zero-width characters — these may cause Edit tool diff mismatches"
       AtFileNotFound        = "@{0}: file not found, skipping"
-      AtFileTooBig          = "[file too large — truncated to 4000 chars]" }
+      AtFileTooBig          = "[file too large — truncated to 4000 chars]"
+      ClipboardUnavailable  = "clipboard unavailable — pbpaste/xclip/wl-paste not found" }
 
 let ru : Strings =
     { Cancelled            = "отменено"
@@ -142,7 +146,8 @@ let ru : Strings =
       AskUsage              = "Использование: /ask <вопрос>"
       ZeroWidthWarning      = "Предупреждение: ввод содержит невидимые символы нулевой ширины — они могут нарушить работу инструмента Edit"
       AtFileNotFound        = "@{0}: файл не найден, пропускаем"
-      AtFileTooBig          = "[файл слишком большой — обрезано до 4000 символов]" }
+      AtFileTooBig          = "[файл слишком большой — обрезано до 4000 символов]"
+      ClipboardUnavailable  = "буфер обмена недоступен — pbpaste/xclip/wl-paste не найдены" }
 
 /// Pick a Strings value by ISO-2 locale code. Unknown locales fall back to en.
 let pick (locale: string) : Strings =


### PR DESCRIPTION
Expands @clipboard token in prompts to current clipboard contents (pbpaste/xclip/wl-paste). Adds ClipboardUnavailable locale key (en+ru). Chains with existing expandAtFiles. 227/227 tests pass.