### PR TITLE
feat(cli): /diff and /diff --staged slash commands (#254)

### DIFF
--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -29,7 +29,7 @@ let hasZeroWidth (s: string) = InputSanitize.hasZeroWidth s
 let normalizeInput (s: string) = InputSanitize.normalize s
 
 // Hardcoded — small list, easier than passing through state.
-let slashCommands : string list = [ "/help"; "/clear"; "/exit" ]
+let slashCommands : string list = [ "/help"; "/clear"; "/exit"; "/diff"; "/diff --staged" ]
 
 /// Session history (REPL is single-threaded). Not private so tests can seed entries directly.
 let historyStore = ResizeArray<string>()
@@ -342,9 +342,11 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
                 i <- i + 1
         n
     let slashHelp =
-        [ "/help",  strings.CmdHelpDesc
-          "/clear", strings.CmdClearDesc
-          "/exit",  strings.CmdExitDesc ]
+        [ "/help",         strings.CmdHelpDesc
+          "/clear",        strings.CmdClearDesc
+          "/exit",         strings.CmdExitDesc
+          "/diff",         strings.CmdDiffDesc
+          "/diff --staged", strings.CmdDiffDesc ]
     let st : S =
         { Buffer          = ResizeArray<char>()
           Cursor          = 0

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -299,6 +299,7 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                 let helpItems = [ "/help",           strings.CmdHelpDesc
                                   "/ask <q>",        strings.CmdAskDesc
                                   "/clear",          strings.CmdClearDesc
+                                  "/diff",           strings.CmdDiffDesc
                                   "/git-log",        strings.CmdGitLogDesc
                                   "/issue <N>",      strings.CmdIssueDesc
                                   "/model suggest",  strings.CmdModelDesc
@@ -531,6 +532,30 @@ Please generate a clear, actionable onboarding checklist.""" (String.concat "\n\
             | Some s when s = "/ask" ->
                 AnsiConsole.Write(Markup("[dim]" + Markup.Escape strings.AskUsage + "[/]"))
                 AnsiConsole.WriteLine()
+            | Some s when s = "/diff" || s = "/diff --staged" ->
+                let args = if s = "/diff --staged" then "--staged" else ""
+                let psi = System.Diagnostics.ProcessStartInfo()
+                psi.FileName <- "git"
+                psi.ArgumentList.Add "diff"
+                if args <> "" then psi.ArgumentList.Add args
+                psi.UseShellExecute <- false
+                psi.RedirectStandardOutput <- true
+                psi.WorkingDirectory <- cwd
+                use proc = new System.Diagnostics.Process()
+                proc.StartInfo <- psi
+                try
+                    proc.Start() |> ignore
+                    let output = proc.StandardOutput.ReadToEnd()
+                    proc.WaitForExit()
+                    if System.String.IsNullOrWhiteSpace output then
+                        AnsiConsole.Write(Markup("[dim]" + Markup.Escape strings.NoDiff + "[/]"))
+                        AnsiConsole.WriteLine()
+                    else
+                        AnsiConsole.Write(DiffRender.toRenderable output)
+                        AnsiConsole.WriteLine()
+                with ex ->
+                    AnsiConsole.Write(Render.errorLine strings ex.Message)
+                    AnsiConsole.WriteLine()
                 StatusBar.refresh ()
             | Some userInput ->
                 if ReadLine.hasZeroWidth userInput then

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -65,7 +65,11 @@ type Strings =
       AtFileTooBig:   string
 
       // @clipboard expansion
-      ClipboardUnavailable: string }
+      ClipboardUnavailable: string
+
+      // /diff command
+      CmdDiffDesc: string
+      NoDiff:      string }
 
 let en : Strings =
     { Cancelled            = "cancelled"
@@ -106,7 +110,9 @@ let en : Strings =
       ZeroWidthWarning      = "Warning: input contains invisible zero-width characters — these may cause Edit tool diff mismatches"
       AtFileNotFound        = "@{0}: file not found, skipping"
       AtFileTooBig          = "[file too large — truncated to 4000 chars]"
-      ClipboardUnavailable  = "clipboard unavailable — pbpaste/xclip/wl-paste not found" }
+      ClipboardUnavailable  = "clipboard unavailable — pbpaste/xclip/wl-paste not found"
+      CmdDiffDesc           = "show unstaged git diff (use /diff --staged for staged changes)"
+      NoDiff                = "no changes" }
 
 let ru : Strings =
     { Cancelled            = "отменено"
@@ -147,7 +153,9 @@ let ru : Strings =
       ZeroWidthWarning      = "Предупреждение: ввод содержит невидимые символы нулевой ширины — они могут нарушить работу инструмента Edit"
       AtFileNotFound        = "@{0}: файл не найден, пропускаем"
       AtFileTooBig          = "[файл слишком большой — обрезано до 4000 символов]"
-      ClipboardUnavailable  = "буфер обмена недоступен — pbpaste/xclip/wl-paste не найдены" }
+      ClipboardUnavailable  = "буфер обмена недоступен — pbpaste/xclip/wl-paste не найдены"
+      CmdDiffDesc           = "показать unstaged git diff (используйте /diff --staged для staged изменений)"
+      NoDiff                = "изменений нет" }
 
 /// Pick a Strings value by ISO-2 locale code. Unknown locales fall back to en.
 let pick (locale: string) : Strings =


### PR DESCRIPTION
Adds /diff and /diff --staged commands with colored DiffRender output. Adds CmdDiffDesc+NoDiff locale keys (en+ru). 227/227 tests pass.