### PR TITLE
feat(cli): /init command — auto-generate FUGUE.md via AI analysis (#207)

### DIFF
--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -29,7 +29,7 @@ let hasZeroWidth (s: string) = InputSanitize.hasZeroWidth s
 let normalizeInput (s: string) = InputSanitize.normalize s
 
 // Hardcoded — small list, easier than passing through state.
-let slashCommands : string list = [ "/help"; "/clear"; "/exit"; "/diff"; "/diff --staged" ]
+let slashCommands : string list = [ "/help"; "/clear"; "/init"; "/exit"; "/diff"; "/diff --staged" ]
 
 /// Session history (REPL is single-threaded). Not private so tests can seed entries directly.
 let historyStore = ResizeArray<string>()
@@ -344,6 +344,7 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
     let slashHelp =
         [ "/help",         strings.CmdHelpDesc
           "/clear",        strings.CmdClearDesc
+          "/init",         strings.CmdInitDesc
           "/exit",         strings.CmdExitDesc
           "/diff",         strings.CmdDiffDesc
           "/diff --staged", strings.CmdDiffDesc ]

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -300,6 +300,7 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                                   "/ask <q>",        strings.CmdAskDesc
                                   "/clear",          strings.CmdClearDesc
                                   "/diff",           strings.CmdDiffDesc
+                                  "/init",           strings.CmdInitDesc
                                   "/git-log",        strings.CmdGitLogDesc
                                   "/issue <N>",      strings.CmdIssueDesc
                                   "/model suggest",  strings.CmdModelDesc
@@ -557,6 +558,28 @@ Please generate a clear, actionable onboarding checklist.""" (String.concat "\n\
                     AnsiConsole.Write(Render.errorLine strings ex.Message)
                     AnsiConsole.WriteLine()
                 StatusBar.refresh ()
+            | Some s when s = "/init" ->
+                let fugueMdPath = System.IO.Path.Combine(cwd, "FUGUE.md")
+                if System.IO.File.Exists fugueMdPath then
+                    AnsiConsole.Write(Markup("[yellow]" + Markup.Escape strings.InitExists + "[/]"))
+                    AnsiConsole.WriteLine()
+                    StatusBar.refresh ()
+                else
+                    let initPrompt =
+                        "Please analyze this project and create a FUGUE.md file in the current directory.\n\n" +
+                        "FUGUE.md is a project context file for Fugue (an AI coding assistant). It should include:\n" +
+                        "- Project purpose and target audience\n" +
+                        "- Architecture overview (key directories, modules, patterns)\n" +
+                        "- Tech stack and dependencies\n" +
+                        "- Development conventions (naming, style, testing approach)\n" +
+                        "- Common commands (build, test, run, deploy)\n" +
+                        "- Any gotchas or non-obvious constraints\n\n" +
+                        "Keep it concise — aim for 50-150 lines. Use Markdown headers.\n" +
+                        "Write the file to ./FUGUE.md using the Write tool."
+                    AnsiConsole.Write(Render.userMessage cfg.Ui "/init")
+                    AnsiConsole.WriteLine()
+                    do! streamAndRender agent session initPrompt cfg cancelSrc
+                    StatusBar.refresh ()
             | Some userInput ->
                 if ReadLine.hasZeroWidth userInput then
                     AnsiConsole.Write(Markup("[dim yellow]" + Markup.Escape strings.ZeroWidthWarning + "[/]"))

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -69,7 +69,11 @@ type Strings =
 
       // /diff command
       CmdDiffDesc: string
-      NoDiff:      string }
+      NoDiff:      string
+
+      // /init command
+      CmdInitDesc: string
+      InitExists:  string }
 
 let en : Strings =
     { Cancelled            = "cancelled"
@@ -112,7 +116,9 @@ let en : Strings =
       AtFileTooBig          = "[file too large — truncated to 4000 chars]"
       ClipboardUnavailable  = "clipboard unavailable — pbpaste/xclip/wl-paste not found"
       CmdDiffDesc           = "show unstaged git diff (use /diff --staged for staged changes)"
-      NoDiff                = "no changes" }
+      NoDiff                = "no changes"
+      CmdInitDesc           = "generate FUGUE.md for this project (creates if absent)"
+      InitExists            = "FUGUE.md already exists. Edit it directly or delete it first." }
 
 let ru : Strings =
     { Cancelled            = "отменено"
@@ -155,7 +161,9 @@ let ru : Strings =
       AtFileTooBig          = "[файл слишком большой — обрезано до 4000 символов]"
       ClipboardUnavailable  = "буфер обмена недоступен — pbpaste/xclip/wl-paste не найдены"
       CmdDiffDesc           = "показать unstaged git diff (используйте /diff --staged для staged изменений)"
-      NoDiff                = "изменений нет" }
+      NoDiff                = "изменений нет"
+      CmdInitDesc           = "создать FUGUE.md для проекта (если отсутствует)"
+      InitExists            = "FUGUE.md уже существует. Отредактируйте его напрямую или сначала удалите." }
 
 /// Pick a Strings value by ISO-2 locale code. Unknown locales fall back to en.
 let pick (locale: string) : Strings =


### PR DESCRIPTION
## Summary

- Adds `/init` slash command that auto-generates `FUGUE.md` for the current project via AI analysis
- Adds `CmdInitDesc` and `InitExists` locale strings (en + ru)
- Adds `/init` to tab-completion list (`slashCommands`) and `/help` display (`slashHelp`)

## Notes

Clean cherry-pick of `6f009fd` from superseded PR #393 onto current `main`. All locale conflicts resolved (kept HEAD's full key set, appended `/init` keys). Tests: 226/227 pass (1 flaky pre-existing `DiscoveryTests` env-var isolation failure that passes in isolation). AOT build: clean, 0 errors.

Closes #207