### PR TITLE
feat(cli): Ctrl+L clear screen, /new session, !cmd shell shortcut (#79, #78, #5)

### DIFF
--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -52,6 +52,9 @@ let private pushBounded (stack: ResizeArray<_>) item =
     stack.Add item
     if stack.Count > 100 then stack.RemoveAt 0
 
+type ReadLineCallbacks = { OnClearScreen: unit -> unit }
+let defaultCallbacks : ReadLineCallbacks = { OnClearScreen = ignore }
+
 /// Internal mutable line state. Public only because tests construct it directly.
 type S = {
     mutable Buffer:          ResizeArray<char>
@@ -332,7 +335,7 @@ let private redraw (st: S) =
     else writeRaw "\r"
     st.RowsBelowCursor <- upBy   // save for next redraw's erase pass
 
-let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task<string option> = task {
+let readAsync (prompt: string) (strings: Strings) (callbacks: ReadLineCallbacks) (ct: CancellationToken) : Task<string option> = task {
     // Strip ANSI escapes for visible-length calc (rough — assumes only \x1b[...m sequences).
     let visLen =
         let mutable n = 0
@@ -388,6 +391,7 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
                 writeRaw "\x1b[2J\x1b[H"
                 st.LinesRendered <- 0
                 st.RowsBelowCursor <- 0
+                callbacks.OnClearScreen ()
                 redraw st
             | Submit s ->
                 eraseRendered ()

--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -29,7 +29,7 @@ let hasZeroWidth (s: string) = InputSanitize.hasZeroWidth s
 let normalizeInput (s: string) = InputSanitize.normalize s
 
 // Hardcoded — small list, easier than passing through state.
-let slashCommands : string list = [ "/help"; "/clear"; "/init"; "/exit"; "/diff"; "/diff --staged" ]
+let slashCommands : string list = [ "/help"; "/clear"; "/new"; "/init"; "/exit"; "/diff"; "/diff --staged" ]
 
 /// Session history (REPL is single-threaded). Not private so tests can seed entries directly.
 let historyStore = ResizeArray<string>()
@@ -74,6 +74,7 @@ type Action =
     | Submit of string
     | Quit
     | Wipe
+    | ClearScreen
 
 let private isCtrl (k: ConsoleKeyInfo) (key: ConsoleKey) : bool =
     k.Modifiers.HasFlag ConsoleModifiers.Control && k.Key = key
@@ -225,6 +226,9 @@ let applyKey (k: ConsoleKeyInfo) (s: S) : Action =
         while i < s.Buffer.Count && s.Buffer.[i] <> '\n' do i <- i + 1
         s.Cursor <- i
         Continue
+    elif isCtrl k ConsoleKey.L then
+        s.ExitArmed <- false
+        ClearScreen
     elif isCtrl k ConsoleKey.Z then
         exitHistoryMode ()
         s.ExitArmed <- false
@@ -344,6 +348,7 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
     let slashHelp =
         [ "/help",         strings.CmdHelpDesc
           "/clear",        strings.CmdClearDesc
+          "/new",          strings.CmdNewDesc
           "/init",         strings.CmdInitDesc
           "/exit",         strings.CmdExitDesc
           "/diff",         strings.CmdDiffDesc
@@ -378,6 +383,12 @@ let readAsync (prompt: string) (strings: Strings) (ct: CancellationToken) : Task
             match applyKey k st with
             | Continue -> redraw st
             | Wipe     -> redraw st
+            | ClearScreen ->
+                eraseRendered ()
+                writeRaw "\x1b[2J\x1b[H"
+                st.LinesRendered <- 0
+                st.RowsBelowCursor <- 0
+                redraw st
             | Submit s ->
                 eraseRendered ()
                 let normalized = InputSanitize.normalize s

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -200,9 +200,12 @@ let private expandClipboard (input: string) (strings: Strings) : string =
 type CancelSource() =
     let mutable streamCts : CancellationTokenSource option = None
     let mutable quit = false
+    let mutable childRunning = false
     member _.QuitRequested = quit
     member _.RequestQuit() = quit <- true
     member _.Token = CancellationToken.None
+    member _.EnterChild () = childRunning <- true
+    member _.ExitChild ()  = childRunning <- false
     member _.NewStreamCts() =
         let cts = new CancellationTokenSource()
         streamCts <- Some cts
@@ -216,8 +219,12 @@ type CancelSource() =
                 try cts.Cancel() with _ -> ()
                 a.Cancel <- true
             | None ->
-                quit <- true
-                a.Cancel <- true
+                if childRunning then
+                    // Child gets SIGINT via process group; suppress quit.
+                    a.Cancel <- true
+                else
+                    quit <- true
+                    a.Cancel <- true
     interface IDisposable with
         member _.Dispose() =
             streamCts |> Option.iter (fun c -> try c.Dispose() with _ -> ())
@@ -584,8 +591,16 @@ Please generate a clear, actionable onboarding checklist.""" (String.concat "\n\
                     StatusBar.refresh ()
             | Some s when s = "/new" ->
                 AnsiConsole.Clear()
-                let! newSession = agent.CreateSessionAsync(CancellationToken.None)
-                session <- newSession
+                match box session with
+                | :? IAsyncDisposable as d ->
+                    try do! d.DisposeAsync().AsTask() with _ -> ()
+                | _ -> ()
+                try
+                    let! newSession = agent.CreateSessionAsync(CancellationToken.None)
+                    session <- newSession
+                with ex ->
+                    AnsiConsole.Write(Render.errorLine strings ex.Message)
+                    AnsiConsole.WriteLine()
                 StatusBar.refresh ()
             | Some s when s.StartsWith "!" ->
                 let cmd = s.Substring(1).Trim()
@@ -602,12 +617,16 @@ Please generate a clear, actionable onboarding checklist.""" (String.concat "\n\
                     psi.UseShellExecute <- false
                     use proc = new System.Diagnostics.Process()
                     proc.StartInfo <- psi
+                    cancelSrc.EnterChild ()
                     try
-                        proc.Start() |> ignore
-                        proc.WaitForExit()
-                    with ex ->
-                        AnsiConsole.Write(Render.errorLine strings ex.Message)
-                        AnsiConsole.WriteLine()
+                        try
+                            proc.Start() |> ignore
+                            proc.WaitForExit()
+                        with ex ->
+                            AnsiConsole.Write(Render.errorLine strings ex.Message)
+                            AnsiConsole.WriteLine()
+                    finally
+                        cancelSrc.ExitChild ()
                 StatusBar.refresh ()
             | Some userInput ->
                 if ReadLine.hasZeroWidth userInput then

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -278,7 +278,8 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
     use cancelSrc = new CancelSource()
     let handler = ConsoleCancelEventHandler(fun _ args -> cancelSrc.OnCtrlC args)
     Console.CancelKeyPress.AddHandler handler
-    let! session = agent.CreateSessionAsync(CancellationToken.None)
+    let! initialSession = agent.CreateSessionAsync(CancellationToken.None)
+    let mutable session = initialSession
     let providerName, modelName = providerInfo cfg.Provider
     DebugLog.sessionStart providerName modelName cwd
     StatusBar.start cwd cfg
@@ -299,6 +300,7 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
                 let helpItems = [ "/help",           strings.CmdHelpDesc
                                   "/ask <q>",        strings.CmdAskDesc
                                   "/clear",          strings.CmdClearDesc
+                                  "/new",             strings.CmdNewDesc
                                   "/diff",           strings.CmdDiffDesc
                                   "/init",           strings.CmdInitDesc
                                   "/git-log",        strings.CmdGitLogDesc
@@ -580,6 +582,23 @@ Please generate a clear, actionable onboarding checklist.""" (String.concat "\n\
                     AnsiConsole.WriteLine()
                     do! streamAndRender agent session initPrompt cfg cancelSrc
                     StatusBar.refresh ()
+            | Some s when s = "/new" ->
+                AnsiConsole.Clear()
+                let! newSession = agent.CreateSessionAsync(CancellationToken.None)
+                session <- newSession
+                StatusBar.refresh ()
+            | Some s when s.StartsWith "!" ->
+                let cmd = s.Substring(1).Trim()
+                if not (String.IsNullOrWhiteSpace cmd) then
+                    let psi = System.Diagnostics.ProcessStartInfo()
+                    psi.FileName <- "/bin/zsh"
+                    psi.Arguments <- "-lc " + cmd
+                    psi.UseShellExecute <- false
+                    use proc = new System.Diagnostics.Process()
+                    proc.StartInfo <- psi
+                    proc.Start() |> ignore
+                    proc.WaitForExit()
+                StatusBar.refresh ()
             | Some userInput ->
                 if ReadLine.hasZeroWidth userInput then
                     AnsiConsole.Write(Markup("[dim yellow]" + Markup.Escape strings.ZeroWidthWarning + "[/]"))

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -286,7 +286,7 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
     let handler = ConsoleCancelEventHandler(fun _ args -> cancelSrc.OnCtrlC args)
     Console.CancelKeyPress.AddHandler handler
     let! initialSession = agent.CreateSessionAsync(CancellationToken.None)
-    let mutable session = initialSession
+    let mutable session : AgentSession | null = initialSession
     let providerName, modelName = providerInfo cfg.Provider
     DebugLog.sessionStart providerName modelName cwd
     StatusBar.start cwd cfg
@@ -294,7 +294,8 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
     let strings = pick cfg.Ui.Locale
     try
         while not cancelSrc.QuitRequested do
-            let! lineOpt = ReadLine.readAsync (Render.prompt cwd) strings cancelSrc.Token
+            let callbacks : ReadLine.ReadLineCallbacks = { OnClearScreen = StatusBar.refresh }
+            let! lineOpt = ReadLine.readAsync (Render.prompt cwd) strings callbacks cancelSrc.Token
             match lineOpt with
             | None ->
                 cancelSrc.RequestQuit()
@@ -599,6 +600,7 @@ Please generate a clear, actionable onboarding checklist.""" (String.concat "\n\
                     let! newSession = agent.CreateSessionAsync(CancellationToken.None)
                     session <- newSession
                 with ex ->
+                    session <- null
                     AnsiConsole.Write(Render.errorLine strings ex.Message)
                     AnsiConsole.WriteLine()
                 StatusBar.refresh ()
@@ -615,9 +617,11 @@ Please generate a clear, actionable onboarding checklist.""" (String.concat "\n\
                     psi.ArgumentList.Add "-c"
                     psi.ArgumentList.Add cmd
                     psi.UseShellExecute <- false
+                    psi.WorkingDirectory <- cwd
                     use proc = new System.Diagnostics.Process()
                     proc.StartInfo <- psi
                     cancelSrc.EnterChild ()
+                    StatusBar.stop ()
                     try
                         try
                             proc.Start() |> ignore
@@ -627,6 +631,7 @@ Please generate a clear, actionable onboarding checklist.""" (String.concat "\n\
                             AnsiConsole.WriteLine()
                     finally
                         cancelSrc.ExitChild ()
+                        StatusBar.start cwd cfg
                 StatusBar.refresh ()
             | Some userInput ->
                 if ReadLine.hasZeroWidth userInput then

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -590,14 +590,24 @@ Please generate a clear, actionable onboarding checklist.""" (String.concat "\n\
             | Some s when s.StartsWith "!" ->
                 let cmd = s.Substring(1).Trim()
                 if not (String.IsNullOrWhiteSpace cmd) then
+                    let shell =
+                        System.Environment.GetEnvironmentVariable "SHELL"
+                        |> Option.ofObj
+                        |> Option.filter (fun s -> s <> "")
+                        |> Option.defaultValue "/bin/sh"
                     let psi = System.Diagnostics.ProcessStartInfo()
-                    psi.FileName <- "/bin/zsh"
-                    psi.Arguments <- "-lc " + cmd
+                    psi.FileName <- shell
+                    psi.ArgumentList.Add "-c"
+                    psi.ArgumentList.Add cmd
                     psi.UseShellExecute <- false
                     use proc = new System.Diagnostics.Process()
                     proc.StartInfo <- psi
-                    proc.Start() |> ignore
-                    proc.WaitForExit()
+                    try
+                        proc.Start() |> ignore
+                        proc.WaitForExit()
+                    with ex ->
+                        AnsiConsole.Write(Render.errorLine strings ex.Message)
+                        AnsiConsole.WriteLine()
                 StatusBar.refresh ()
             | Some userInput ->
                 if ReadLine.hasZeroWidth userInput then

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -27,6 +27,7 @@ type Strings =
       // Slash commands
       CmdHelpDesc:       string
       CmdClearDesc:      string
+      CmdNewDesc:        string
       CmdExitDesc:       string
       CmdModelDesc:      string
       CmdReviewPrDesc:   string
@@ -92,6 +93,7 @@ let en : Strings =
       DiscoveryPickProvider = "Pick a provider:"
       CmdHelpDesc           = "show this help"
       CmdClearDesc          = "clear the screen"
+      CmdNewDesc            = "start fresh conversation (new session)"
       CmdExitDesc           = "exit Fugue"
       CmdModelDesc          = "suggest best model for current task"
       CmdReviewPrDesc       = "fetch PR diff and generate AI review"
@@ -137,6 +139,7 @@ let ru : Strings =
       DiscoveryPickProvider = "Выберите провайдер:"
       CmdHelpDesc           = "показать эту справку"
       CmdClearDesc          = "очистить экран"
+      CmdNewDesc            = "начать новый разговор (новая сессия)"
       CmdExitDesc           = "выйти из Fugue"
       CmdModelDesc          = "рекомендовать лучшую модель для текущей задачи"
       CmdReviewPrDesc       = "получить diff PR и сгенерировать AI-ревью"

--- a/tests/Fugue.Tests/ReadLineTests.fs
+++ b/tests/Fugue.Tests/ReadLineTests.fs
@@ -154,6 +154,13 @@ let ``slash buffer prefix is recognized for hint rendering`` () =
     s.Buffer.Count |> should equal 1
     s.Buffer.[0] |> should equal '/'
 
+[<Fact>]
+let ``CtrlL_returns_ClearScreen`` () =
+    let s = mkState "hello" 3
+    let act = applyKey (special ConsoleKey.L ConsoleModifiers.Control) s
+    act |> should equal ClearScreen
+    s.ExitArmed |> should equal false
+
 // ── History tests ─────────────────────────────────────────────────────────────
 
 [<Fact>]


### PR DESCRIPTION
## Summary

- **Ctrl+L** — clear screen without losing prompt state; refreshes status bar
- **/new** — start a fresh conversation session (disposes old session, creates new `AgentSession`, null-safe)
- **!cmd** — run shell commands directly from the REPL prompt (uses `$SHELL -c`, `ArgumentList`, cwd-aware, scroll-region-safe)
- Adds `CmdNewDesc` locale string (en + ru)
- `/new` added to tab-completion and `/help` display

## Notes

Clean cherry-picks of 4 commits (`ebdcb1b` → `e0ba3a3` → `7438356` → `b56504c`) from superseded PR #221 onto current main. Tests: 228/228 pass. AOT: clean.

Closes #79 · Closes #78 · Closes #5