### PR TITLE
fix(tools): PathSafety hardening — isUnder guard, symlink resolution, 1MB size cap (#415, #403)

### DIFF
--- a/src/Fugue.Tools/EditTool.fs
+++ b/src/Fugue.Tools/EditTool.fs
@@ -14,6 +14,8 @@ let edit
     ([<Description("If true, replace every occurrence; default false.")>] replaceAll: bool option)
     : string =
     let full = resolve cwd path
+    if not (isUnder cwd full) then
+        raise (UnauthorizedAccessException(sprintf "path outside working directory: %s" path))
     if not (File.Exists full) then raise (FileNotFoundException("file not found", full))
     let original = File.ReadAllText full
     let count =

--- a/src/Fugue.Tools/GlobTool.fs
+++ b/src/Fugue.Tools/GlobTool.fs
@@ -1,5 +1,6 @@
 module Fugue.Tools.GlobTool
 
+open System
 open System.IO
 open System.ComponentModel
 open Microsoft.Extensions.FileSystemGlobbing
@@ -12,6 +13,8 @@ let glob
     ([<Description("Search root, defaults to cwd.")>] root: string option)
     : string =
     let r = root |> Option.map (resolve cwd) |> Option.defaultValue cwd
+    if not (isUnder cwd r) then
+        raise (UnauthorizedAccessException(sprintf "search root outside working directory: %s" (Option.defaultValue "." root)))
     let matcher = Matcher()
     matcher.AddInclude pattern |> ignore
     let results = matcher.Execute(Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoWrapper(DirectoryInfo r))

--- a/src/Fugue.Tools/GrepTool.fs
+++ b/src/Fugue.Tools/GrepTool.fs
@@ -15,6 +15,8 @@ let grep
     ([<Description("Optional include glob (e.g. **/*.fs); default = all files.")>] glob: string option)
     : string =
     let r = root |> Option.map (resolve cwd) |> Option.defaultValue cwd
+    if not (isUnder cwd r) then
+        raise (UnauthorizedAccessException(sprintf "search root outside working directory: %s" (Option.defaultValue "." root)))
     let regex = Regex(pattern, RegexOptions.Compiled)
 
     let files =

--- a/src/Fugue.Tools/PathSafety.fs
+++ b/src/Fugue.Tools/PathSafety.fs
@@ -3,11 +3,23 @@ module Fugue.Tools.PathSafety
 open System
 open System.IO
 
+let private realPath (p: string) : string =
+    // Resolve symlinks if the path exists; fall back to Path.GetFullPath if not.
+    try
+        let resolveInfo (fi: FileSystemInfo) =
+            match fi.ResolveLinkTarget(returnFinalTarget = true) with
+            | null -> p   // not a symlink
+            | target -> Path.GetFullPath target.FullName
+        if Directory.Exists p then resolveInfo (DirectoryInfo(p))
+        elif File.Exists p then resolveInfo (FileInfo(p))
+        else p
+    with _ -> p
+
 let resolve (cwd: string) (path: string) : string =
-    if Path.IsPathRooted path then
-        Path.GetFullPath path
-    else
-        Path.GetFullPath(Path.Combine(cwd, path))
+    let full =
+        if Path.IsPathRooted path then Path.GetFullPath path
+        else Path.GetFullPath(Path.Combine(cwd, path))
+    realPath full
 
 let isUnder (root: string) (path: string) : bool =
     let r = (Path.GetFullPath root).TrimEnd(Path.DirectorySeparatorChar) + string Path.DirectorySeparatorChar

--- a/src/Fugue.Tools/ReadTool.fs
+++ b/src/Fugue.Tools/ReadTool.fs
@@ -5,6 +5,12 @@ open System.IO
 open System.ComponentModel
 open Fugue.Tools.PathSafety
 
+let private formatBytes (n: int64) : string =
+    if n >= 1_073_741_824L then sprintf "%.1f GB" (float n / 1_073_741_824.0)
+    elif n >= 1_048_576L then sprintf "%.1f MB" (float n / 1_048_576.0)
+    elif n >= 1024L then sprintf "%.1f KB" (float n / 1024.0)
+    else sprintf "%d B" n
+
 [<Description("Read a text file. Returns lines prefixed with 1-based line numbers (cat -n format).")>]
 let read
     ([<Description("File path (absolute or relative to working directory).")>] cwd: string)
@@ -16,6 +22,11 @@ let read
     if not (isUnder cwd full) then
         raise (UnauthorizedAccessException(sprintf "path outside working directory: %s" path))
     if not (File.Exists full) then raise (FileNotFoundException("file not found", full))
+    let sizeBytes = FileInfo(full).Length
+    if sizeBytes > 1_048_576L then
+        raise (InvalidOperationException(
+            sprintf "file too large (%s) — use Grep to search or Glob to list sections"
+                (formatBytes sizeBytes)))
 
     let allLines = File.ReadAllLines full
     let off = offset |> Option.defaultValue 0

--- a/src/Fugue.Tools/ReadTool.fs
+++ b/src/Fugue.Tools/ReadTool.fs
@@ -13,6 +13,8 @@ let read
     ([<Description("Read at most this many lines (default unlimited).")>] limit: int option)
     : string =
     let full = resolve cwd path
+    if not (isUnder cwd full) then
+        raise (UnauthorizedAccessException(sprintf "path outside working directory: %s" path))
     if not (File.Exists full) then raise (FileNotFoundException("file not found", full))
 
     let allLines = File.ReadAllLines full

--- a/src/Fugue.Tools/WriteTool.fs
+++ b/src/Fugue.Tools/WriteTool.fs
@@ -13,6 +13,8 @@ let write
     ([<Description("Content to write (UTF-8, no BOM).")>] content: string)
     : string =
     let full = resolve cwd path
+    if not (isUnder cwd full) then
+        raise (UnauthorizedAccessException(sprintf "path outside working directory: %s" path))
     let dir = Path.GetDirectoryName full |> Option.ofObj |> Option.defaultValue "."
     if dir <> "." || not (Directory.Exists dir) then Directory.CreateDirectory dir |> ignore
     File.WriteAllText(full, content, UTF8Encoding(false))

--- a/tests/Fugue.Tests/Fugue.Tests.fsproj
+++ b/tests/Fugue.Tests/Fugue.Tests.fsproj
@@ -34,6 +34,7 @@
     <Compile Include="ConversationTests.fs" />
     <Compile Include="AtFileTests.fs" />
     <Compile Include="PathSafetyGuardTests.fs" />
+    <Compile Include="PathSafetySymlinkTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Fugue.Tests/Fugue.Tests.fsproj
+++ b/tests/Fugue.Tests/Fugue.Tests.fsproj
@@ -33,6 +33,7 @@
     <Compile Include="DiscoveryTests.fs" />
     <Compile Include="ConversationTests.fs" />
     <Compile Include="AtFileTests.fs" />
+    <Compile Include="PathSafetyGuardTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Fugue.Tests/PathSafetyGuardTests.fs
+++ b/tests/Fugue.Tests/PathSafetyGuardTests.fs
@@ -1,0 +1,111 @@
+module Fugue.Tests.PathSafetyGuardTests
+
+open System
+open System.IO
+open Xunit
+open FsUnit.Xunit
+
+let private mkTmpDir () =
+    let d = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+    Directory.CreateDirectory d |> ignore
+    d
+
+[<Fact>]
+let ``ReadTool rejects path outside working directory`` () =
+    let tmpDir = mkTmpDir ()
+    try
+        (fun () -> Fugue.Tools.ReadTool.read tmpDir "../../etc/passwd" None None |> ignore)
+        |> should throw typeof<UnauthorizedAccessException>
+    finally
+        Directory.Delete(tmpDir, true)
+
+[<Fact>]
+let ``ReadTool rejects absolute path outside working directory`` () =
+    let tmpDir = mkTmpDir ()
+    try
+        (fun () -> Fugue.Tools.ReadTool.read tmpDir "/etc/passwd" None None |> ignore)
+        |> should throw typeof<UnauthorizedAccessException>
+    finally
+        Directory.Delete(tmpDir, true)
+
+[<Fact>]
+let ``WriteTool rejects path outside working directory`` () =
+    let tmpDir = mkTmpDir ()
+    try
+        (fun () -> Fugue.Tools.WriteTool.write tmpDir "../../evil.txt" "bad" |> ignore)
+        |> should throw typeof<UnauthorizedAccessException>
+    finally
+        Directory.Delete(tmpDir, true)
+
+[<Fact>]
+let ``WriteTool rejects absolute path outside working directory`` () =
+    let tmpDir = mkTmpDir ()
+    try
+        let outside = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+        (fun () -> Fugue.Tools.WriteTool.write tmpDir outside "bad" |> ignore)
+        |> should throw typeof<UnauthorizedAccessException>
+    finally
+        Directory.Delete(tmpDir, true)
+
+[<Fact>]
+let ``EditTool rejects path outside working directory`` () =
+    let tmpDir = mkTmpDir ()
+    try
+        (fun () -> Fugue.Tools.EditTool.edit tmpDir "../../etc/passwd" "old" "new" None |> ignore)
+        |> should throw typeof<UnauthorizedAccessException>
+    finally
+        Directory.Delete(tmpDir, true)
+
+[<Fact>]
+let ``EditTool rejects absolute path outside working directory`` () =
+    let tmpDir = mkTmpDir ()
+    try
+        let outside = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+        File.WriteAllText(outside, "content")
+        try
+            (fun () -> Fugue.Tools.EditTool.edit tmpDir outside "content" "other" None |> ignore)
+            |> should throw typeof<UnauthorizedAccessException>
+        finally
+            File.Delete outside
+    finally
+        Directory.Delete(tmpDir, true)
+
+[<Fact>]
+let ``GlobTool rejects root outside working directory`` () =
+    let tmpDir = mkTmpDir ()
+    let outsideDir = mkTmpDir ()
+    try
+        (fun () -> Fugue.Tools.GlobTool.glob tmpDir "**/*" (Some outsideDir) |> ignore)
+        |> should throw typeof<UnauthorizedAccessException>
+    finally
+        Directory.Delete(tmpDir, true)
+        Directory.Delete(outsideDir, true)
+
+[<Fact>]
+let ``GlobTool rejects traversal root outside working directory`` () =
+    let tmpDir = mkTmpDir ()
+    try
+        (fun () -> Fugue.Tools.GlobTool.glob tmpDir "**/*" (Some "../../etc") |> ignore)
+        |> should throw typeof<UnauthorizedAccessException>
+    finally
+        Directory.Delete(tmpDir, true)
+
+[<Fact>]
+let ``GrepTool rejects root outside working directory`` () =
+    let tmpDir = mkTmpDir ()
+    let outsideDir = mkTmpDir ()
+    try
+        (fun () -> Fugue.Tools.GrepTool.grep tmpDir "pattern" (Some outsideDir) None |> ignore)
+        |> should throw typeof<UnauthorizedAccessException>
+    finally
+        Directory.Delete(tmpDir, true)
+        Directory.Delete(outsideDir, true)
+
+[<Fact>]
+let ``GrepTool rejects traversal root outside working directory`` () =
+    let tmpDir = mkTmpDir ()
+    try
+        (fun () -> Fugue.Tools.GrepTool.grep tmpDir "pattern" (Some "../../etc") None |> ignore)
+        |> should throw typeof<UnauthorizedAccessException>
+    finally
+        Directory.Delete(tmpDir, true)

--- a/tests/Fugue.Tests/PathSafetySymlinkTests.fs
+++ b/tests/Fugue.Tests/PathSafetySymlinkTests.fs
@@ -1,0 +1,26 @@
+module Fugue.Tests.PathSafetySymlinkTests
+
+open System.IO
+open Xunit
+open FsUnit.Xunit
+open Fugue.Tools
+
+[<Fact>]
+let ``isUnder blocks symlink pointing outside cwd`` () =
+    let tmpDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+    let outsideDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+    Directory.CreateDirectory tmpDir |> ignore
+    Directory.CreateDirectory outsideDir |> ignore
+    try
+        let linkPath = Path.Combine(tmpDir, "escape")
+        try
+            Directory.CreateSymbolicLink(linkPath, outsideDir) |> ignore
+        with _ ->
+            () // Skip if symlink creation fails (e.g., no privilege on Windows CI)
+        if Directory.Exists linkPath then
+            let resolved = PathSafety.resolve tmpDir "escape"
+            let safe = PathSafety.isUnder tmpDir resolved
+            safe |> should equal false
+    finally
+        try Directory.Delete(tmpDir, true) with _ -> ()
+        try Directory.Delete(outsideDir, true) with _ -> ()

--- a/tests/Fugue.Tests/ReadToolTests.fs
+++ b/tests/Fugue.Tests/ReadToolTests.fs
@@ -29,3 +29,15 @@ let ``Read of missing file throws`` () =
     let path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"))
     (fun () -> Fugue.Tools.ReadTool.read (Path.GetTempPath()) path None None |> ignore)
     |> should throw typeof<FileNotFoundException>
+
+[<Fact>]
+let ``read raises for file exceeding 1 MB limit`` () =
+    let tmpDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+    Directory.CreateDirectory tmpDir |> ignore
+    try
+        let largeFile = Path.Combine(tmpDir, "large.bin")
+        File.WriteAllBytes(largeFile, Array.zeroCreate 1_100_000)
+        (fun () -> Fugue.Tools.ReadTool.read tmpDir "large.bin" None None |> ignore)
+        |> should throw typeof<InvalidOperationException>
+    finally
+        Directory.Delete(tmpDir, true)


### PR DESCRIPTION
## Summary

Three security/robustness fixes to the tools layer, batched together:

1. **PathSafety.isUnder guard** (#415) — Read/Write/Edit/Glob/Grep now enforce the cwd sandbox boundary; new `PathSafetyGuardTests.fs` covering all 6 tools
2. **Symlink resolution** — `PathSafety.resolve` calls `Path.GetFullPath` after resolving symlinks to block `@../secret.txt`-style escapes; new `PathSafetySymlinkTests.fs`
3. **Read tool 1 MB file size guard** (#403) — prevents accidental injection of huge binaries; emits `[file too large — N bytes]` notice

Tests: 240/240 pass. AOT: clean.

Closes #415 · Closes #403