### PR TITLE
feat(cli): batch 3 — NO_COLOR, maxTokens, elapsed time, turn numbers, placeholder, structured errors

### DIFF
--- a/src/Fugue.Agent/AgentFactory.fs
+++ b/src/Fugue.Agent/AgentFactory.fs
@@ -10,7 +10,8 @@ open global.Anthropic
 
 /// Build an AIAgent (with system prompt and tools wired in) for the given provider.
 /// `configBaseUrl` is from ~/.fugue/config.json; env vars win if both are set.
-let create (provider: ProviderConfig) (configBaseUrl: string option) (systemPrompt: string) (tools: AIFunction list) : AIAgent =
+/// `maxTokens` caps completion tokens per request (None = provider default).
+let create (provider: ProviderConfig) (configBaseUrl: string option) (maxTokens: int option) (systemPrompt: string) (tools: AIFunction list) : AIAgent =
     let toolList : System.Collections.Generic.IList<AITool> =
         ResizeArray<AITool>(tools |> List.map (fun t -> t :> AITool))
 
@@ -18,6 +19,12 @@ let create (provider: ProviderConfig) (configBaseUrl: string option) (systemProm
         match Environment.GetEnvironmentVariable envVar with
         | null | "" -> configBaseUrl
         | url       -> Some url
+
+    // Build ChatClientAgentOptions with optional MaxOutputTokens for providers that use IChatClient.AsAIAgent.
+    let makeAgentOpts () : ChatClientAgentOptions =
+        let chatOpts = ChatOptions(Instructions = systemPrompt, Tools = toolList)
+        maxTokens |> Option.iter (fun t -> chatOpts.MaxOutputTokens <- Nullable t)
+        ChatClientAgentOptions(Name = "Fugue", ChatOptions = chatOpts)
 
     match provider with
     | Anthropic(apiKey, model) ->
@@ -32,7 +39,8 @@ let create (provider: ProviderConfig) (configBaseUrl: string option) (systemProm
             instructions = systemPrompt,
             name = "Fugue",
             description = null,
-            tools = toolList)
+            tools = toolList,
+            defaultMaxTokens = (maxTokens |> Option.map Nullable |> Option.defaultValue (Nullable())))
 
     | OpenAI(apiKey, model) ->
         // OPENAI_BASE_URL (env) or config baseUrl allows pointing at OpenAI-compat servers.
@@ -41,17 +49,8 @@ let create (provider: ProviderConfig) (configBaseUrl: string option) (systemProm
             match resolvedBase "OPENAI_BASE_URL" with
             | None     -> new OpenAI.OpenAIClient(cred)
             | Some url -> new OpenAI.OpenAIClient(cred, OpenAI.OpenAIClientOptions(Endpoint = Uri url))
-        let chatClient = openAi.GetChatClient(model).AsIChatClient()
-        chatClient.AsAIAgent(
-            instructions = systemPrompt,
-            name = "Fugue",
-            description = null,
-            tools = toolList)
+        openAi.GetChatClient(model).AsIChatClient().AsAIAgent(makeAgentOpts ())
 
     | Ollama(endpoint, model) ->
         let ollama = new OllamaSharp.OllamaApiClient(endpoint, model)
-        (ollama :> IChatClient).AsAIAgent(
-            instructions = systemPrompt,
-            name = "Fugue",
-            description = null,
-            tools = toolList)
+        (ollama :> IChatClient).AsAIAgent(makeAgentOpts ())

--- a/src/Fugue.Cli/Program.fs
+++ b/src/Fugue.Cli/Program.fs
@@ -6,6 +6,11 @@ open Microsoft.Agents.AI
 open Fugue.Core.Config
 open Fugue.Agent
 
+let private noColor () =
+    let isSet name = Environment.GetEnvironmentVariable name |> isNull |> not
+    isSet "NO_COLOR" || isSet "FUGUE_NO_COLOR"
+    || Environment.GetEnvironmentVariable "TERM" = "dumb"
+
 let private buildAgent (cfg: AppConfig) : AIAgent =
     let cwd = Environment.CurrentDirectory
     let tools = Fugue.Tools.ToolRegistry.buildAll cwd
@@ -24,6 +29,7 @@ let private buildAgent (cfg: AppConfig) : AIAgent =
 [<RequiresUnreferencedCode("Calls Repl.run and Config.saveToFile which use STJ reflection; System.Text.Json is TrimmerRootAssembly")>]
 [<RequiresDynamicCode("Calls Repl.run and Config.saveToFile which use STJ reflection; System.Text.Json is TrimmerRootAssembly")>]
 let private runWithCfg (cfg: AppConfig) : int =
+    Render.initColor (not (noColor ()))
     let agent = buildAgent cfg
     let cwd = Environment.CurrentDirectory
     let t = Repl.run agent cfg cwd

--- a/src/Fugue.Cli/Program.fs
+++ b/src/Fugue.Cli/Program.fs
@@ -24,7 +24,7 @@ let private buildAgent (cfg: AppConfig) : AIAgent =
         match cfg.ProfileContent with
         | Some profile -> profile + "\n\n---\n\n" + basePrompt
         | None -> basePrompt
-    AgentFactory.create cfg.Provider cfg.BaseUrl sysPrompt tools
+    AgentFactory.create cfg.Provider cfg.BaseUrl cfg.MaxTokens sysPrompt tools
 
 [<RequiresUnreferencedCode("Calls Repl.run and Config.saveToFile which use STJ reflection; System.Text.Json is TrimmerRootAssembly")>]
 [<RequiresDynamicCode("Calls Repl.run and Config.saveToFile which use STJ reflection; System.Text.Json is TrimmerRootAssembly")>]
@@ -73,7 +73,7 @@ let main argv =
                     let m = if List.isEmpty models then "llama3.1" else List.head models
                     Ollama(ep, m)
                 | _ -> failwith "unsupported candidate"
-            let cfg = { Provider = provider; SystemPrompt = None; ProfileContent = profileContent; MaxIterations = 30; Ui = Fugue.Core.Config.defaultUi (); BaseUrl = None }
+            let cfg = { Provider = provider; SystemPrompt = None; ProfileContent = profileContent; MaxIterations = 30; MaxTokens = None; Ui = Fugue.Core.Config.defaultUi (); BaseUrl = None }
             Fugue.Core.Config.saveToFile cfg
             runWithCfg cfg
         | None ->

--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -72,6 +72,8 @@ type S = {
     PromptText:              string
     PromptVisLen:            int
     HintWhenArmed:           string
+    Placeholder:             string
+    ColorEnabled:            bool
     Width:                   int
     SlashHelp:               (string * string) list  // (name, dim description) pairs
 }
@@ -330,6 +332,11 @@ let private redraw (st: S) =
     writeRaw st.PromptText
     let bufStr = String(st.Buffer.ToArray())
     writeRaw bufStr
+    // 2b. if buffer is empty and color is on, write dim placeholder then move cursor back
+    if st.Buffer.Count = 0 && st.Placeholder <> "" && st.ColorEnabled then
+        writeRaw ("\x1b[2m" + st.Placeholder + "\x1b[0m")
+        // move cursor back to right after the prompt (col = PromptVisLen)
+        writeRaw ("\r\x1b[" + string st.PromptVisLen + "C")
     // 3. count rendered terminal lines (= 1 + number of '\n' in buffer)
     let newlines = bufStr |> Seq.filter (fun c -> c = '\n') |> Seq.length
     st.LinesRendered <- 1 + newlines
@@ -365,7 +372,7 @@ let private redraw (st: S) =
     else writeRaw "\r"
     st.RowsBelowCursor <- upBy   // save for next redraw's erase pass
 
-let readAsync (prompt: string) (strings: Strings) (callbacks: ReadLineCallbacks) (ct: CancellationToken) : Task<string option> = task {
+let readAsync (prompt: string) (strings: Strings) (callbacks: ReadLineCallbacks) (colorEnabled: bool) (ct: CancellationToken) : Task<string option> = task {
     // Strip ANSI escapes for visible-length calc (rough — assumes only \x1b[...m sequences).
     let visLen =
         let mutable n = 0
@@ -403,6 +410,8 @@ let readAsync (prompt: string) (strings: Strings) (callbacks: ReadLineCallbacks)
           PromptText      = prompt
           PromptVisLen    = visLen
           HintWhenArmed   = strings.ExitHint
+          Placeholder     = strings.InputPlaceholder
+          ColorEnabled    = colorEnabled
           Width           = max 40 Console.WindowWidth
           SlashHelp       = slashHelp }
 

--- a/src/Fugue.Cli/Render.fs
+++ b/src/Fugue.Cli/Render.fs
@@ -11,18 +11,28 @@ type ToolState =
     | Completed of name: string * args: string * output: string
     | Failed    of name: string * args: string * err: string
 
+let mutable private colorEnabled = true
+
+let initColor (enabled: bool) =
+    colorEnabled <- enabled
+
+let isColorEnabled () = colorEnabled
+
 /// Path-aware prompt string for ReadLine. Just visible chars; ANSI not added here
 /// because Console.WriteLine inside ReadLine doesn't go through Spectre.
 let prompt (_cwd: string) : string = "› "
 
 let userMessage (ui: UiConfig) (text: string) : IRenderable =
-    let escaped = Markup.Escape text
-    match ui.UserAlignment with
-    | Left ->
-        Markup(sprintf "[grey]›[/] %s" escaped) :> _
-    | Right ->
-        let bubble = Padder(Markup(escaped)).PadLeft(2).PadRight(2) :> IRenderable
-        Align(bubble, HorizontalAlignment.Right) :> _
+    if colorEnabled then
+        let escaped = Markup.Escape text
+        match ui.UserAlignment with
+        | Left ->
+            Markup(sprintf "[grey]›[/] %s" escaped) :> _
+        | Right ->
+            let bubble = Padder(Markup(escaped)).PadLeft(2).PadRight(2) :> IRenderable
+            Align(bubble, HorizontalAlignment.Right) :> _
+    else
+        Text(sprintf "> %s" text) :> _
 
 /// Plain assistant text during streaming (no markdown parse — buffer is partial).
 let assistantLive (text: string) : IRenderable =
@@ -30,13 +40,20 @@ let assistantLive (text: string) : IRenderable =
 
 /// Final assistant text rendered as markdown.
 let assistantFinal (text: string) : IRenderable =
-    MarkdownRender.toRenderable text
+    if colorEnabled then MarkdownRender.toRenderable text
+    else Text(text) :> _
 
 let cancelled (s: Strings) : IRenderable =
-    Markup(sprintf "[yellow]⚠ %s[/]" (Markup.Escape s.Cancelled)) :> _
+    if colorEnabled then
+        Markup(sprintf "[yellow]⚠ %s[/]" (Markup.Escape s.Cancelled)) :> _
+    else
+        Text(s.Cancelled) :> _
 
 let errorLine (s: Strings) (msg: string) : IRenderable =
-    Markup(sprintf "[red]⚠ %s:[/] %s" (Markup.Escape s.ErrorPrefix) (Markup.Escape msg)) :> _
+    if colorEnabled then
+        Markup(sprintf "[red]⚠ %s:[/] %s" (Markup.Escape s.ErrorPrefix) (Markup.Escape msg)) :> _
+    else
+        Text(sprintf "%s: %s" s.ErrorPrefix msg) :> _
 
 let private termWidth () =
     let w = Console.WindowWidth
@@ -57,43 +74,62 @@ let private softWrap (width: int) (line: string) : string list =
         result
 
 let private renderToolBody (output: string) : IRenderable =
-    if DiffRender.looksLikeDiff output then DiffRender.toRenderable output
-    elif output.Contains "```" || output.Contains "**" || output.StartsWith "#" then
-        MarkdownRender.toRenderable output
+    if colorEnabled then
+        if DiffRender.looksLikeDiff output then DiffRender.toRenderable output
+        elif output.Contains "```" || output.Contains "**" || output.StartsWith "#" then
+            MarkdownRender.toRenderable output
+        else
+            // dim plain text, indented
+            let lines = output.Split('\n')
+            let trimmed =
+                if lines.Length > 12 then
+                    Array.append (Array.truncate 12 lines)
+                        [| "+ " + string (lines.Length - 12) + " more lines" |]
+                else lines
+            let rows =
+                trimmed
+                |> Array.map (fun l ->
+                    Markup(sprintf "[dim]%s[/]" (Markup.Escape l)) :> IRenderable)
+            Padder(Rows(rows)).PadLeft(2) :> _
     else
-        // dim plain text, indented
         let lines = output.Split('\n')
         let trimmed =
             if lines.Length > 12 then
                 Array.append (Array.truncate 12 lines)
                     [| "+ " + string (lines.Length - 12) + " more lines" |]
             else lines
-        let w = termWidth ()
-        let rows =
-            trimmed
-            |> Array.collect (fun l -> softWrap w l |> List.toArray)
-            |> Array.map (fun l ->
-                Markup(sprintf "[dim]%s[/]" (Markup.Escape l)) :> IRenderable)
-        Padder(Rows(rows)).PadLeft(2) :> _
+        Padder(Rows(trimmed |> Array.map (fun l -> Text(l) :> IRenderable))).PadLeft(2) :> _
 
 let toolBullet (s: Strings) (state: ToolState) : IRenderable =
-    match state with
-    | Running(name, args) ->
-        let header =
-            sprintf "[yellow]●[/] [bold]%s[/]([dim]%s[/])"
-                (Markup.Escape name) (Markup.Escape args)
-        let body =
-            Padder(Markup(sprintf "[dim]%s[/]" (Markup.Escape s.ToolRunning))).PadLeft(2)
-        Rows([ Markup(header) :> IRenderable; body :> _ ]) :> _
-    | Completed(name, args, output) ->
-        let header =
-            sprintf "[green]●[/] [bold]%s[/]([dim]%s[/])"
-                (Markup.Escape name) (Markup.Escape args)
-        Rows([ Markup(header) :> IRenderable; renderToolBody output ]) :> _
-    | Failed(name, args, err) ->
-        let header =
-            sprintf "[red]●[/] [bold]%s[/]([dim]%s[/])"
-                (Markup.Escape name) (Markup.Escape args)
-        let body =
-            Padder(Markup(sprintf "[red]%s[/]" (Markup.Escape err))).PadLeft(2)
-        Rows([ Markup(header) :> IRenderable; body :> _ ]) :> _
+    if colorEnabled then
+        match state with
+        | Running(name, args) ->
+            let header =
+                sprintf "[yellow]●[/] [bold]%s[/]([dim]%s[/])"
+                    (Markup.Escape name) (Markup.Escape args)
+            let body =
+                Padder(Markup(sprintf "[dim]%s[/]" (Markup.Escape s.ToolRunning))).PadLeft(2)
+            Rows([ Markup(header) :> IRenderable; body :> _ ]) :> _
+        | Completed(name, args, output) ->
+            let header =
+                sprintf "[green]●[/] [bold]%s[/]([dim]%s[/])"
+                    (Markup.Escape name) (Markup.Escape args)
+            Rows([ Markup(header) :> IRenderable; renderToolBody output ]) :> _
+        | Failed(name, args, err) ->
+            let header =
+                sprintf "[red]●[/] [bold]%s[/]([dim]%s[/])"
+                    (Markup.Escape name) (Markup.Escape args)
+            let body =
+                Padder(Markup(sprintf "[red]%s[/]" (Markup.Escape err))).PadLeft(2)
+            Rows([ Markup(header) :> IRenderable; body :> _ ]) :> _
+    else
+        match state with
+        | Running(name, args) ->
+            Rows([ Text(sprintf "* %s(%s)" name args) :> IRenderable
+                   Padder(Text(s.ToolRunning)).PadLeft(2) :> _ ]) :> _
+        | Completed(name, args, output) ->
+            Rows([ Text(sprintf "* %s(%s)" name args) :> IRenderable
+                   renderToolBody output ]) :> _
+        | Failed(name, args, err) ->
+            Rows([ Text(sprintf "* %s(%s)" name args) :> IRenderable
+                   Padder(Text(sprintf "Error: %s" err)).PadLeft(2) :> _ ]) :> _

--- a/src/Fugue.Cli/Render.fs
+++ b/src/Fugue.Cli/Render.fs
@@ -108,6 +108,22 @@ let private renderToolBody (output: string) : IRenderable =
             else lines
         Padder(Rows(trimmed |> Array.map (fun l -> Text(l) :> IRenderable))).PadLeft(2) :> _
 
+/// Extract the first readable line from a raw error string, suppressing .NET stack frames.
+let private summarizeToolError (raw: string) : string =
+    let lines = raw.Split('\n')
+    let headline =
+        lines
+        |> Array.tryFind (fun l ->
+            let t = l.TrimStart()
+            t.Length > 0
+            && not (t.StartsWith("at "))
+            && not (t.StartsWith("--- End of"))
+            && not (t.StartsWith("System."))
+            && not (t.StartsWith("Microsoft.")))
+        |> Option.defaultWith (fun () ->
+            lines |> Array.tryFind (fun l -> l.TrimStart().Length > 0) |> Option.defaultValue raw)
+    if headline.Length > 120 then headline.[..116] + " …" else headline
+
 let toolBullet (s: Strings) (state: ToolState) : IRenderable =
     if colorEnabled then
         match state with
@@ -128,7 +144,7 @@ let toolBullet (s: Strings) (state: ToolState) : IRenderable =
                 sprintf "[red]●[/] [bold]%s[/]([dim]%s[/]) [dim]%s[/]"
                     (Markup.Escape name) (Markup.Escape args) (formatElapsed elapsed)
             let body =
-                Padder(Markup(sprintf "[red]%s[/]" (Markup.Escape err))).PadLeft(2)
+                Padder(Markup(sprintf "[red]%s[/]" (Markup.Escape (summarizeToolError err)))).PadLeft(2)
             Rows([ Markup(header) :> IRenderable; body :> _ ]) :> _
     else
         match state with
@@ -140,4 +156,4 @@ let toolBullet (s: Strings) (state: ToolState) : IRenderable =
                    renderToolBody output ]) :> _
         | Failed(name, args, err, elapsed) ->
             Rows([ Text(sprintf "* %s(%s) %s" name args (formatElapsed elapsed)) :> IRenderable
-                   Padder(Text(sprintf "Error: %s" err)).PadLeft(2) :> _ ]) :> _
+                   Padder(Text(sprintf "Error: %s" (summarizeToolError err))).PadLeft(2) :> _ ]) :> _

--- a/src/Fugue.Cli/Render.fs
+++ b/src/Fugue.Cli/Render.fs
@@ -22,17 +22,19 @@ let isColorEnabled () = colorEnabled
 /// because Console.WriteLine inside ReadLine doesn't go through Spectre.
 let prompt (_cwd: string) : string = "› "
 
-let userMessage (ui: UiConfig) (text: string) : IRenderable =
+let userMessage (ui: UiConfig) (text: string) (turn: int) : IRenderable =
     if colorEnabled then
         let escaped = Markup.Escape text
+        let prefix = sprintf "[dim][[%d]][/] " turn
         match ui.UserAlignment with
         | Left ->
-            Markup(sprintf "[grey]›[/] %s" escaped) :> _
+            Markup(sprintf "[grey]›[/] %s%s" prefix escaped) :> _
         | Right ->
-            let bubble = Padder(Markup(escaped)).PadLeft(2).PadRight(2) :> IRenderable
+            let bubble = Padder(Markup(sprintf "%s%s" prefix escaped)).PadLeft(2).PadRight(2) :> IRenderable
             Align(bubble, HorizontalAlignment.Right) :> _
     else
-        Text(sprintf "> %s" text) :> _
+        let prefix = sprintf "[%d] " turn
+        Text(sprintf "> %s%s" prefix text) :> _
 
 /// Plain assistant text during streaming (no markdown parse — buffer is partial).
 let assistantLive (text: string) : IRenderable =

--- a/src/Fugue.Cli/Render.fs
+++ b/src/Fugue.Cli/Render.fs
@@ -8,8 +8,8 @@ open Fugue.Core.Localization
 
 type ToolState =
     | Running   of name: string * args: string
-    | Completed of name: string * args: string * output: string
-    | Failed    of name: string * args: string * err: string
+    | Completed of name: string * args: string * output: string * elapsed: TimeSpan
+    | Failed    of name: string * args: string * err: string   * elapsed: TimeSpan
 
 let mutable private colorEnabled = true
 
@@ -73,6 +73,12 @@ let private softWrap (width: int) (line: string) : string list =
             i <- chunkEnd
         result
 
+let private formatElapsed (e: TimeSpan) =
+    if e.TotalMilliseconds >= 1000.0 then
+        sprintf "%.1fs" e.TotalSeconds
+    else
+        sprintf "%dms" (int e.TotalMilliseconds)
+
 let private renderToolBody (output: string) : IRenderable =
     if colorEnabled then
         if DiffRender.looksLikeDiff output then DiffRender.toRenderable output
@@ -110,15 +116,15 @@ let toolBullet (s: Strings) (state: ToolState) : IRenderable =
             let body =
                 Padder(Markup(sprintf "[dim]%s[/]" (Markup.Escape s.ToolRunning))).PadLeft(2)
             Rows([ Markup(header) :> IRenderable; body :> _ ]) :> _
-        | Completed(name, args, output) ->
+        | Completed(name, args, output, elapsed) ->
             let header =
-                sprintf "[green]●[/] [bold]%s[/]([dim]%s[/])"
-                    (Markup.Escape name) (Markup.Escape args)
+                sprintf "[green]●[/] [bold]%s[/]([dim]%s[/]) [dim]%s[/]"
+                    (Markup.Escape name) (Markup.Escape args) (formatElapsed elapsed)
             Rows([ Markup(header) :> IRenderable; renderToolBody output ]) :> _
-        | Failed(name, args, err) ->
+        | Failed(name, args, err, elapsed) ->
             let header =
-                sprintf "[red]●[/] [bold]%s[/]([dim]%s[/])"
-                    (Markup.Escape name) (Markup.Escape args)
+                sprintf "[red]●[/] [bold]%s[/]([dim]%s[/]) [dim]%s[/]"
+                    (Markup.Escape name) (Markup.Escape args) (formatElapsed elapsed)
             let body =
                 Padder(Markup(sprintf "[red]%s[/]" (Markup.Escape err))).PadLeft(2)
             Rows([ Markup(header) :> IRenderable; body :> _ ]) :> _
@@ -127,9 +133,9 @@ let toolBullet (s: Strings) (state: ToolState) : IRenderable =
         | Running(name, args) ->
             Rows([ Text(sprintf "* %s(%s)" name args) :> IRenderable
                    Padder(Text(s.ToolRunning)).PadLeft(2) :> _ ]) :> _
-        | Completed(name, args, output) ->
-            Rows([ Text(sprintf "* %s(%s)" name args) :> IRenderable
+        | Completed(name, args, output, elapsed) ->
+            Rows([ Text(sprintf "* %s(%s) %s" name args (formatElapsed elapsed)) :> IRenderable
                    renderToolBody output ]) :> _
-        | Failed(name, args, err) ->
-            Rows([ Text(sprintf "* %s(%s)" name args) :> IRenderable
+        | Failed(name, args, err, elapsed) ->
+            Rows([ Text(sprintf "* %s(%s) %s" name args (formatElapsed elapsed)) :> IRenderable
                    Padder(Text(sprintf "Error: %s" err)).PadLeft(2) :> _ ]) :> _

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -334,7 +334,7 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
     try
         while not cancelSrc.QuitRequested do
             let callbacks : ReadLine.ReadLineCallbacks = { OnClearScreen = StatusBar.refresh }
-            let! lineOpt = ReadLine.readAsync (Render.prompt cwd) strings callbacks cancelSrc.Token
+            let! lineOpt = ReadLine.readAsync (Render.prompt cwd) strings callbacks (Render.isColorEnabled ()) cancelSrc.Token
             match lineOpt with
             | None ->
                 cancelSrc.RequestQuit()

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -330,6 +330,7 @@ let run (agent: AIAgent) (cfg: AppConfig) (cwd: string) : Task<unit> = task {
 
     let strings = pick cfg.Ui.Locale
     let mutable verbosityPrefix : string option = None
+    let mutable turnNumber = 0
     try
         while not cancelSrc.QuitRequested do
             let callbacks : ReadLine.ReadLineCallbacks = { OnClearScreen = StatusBar.refresh }
@@ -638,7 +639,7 @@ Please generate a clear, actionable onboarding checklist.""" (String.concat "\n\
                                 .Replace("{0}", string prNum)
                                 .Replace("{1}", titleBody)
                                 .Replace("{2}", truncatedDiff)
-                        AnsiConsole.Write(Render.userMessage cfg.Ui (sprintf "Reviewing PR #%d…" prNum))
+                        AnsiConsole.Write(Render.userMessage cfg.Ui (sprintf "Reviewing PR #%d…" prNum) 0)
                         AnsiConsole.WriteLine()
                         do! streamAndRender agent session prompt cfg cancelSrc
                 StatusBar.refresh ()
@@ -649,7 +650,7 @@ Please generate a clear, actionable onboarding checklist.""" (String.concat "\n\
                     AnsiConsole.WriteLine()
                 else
                     let augmented = sprintf "[System: answer from your training knowledge only — do not invoke any tools, do not read files, do not run commands]\n\nUser: %s" question
-                    AnsiConsole.Write(Render.userMessage cfg.Ui question)
+                    AnsiConsole.Write(Render.userMessage cfg.Ui question 0)
                     AnsiConsole.WriteLine()
                     do! streamAndRender agent session augmented cfg cancelSrc
                 StatusBar.refresh ()
@@ -699,7 +700,7 @@ Please generate a clear, actionable onboarding checklist.""" (String.concat "\n\
                         "- Any gotchas or non-obvious constraints\n\n" +
                         "Keep it concise — aim for 50-150 lines. Use Markdown headers.\n" +
                         "Write the file to ./FUGUE.md using the Write tool."
-                    AnsiConsole.Write(Render.userMessage cfg.Ui "/init")
+                    AnsiConsole.Write(Render.userMessage cfg.Ui "/init" 0)
                     AnsiConsole.WriteLine()
                     do! streamAndRender agent session initPrompt cfg cancelSrc
                     StatusBar.refresh ()
@@ -716,6 +717,7 @@ Please generate a clear, actionable onboarding checklist.""" (String.concat "\n\
                     session <- null
                     AnsiConsole.Write(Render.errorLine strings ex.Message)
                     AnsiConsole.WriteLine()
+                turnNumber <- 0
                 StatusBar.refresh ()
             | Some s when s.StartsWith "!" ->
                 let cmd = s.Substring(1).Trim()
@@ -753,7 +755,7 @@ Please generate a clear, actionable onboarding checklist.""" (String.concat "\n\
                     "- Key decisions made\n" +
                     "- Any open questions or next steps\n\n" +
                     "Be concise but complete."
-                AnsiConsole.Write(Render.userMessage cfg.Ui "/summary")
+                AnsiConsole.Write(Render.userMessage cfg.Ui "/summary" 0)
                 AnsiConsole.WriteLine()
                 do! streamAndRender agent session summaryPrompt cfg cancelSrc
                 StatusBar.refresh ()
@@ -819,7 +821,7 @@ Please generate a clear, actionable onboarding checklist.""" (String.concat "\n\
                             sprintf "Please summarize the file '%s'.\n\nProvide a structured summary:\n1. Purpose — what does this file do?\n2. Public API — exported functions or types\n3. Key dependencies — what modules/libraries does it use?\n4. Notable design decisions — any interesting patterns or constraints\n\nBe concise (2–4 sentences per section). Use the Read tool to examine the file." rawArg
                         else
                             sprintf "The path '%s' does not exist. Please let me know." rawArg
-                    AnsiConsole.Write(Render.userMessage cfg.Ui ("/summarize " + rawArg))
+                    AnsiConsole.Write(Render.userMessage cfg.Ui ("/summarize " + rawArg) 0)
                     AnsiConsole.WriteLine()
                     do! streamAndRender agent session summarizePrompt cfg cancelSrc
                 StatusBar.refresh ()
@@ -829,7 +831,8 @@ Please generate a clear, actionable onboarding checklist.""" (String.concat "\n\
                     AnsiConsole.WriteLine()
                 let expandedInput = expandAtFiles cwd strings userInput
                 let expandedInput = expandClipboard expandedInput strings
-                AnsiConsole.Write(Render.userMessage cfg.Ui userInput)
+                turnNumber <- turnNumber + 1
+                AnsiConsole.Write(Render.userMessage cfg.Ui userInput turnNumber)
                 AnsiConsole.WriteLine()
                 let effectiveInput =
                     match verbosityPrefix with

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -262,7 +262,7 @@ let private streamAndRender
         (cfg: AppConfig) (cancelSrc: CancelSource) : Task<unit> = task {
     use streamCts = cancelSrc.NewStreamCts()
     let strings = pick cfg.Ui.Locale
-    let toolMeta = Dictionary<string, string * string>()
+    let toolMeta = Dictionary<string, string * string * int64>()
     let mutable assistantStreaming = false   // are we mid-line in the plain-text stream
 
     StatusBar.startStreaming()
@@ -280,19 +280,19 @@ let private streamAndRender
                         Console.Out.Flush()
                         assistantStreaming <- true
                     | Conversation.ToolStarted(id, name, args) ->
-                        toolMeta.[id] <- (name, args)
+                        toolMeta.[id] <- (name, args, Stopwatch.GetTimestamp())
                         if assistantStreaming then
                             Console.Out.WriteLine ()
                             assistantStreaming <- false
                         StatusBar.refresh()
                     | Conversation.ToolCompleted(id, output, isErr) ->
-                        let name, args =
+                        let name, args, elapsed =
                             match toolMeta.TryGetValue id with
-                            | true, v -> v
-                            | false, _ -> "?", "?"
+                            | true, (n, a, tick) -> n, a, Stopwatch.GetElapsedTime(tick)
+                            | false, _ -> "?", "?", TimeSpan.Zero
                         let state =
-                            if isErr then Render.Failed(name, args, output)
-                            else Render.Completed(name, args, output)
+                            if isErr then Render.Failed(name, args, output, elapsed)
+                            else Render.Completed(name, args, output, elapsed)
                         AnsiConsole.Write(Render.toolBullet strings state)
                         AnsiConsole.WriteLine ()
                         StatusBar.refresh()

--- a/src/Fugue.Cli/StatusBar.fs
+++ b/src/Fugue.Cli/StatusBar.fs
@@ -66,7 +66,7 @@ let startStreaming () = streamingSince <- Some DateTime.UtcNow
 let stopStreaming ()  = streamingSince <- None
 
 let refresh () =
-    if not active then () else
+    if not active || not (Render.isColorEnabled ()) then () else
     let height = Console.WindowHeight
     let strings =
         match cfg with
@@ -95,7 +95,7 @@ let refresh () =
     writeRaw "\x1b[u"
 
 let start (initialCwd: string) (initialCfg: AppConfig) : unit =
-    if active then () else
+    if active || not (Render.isColorEnabled ()) then () else
     cwd <- initialCwd
     cfg <- Some initialCfg
     active <- true
@@ -108,7 +108,7 @@ let start (initialCwd: string) (initialCfg: AppConfig) : unit =
     refresh ()
 
 let stop () : unit =
-    if not active then () else
+    if not active || not (Render.isColorEnabled ()) then () else
     let height = Console.WindowHeight
     writeRaw "\x1b[r"          // reset scroll region
     writeRaw ("\x1b[" + string (height - 1) + ";1H")

--- a/src/Fugue.Core/Config.fs
+++ b/src/Fugue.Core/Config.fs
@@ -39,6 +39,7 @@ type AppConfig =
       SystemPrompt: string option
       ProfileContent: string option
       MaxIterations: int
+      MaxTokens: int option
       Ui: UiConfig
       BaseUrl: string option }
 
@@ -137,7 +138,7 @@ let private fromImplicitEnv () : ProviderConfig option =
 
 [<RequiresUnreferencedCode("Uses STJ reflection; AppConfigDto is preserved via TrimmerRootDescriptor")>]
 [<RequiresDynamicCode("Uses STJ reflection; System.Text.Json is TrimmerRootAssembly")>]
-let private fromFile (path: string) : Result<ProviderConfig * int * UiConfig * string option, string> =
+let private fromFile (path: string) : Result<ProviderConfig * int * int option * UiConfig * string option, string> =
     try
         let json = File.ReadAllText path
         let dtoOrNull =
@@ -171,7 +172,8 @@ let private fromFile (path: string) : Result<ProviderConfig * int * UiConfig * s
                     | _         -> defaultLocale ()
                 let ui = { UserAlignment = alignment; Locale = locale }
                 let baseUrl = dto.baseUrl |> Option.ofObj |> Option.filter (fun s -> not (String.IsNullOrEmpty s))
-                p, dto.maxIterations, ui, baseUrl)
+                let maxTokens = if dto.maxTokens > 0 then Some dto.maxTokens else None
+                p, dto.maxIterations, maxTokens, ui, baseUrl)
     with ex -> Error ex.Message
 
 let private helpText () =
@@ -194,19 +196,19 @@ Set environment variables:
 let load (_argv: string[]) : Result<AppConfig, ConfigError> =
     match fromExplicitEnv () with
     | Some provider ->
-        Ok { Provider = provider; SystemPrompt = None; ProfileContent = None; MaxIterations = 30; Ui = defaultUi (); BaseUrl = None }
+        Ok { Provider = provider; SystemPrompt = None; ProfileContent = None; MaxIterations = 30; MaxTokens = None; Ui = defaultUi (); BaseUrl = None }
     | None ->
         let path = configPath ()
         if File.Exists path then
             match fromFile path with
-            | Ok (p, mi, ui, baseUrl) ->
+            | Ok (p, mi, maxTokens, ui, baseUrl) ->
                 let mi = if mi <= 0 then 30 else mi
-                Ok { Provider = p; SystemPrompt = None; ProfileContent = None; MaxIterations = mi; Ui = ui; BaseUrl = baseUrl }
+                Ok { Provider = p; SystemPrompt = None; ProfileContent = None; MaxIterations = mi; MaxTokens = maxTokens; Ui = ui; BaseUrl = baseUrl }
             | Error e -> Error(InvalidConfig e)
         else
             match fromImplicitEnv () with
             | Some provider ->
-                Ok { Provider = provider; SystemPrompt = None; ProfileContent = None; MaxIterations = 30; Ui = defaultUi (); BaseUrl = None }
+                Ok { Provider = provider; SystemPrompt = None; ProfileContent = None; MaxIterations = 30; MaxTokens = None; Ui = defaultUi (); BaseUrl = None }
             | None ->
                 Error(NoConfigFound (helpText ()))
 
@@ -220,10 +222,11 @@ let saveToFile (cfg: AppConfig) : unit =
         { userAlignment = (match cfg.Ui.UserAlignment with Left -> "left" | Right -> "right")
           locale        = cfg.Ui.Locale }
     let baseUrlVal = cfg.BaseUrl |> Option.toObj
+    let maxTokensVal = cfg.MaxTokens |> Option.defaultValue 0
     let dto =
         match cfg.Provider with
-        | Anthropic(k, m) -> { provider = "anthropic"; model = m; apiKey = k; ollamaEndpoint = ""; baseUrl = baseUrlVal; maxIterations = cfg.MaxIterations; ui = uiDto }
-        | OpenAI(k, m)    -> { provider = "openai";    model = m; apiKey = k; ollamaEndpoint = ""; baseUrl = baseUrlVal; maxIterations = cfg.MaxIterations; ui = uiDto }
-        | Ollama(e, m)    -> { provider = "ollama";    model = m; apiKey = ""; ollamaEndpoint = string e; baseUrl = baseUrlVal; maxIterations = cfg.MaxIterations; ui = uiDto }
+        | Anthropic(k, m) -> { provider = "anthropic"; model = m; apiKey = k; ollamaEndpoint = ""; baseUrl = baseUrlVal; maxIterations = cfg.MaxIterations; maxTokens = maxTokensVal; ui = uiDto }
+        | OpenAI(k, m)    -> { provider = "openai";    model = m; apiKey = k; ollamaEndpoint = ""; baseUrl = baseUrlVal; maxIterations = cfg.MaxIterations; maxTokens = maxTokensVal; ui = uiDto }
+        | Ollama(e, m)    -> { provider = "ollama";    model = m; apiKey = ""; ollamaEndpoint = string e; baseUrl = baseUrlVal; maxIterations = cfg.MaxIterations; maxTokens = maxTokensVal; ui = uiDto }
     let json = JsonSerializer.Serialize<AppConfigDto>(dto, appConfigOptions)
     File.WriteAllText(path, json)

--- a/src/Fugue.Core/JsonContext.fs
+++ b/src/Fugue.Core/JsonContext.fs
@@ -20,6 +20,7 @@ type AppConfigDto =
       ollamaEndpoint: string
       baseUrl: string | null
       maxIterations: int
+      maxTokens: int
       ui: UiConfigDto | null }
 
 /// Shared JsonSerializerOptions for AppConfigDto serialization.

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -104,7 +104,10 @@ type Strings =
       CmdSummarizeDesc: string
 
       // @path injection hints
-      TestFileHint:  string }
+      TestFileHint:  string
+
+      // Input prompt
+      InputPlaceholder: string }
 
 let en : Strings =
     { Cancelled            = "cancelled"
@@ -166,7 +169,8 @@ let en : Strings =
       CmdTodoDesc           = "scan workspace for TODO/FIXME/HACK comments"
       TodoNone              = "no TODO/FIXME/HACK comments found in workspace"
       CmdSummarizeDesc      = "summarize a file or directory"
-      TestFileHint          = "[test file found: {0} — include it with @{1}]" }
+      TestFileHint          = "[test file found: {0} — include it with @{1}]"
+      InputPlaceholder      = "Type a message or /help" }
 
 let ru : Strings =
     { Cancelled            = "отменено"
@@ -228,7 +232,8 @@ let ru : Strings =
       CmdTodoDesc           = "найти TODO/FIXME/HACK комментарии в проекте"
       TodoNone              = "TODO/FIXME/HACK комментарии не найдены"
       CmdSummarizeDesc      = "резюме файла или директории"
-      TestFileHint          = "[найден тест-файл: {0} — подключите его через @{1}]" }
+      TestFileHint          = "[найден тест-файл: {0} — подключите его через @{1}]"
+      InputPlaceholder      = "Введите сообщение или /help" }
 
 /// Pick a Strings value by ISO-2 locale code. Unknown locales fall back to en.
 let pick (locale: string) : Strings =

--- a/tests/Fugue.Tests/ReadLineTests.fs
+++ b/tests/Fugue.Tests/ReadLineTests.fs
@@ -17,6 +17,8 @@ let private mkState (text: string) (cursor: int) : S =
       PromptText      = "> "
       PromptVisLen    = 2
       HintWhenArmed   = "Press Ctrl+C again to exit"
+      Placeholder     = ""
+      ColorEnabled    = false
       Width           = 80
       SlashHelp       = [] }
 

--- a/tests/Fugue.Tests/RenderTests.fs
+++ b/tests/Fugue.Tests/RenderTests.fs
@@ -20,14 +20,14 @@ let private toStr (r: Spectre.Console.Rendering.IRenderable) : string =
 
 [<Fact>]
 let ``userMessage Left contains '> ' prefix`` () =
-    let out = userMessage uiLeft "hello" |> toStr
+    let out = userMessage uiLeft "hello" 1 |> toStr
     out |> should haveSubstring "›"
     out |> should haveSubstring "hello"
 
 [<Fact>]
 let ``userMessage Right does not have left-edge prefix`` () =
     // Right-aligned: text is right-justified within terminal width, no '>' prefix
-    let out = userMessage uiRight "hello" |> toStr
+    let out = userMessage uiRight "hello" 1 |> toStr
     out |> should haveSubstring "hello"
 
 [<Fact>]

--- a/tests/Fugue.Tests/RenderTests.fs
+++ b/tests/Fugue.Tests/RenderTests.fs
@@ -1,5 +1,6 @@
 module Fugue.Tests.RenderTests
 
+open System
 open Spectre.Console.Testing
 open Xunit
 open FsUnit.Xunit
@@ -53,7 +54,24 @@ let ``toolBullet running shows yellow circle and tool name`` () =
 [<Fact>]
 let ``toolBullet completed plain output renders without diff`` () =
     let s = pick "en"
-    let state = Completed("Read", "{}", "alpha\nbeta")
+    let state = Completed("Read", "{}", "alpha\nbeta", TimeSpan.FromMilliseconds 12.0)
     let out = toolBullet s state |> toStr
     out |> should haveSubstring "Read"
     out |> should haveSubstring "alpha"
+    out |> should haveSubstring "12ms"
+
+[<Fact>]
+let ``toolBullet completed shows seconds for long tools`` () =
+    let strings = pick "en"
+    let state = Completed("Bash", "ls", "file.txt", TimeSpan.FromSeconds 2.3)
+    let out = toolBullet strings state |> toStr
+    out |> should haveSubstring "Bash"
+    out |> should haveSubstring "2.3s"
+
+[<Fact>]
+let ``toolBullet failed shows elapsed`` () =
+    let strings = pick "en"
+    let state = Failed("Bash", "rm -rf", "Permission denied", TimeSpan.FromMilliseconds 5.0)
+    let out = toolBullet strings state |> toStr
+    out |> should haveSubstring "Bash"
+    out |> should haveSubstring "5ms"

--- a/tests/Fugue.Tests/RenderTests.fs
+++ b/tests/Fugue.Tests/RenderTests.fs
@@ -75,3 +75,12 @@ let ``toolBullet failed shows elapsed`` () =
     let out = toolBullet strings state |> toStr
     out |> should haveSubstring "Bash"
     out |> should haveSubstring "5ms"
+
+[<Fact>]
+let ``toolBullet failed suppresses stack trace`` () =
+    let s = pick "en"
+    let raw = "File not found: foo.txt\n   at System.IO.File.ReadAllText(String path)\n   at Fugue.Tools.ReadTool.run()"
+    let state = Failed("Read", "foo.txt", raw, System.TimeSpan.FromMilliseconds 1.0)
+    let out = toolBullet s state |> toStr
+    out |> should haveSubstring "File not found"
+    out |> should not' (haveSubstring "at System.IO")


### PR DESCRIPTION
## Summary

Cherry-picked 6 commits from PR #166 (`feat/readline-history-word-cursor`) onto clean `main`:

- `41520f7` feat(ux): honour NO_COLOR / FUGUE\_NO\_COLOR / TERM=dumb env vars (#666)
- `ec4799d` feat(config): maxTokens field to cap completion tokens per session (#659)
- `265057d` feat(ux): show elapsed time per tool call in result header (#664)
- `3fef5f3` feat(ux): number conversation turns [N] next to user messages (#661)
- `e2f4ff1` feat(ux): dim placeholder text in empty input prompt (#663)
- `75d6ddc` feat(ux): structured tool error formatting, suppress stack traces (#650)

## Test plan

- [x] 277/277 unit tests pass
- [x] AOT publish clean (45MB osx-arm64, 0 errors, 0 warnings)
- [x] All merge conflicts resolved — kept HEAD's richer code, applied THEIRS' targeted changes