### PR TITLE
fix: env-var test flakiness (#689) + non-TTY headless mode (#665)

### DIFF
--- a/src/Fugue.Cli/Program.fs
+++ b/src/Fugue.Cli/Program.fs
@@ -10,6 +10,8 @@ let private noColor () =
     let isSet name = Environment.GetEnvironmentVariable name |> isNull |> not
     isSet "NO_COLOR" || isSet "FUGUE_NO_COLOR"
     || Environment.GetEnvironmentVariable "TERM" = "dumb"
+    || Console.IsOutputRedirected
+    || Console.IsInputRedirected
 
 let private buildAgent (cfg: AppConfig) : AIAgent =
     let cwd = Environment.CurrentDirectory
@@ -32,7 +34,9 @@ let private runWithCfg (cfg: AppConfig) : int =
     Render.initColor (not (noColor ()))
     let agent = buildAgent cfg
     let cwd = Environment.CurrentDirectory
-    let t = Repl.run agent cfg cwd
+    let t =
+        if Console.IsInputRedirected then Repl.runHeadless agent cfg cwd
+        else Repl.run agent cfg cwd
     try t.Wait()
     with
     | :? AggregateException as agg ->

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -847,3 +847,30 @@ Please generate a clear, actionable onboarding checklist.""" (String.concat "\n\
         Console.Out.Flush()
         StatusBar.stop ()
 }
+
+[<RequiresUnreferencedCode("Calls Conversation.run which uses STJ reflection; System.Text.Json is TrimmerRootAssembly")>]
+[<RequiresDynamicCode("Calls Conversation.run which uses STJ reflection; System.Text.Json is TrimmerRootAssembly")>]
+let runHeadless (agent: AIAgent) (cfg: AppConfig) (_cwd: string) : Task<unit> = task {
+    let input = Console.In.ReadToEnd().Trim()
+    if not (String.IsNullOrWhiteSpace input) then
+        let! session = agent.CreateSessionAsync(CancellationToken.None)
+        let stream = Conversation.run agent session input CancellationToken.None
+        let enumerator = stream.GetAsyncEnumerator(CancellationToken.None)
+        let mutable hasNext = true
+        while hasNext do
+            let! step = enumerator.MoveNextAsync().AsTask()
+            if step then
+                match enumerator.Current with
+                | Conversation.TextChunk t ->
+                    Console.Out.Write t
+                    Console.Out.Flush()
+                | Conversation.ToolStarted(_, name, args) ->
+                    Console.Error.WriteLine(sprintf "[tool: %s(%s)]" name args)
+                | Conversation.ToolCompleted(id, output, isErr) ->
+                    ignore id
+                    if isErr then Console.Error.WriteLine(sprintf "[tool error: %s]" output)
+                | Conversation.Finished -> ()
+                | Conversation.Failed ex -> raise ex
+            else hasNext <- false
+        Console.Out.WriteLine()
+}

--- a/tests/Fugue.Tests/ConfigTests.fs
+++ b/tests/Fugue.Tests/ConfigTests.fs
@@ -1,3 +1,4 @@
+[<Xunit.Collection("Sequential")>]
 module Fugue.Tests.ConfigTests
 
 open System

--- a/tests/Fugue.Tests/DiscoveryTests.fs
+++ b/tests/Fugue.Tests/DiscoveryTests.fs
@@ -1,3 +1,4 @@
+[<Xunit.Collection("Sequential")>]
 module Fugue.Tests.DiscoveryTests
 
 open System

--- a/tests/Fugue.Tests/Fugue.Tests.fsproj
+++ b/tests/Fugue.Tests/Fugue.Tests.fsproj
@@ -5,6 +5,7 @@
     <PublishAot>false</PublishAot>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="TestCollections.fs" />
     <Compile Include="ArgsTests.fs" />
     <Compile Include="DelegatedFnTests.fs" />
     <Compile Include="ReadFnTests.fs" />

--- a/tests/Fugue.Tests/TestCollections.fs
+++ b/tests/Fugue.Tests/TestCollections.fs
@@ -1,0 +1,8 @@
+module Fugue.Tests.TestCollections
+
+open Xunit
+
+/// Tests that mutate process-wide environment variables must run sequentially to avoid
+/// flaky failures caused by parallel test execution clobbering shared env-var state.
+[<CollectionDefinition("Sequential", DisableParallelization = true)>]
+type SequentialCollectionDef() = class end


### PR DESCRIPTION
## Summary

- **fix(tests)** #689: Mark `DiscoveryTests` and `ConfigTests` with `[<Collection("Sequential")>]` to prevent parallel-run env-var contamination. Added `TestCollections.fs` with the `SequentialCollectionDef` xUnit v2 collection definition.

- **feat(cli)** #665: Non-TTY graceful degradation. When `Console.IsInputRedirected` (stdin piped), `runHeadless` is used instead of the interactive REPL — reads all of stdin as the prompt, streams the response as plain text to stdout, emits tool events to stderr. `noColor()` now also returns `true` on redirected stdout/stdin, disabling all ANSI escapes and the status bar scroll region.

## Test plan

- [x] 277/277 tests pass
- [x] AOT build clean
- [x] `DiscoveryTests` and `ConfigTests` now run sequentially — no more parallel env-var races
- [x] `echo "say hello" | fugue` will use headless mode (no ANSI, no StatusBar, exits after response)