### PR TITLE
fix(render): dollar-before-digit treated as currency not math (#683)

### DIFF
--- a/src/Fugue.Cli/MathRender.fs
+++ b/src/Fugue.Cli/MathRender.fs
@@ -223,11 +223,14 @@ let private stripDelimiters (s: string) : string =
             result.Append(s.[i]) |> ignore
             i <- i + 1
     let s2 = result.ToString()
-    // Strip $...$
+    // Strip $...$  but skip $digit (likely currency like $5, $10 — not math).
     let result2 = System.Text.StringBuilder()
     let mutable j = 0
     while j < s2.Length do
-        if s2.[j] = '$' then
+        let isMathStart =
+            s2.[j] = '$'
+            && not (j + 1 < s2.Length && System.Char.IsDigit s2.[j + 1])
+        if isMathStart then
             let start = j + 1
             let close = s2.IndexOf('$', start)
             if close >= 0 then

--- a/tests/Fugue.Tests/MathRenderTests.fs
+++ b/tests/Fugue.Tests/MathRenderTests.fs
@@ -287,3 +287,23 @@ let ``plain text without math is unchanged`` () =
 [<Fact>]
 let ``empty string is unchanged`` () =
     MathRender.preprocess "" |> should equal ""
+
+// Bug #683: $digit should not be treated as a math delimiter (currency guard)
+[<Fact>]
+let ``dollar sign before digit is treated as currency not math`` () =
+    MathRender.preprocess "$5 and $10" |> should equal "$5 and $10"
+
+[<Fact>]
+let ``dollar sign before letter is still treated as math delimiter`` () =
+    MathRender.preprocess "$x$" |> should equal "x"
+
+// Bug #682 (known limitation): LaTeX inside code fences is preprocessed.
+// Correct behavior would leave code-fence content untouched; this test
+// documents the current behaviour so regressions are visible.
+[<Fact>]
+let ``dollar signs inside code fences are processed (known limitation 682)`` () =
+    // A TeX tutorial in a fenced block should ideally be left verbatim,
+    // but currently preprocess runs on the raw string before Markdig parses.
+    let input = "```tex\n$\\alpha$\n```"
+    // Current (undesirable) behaviour: α is substituted even inside the fence.
+    MathRender.preprocess input |> should haveSubstring "α"


### PR DESCRIPTION
## Summary

`MathRender.stripDelimiters` was treating `$5` and `$10` as inline math delimiters, stripping them and producing `5 and 10` from `$5 and $10`.

**Fix:** Skip `$` as a math-start delimiter when the next character is a digit — this is almost always currency rather than LaTeX.

**Known limitation #682 documented:** A test case is added that records the current behaviour of `preprocess` running on raw markdown before code fences are parsed, so any future regression is visible.

## Test plan

- [x] `"$5 and $10"` → `"$5 and $10"` (unchanged)
- [x] `"$x$"` → `"x"` (math still works)
- [x] 280/280 tests pass