### PR TITLE
fix(render): LaTeX inside code fences no longer preprocessed (#682)

### DIFF
--- a/src/Fugue.Cli/MathRender.fs
+++ b/src/Fugue.Cli/MathRender.fs
@@ -244,12 +244,51 @@ let private stripDelimiters (s: string) : string =
             j <- j + 1
     result2.ToString()
 
+/// Apply transform to portions of s that are outside fenced code blocks (```) and inline code spans (`).
+/// Emits code regions verbatim so LaTeX inside code examples is not mangled.
+let private applyOutsideCode (transform: string -> string) (s: string) : string =
+    let sb = System.Text.StringBuilder()
+    let mutable i = 0
+    while i < s.Length do
+        // Fenced code block: ``` or ~~~
+        if i + 2 < s.Length &&
+           ((s.[i] = '`' && s.[i+1] = '`' && s.[i+2] = '`') ||
+            (s.[i] = '~' && s.[i+1] = '~' && s.[i+2] = '~')) then
+            let fence = s.[i..i+2]
+            let closeIdx = s.IndexOf(fence, i + 3, System.StringComparison.Ordinal)
+            if closeIdx >= 0 then
+                sb.Append(s, i, closeIdx + 3 - i) |> ignore
+                i <- closeIdx + 3
+            else
+                sb.Append(s, i, s.Length - i) |> ignore
+                i <- s.Length
+        // Inline code span: `...`
+        elif s.[i] = '`' then
+            let closeIdx = s.IndexOf('`', i + 1)
+            if closeIdx >= 0 then
+                sb.Append(s, i, closeIdx + 1 - i) |> ignore
+                i <- closeIdx + 1
+            else
+                sb.Append(s.[i]) |> ignore
+                i <- i + 1
+        else
+            // Collect non-code text up to the next backtick or fence
+            let mutable j = i
+            while j < s.Length && s.[j] <> '`' &&
+                  not (j + 2 < s.Length && s.[j] = '~' && s.[j+1] = '~' && s.[j+2] = '~') do
+                j <- j + 1
+            sb.Append(transform (s.[i..j-1])) |> ignore
+            i <- j
+    sb.ToString()
+
 /// Pre-process a string, converting common LaTeX math to Unicode approximations.
 /// Call this before passing text to Markdig so the rendered output contains
 /// readable Unicode rather than raw LaTeX commands.
+/// Content inside code fences (```) or inline code spans (`) is left untouched.
 let preprocess (s: string) : string =
-    s
-    |> replaceFrac
-    |> replaceCommands
-    |> replaceScripts
-    |> stripDelimiters
+    applyOutsideCode (fun chunk ->
+        chunk
+        |> replaceFrac
+        |> replaceCommands
+        |> replaceScripts
+        |> stripDelimiters) s

--- a/tests/Fugue.Tests/MathRenderTests.fs
+++ b/tests/Fugue.Tests/MathRenderTests.fs
@@ -297,13 +297,18 @@ let ``dollar sign before digit is treated as currency not math`` () =
 let ``dollar sign before letter is still treated as math delimiter`` () =
     MathRender.preprocess "$x$" |> should equal "x"
 
-// Bug #682 (known limitation): LaTeX inside code fences is preprocessed.
-// Correct behavior would leave code-fence content untouched; this test
-// documents the current behaviour so regressions are visible.
+// Bug #682 fix: LaTeX inside code fences must not be preprocessed.
 [<Fact>]
-let ``dollar signs inside code fences are processed (known limitation 682)`` () =
-    // A TeX tutorial in a fenced block should ideally be left verbatim,
-    // but currently preprocess runs on the raw string before Markdig parses.
+let ``dollar signs inside code fences are left verbatim`` () =
     let input = "```tex\n$\\alpha$\n```"
-    // Current (undesirable) behaviour: α is substituted even inside the fence.
-    MathRender.preprocess input |> should haveSubstring "α"
+    MathRender.preprocess input |> should equal input
+
+[<Fact>]
+let ``dollar signs in inline code span are left verbatim`` () =
+    let input = "Use `$\\alpha$` in your LaTeX source."
+    MathRender.preprocess input |> should equal input
+
+[<Fact>]
+let ``math outside code fence is still processed`` () =
+    let result = MathRender.preprocess "Before ```code block``` and $\\alpha$ after."
+    result |> should haveSubstring "α"


### PR DESCRIPTION
## Summary

Added `applyOutsideCode` helper to `MathRender.preprocess` that skips transformation of content inside:
- Fenced code blocks (triple backtick or tilde)
- Inline code spans (single backtick)

Previously, `\alpha` inside a ` ```tex ` block would be silently converted to `α`, breaking TeX tutorials and documentation examples.

## Test plan

- [x] `"```tex\n$\\alpha$\n```"` → unchanged (fence content preserved)
- [x] `` "`$\\alpha$`" `` inline code → unchanged  
- [x] Math outside code fences still renders correctly
- [x] 282/282 tests pass