### PR TITLE
feat(statusbar): extract pure renderStatusBar — Phase 1.2a

### DIFF
--- a/src/Fugue.Cli/StatusBar.fs
+++ b/src/Fugue.Cli/StatusBar.fs
@@ -5,6 +5,189 @@ open System.Diagnostics
 open System.IO
 open Fugue.Core.Localization
 open Fugue.Core.Config
+open Fugue.Surface
+
+// ---------------------------------------------------------------------------
+// Pure render types — used by renderStatusBar (no Console dependency)
+// ---------------------------------------------------------------------------
+
+/// Annotation counts for thumbs-up / thumbs-down turn ratings.
+type AnnotState = { Up: int; Down: int }
+
+/// Snapshot of the streaming meter — all values needed to render the
+/// ThinkingLine without touching any global mutable.
+type StreamingSnapshot = {
+    /// Wall-clock time when streaming started (for elapsed display).
+    Since:           DateTimeOffset
+    /// Current spinner frame index (caller advances this).
+    SpinnerFrame:    int
+    /// Ring-buffer of Stopwatch timestamps (last N token arrivals for tok/s).
+    TokensInWindow:  int64 array
+}
+
+/// Immutable snapshot of everything the status bar needs to render one frame.
+/// Populated by captureState () from the 15 module-level mutables;
+/// can also be constructed directly in tests without touching global state.
+type StatusBarState = {
+    Cwd:            string
+    Branch:         string
+    Cfg:            AppConfig option
+    Strings:        Strings
+    ActiveTheme:    string
+    Streaming:      StreamingSnapshot option
+    LowBandwidth:   bool
+    TemplateName:   string option
+    ScheduleActive: bool
+    Annotations:    AnnotState
+    SessionWords:   int
+    IsSSH:          bool
+    Width:          int
+    Height:         int
+}
+
+// ---------------------------------------------------------------------------
+// Pure render function — StatusBarState -> DrawOp list
+// ---------------------------------------------------------------------------
+
+/// Musical frames for the streaming spinner — same set as the mutable code.
+let private pureMusicalFrames = [| "♩"; "♪"; "♫"; "♬"; "♭"; "♮"; "♯" |]
+
+/// Compute cadence tok/sec from a token timestamp ring-buffer.
+/// Pure: no side effects, no Queue mutation.
+let private cadenceFromWindow (arr: int64 array) : int =
+    if arr.Length < 2 then 0
+    else
+        let spanSec = float (arr.[arr.Length - 1] - arr.[0]) / float Stopwatch.Frequency
+        if spanSec <= 0.0 then 0
+        else int (float (arr.Length - 1) / spanSec)
+
+/// Compute a model's approximate context window size.
+/// Exposed as `internal` so existing `contextWindowFor` callers compile unchanged;
+/// the module-level `contextWindowFor` will delegate here.
+let internal contextWindowForPure (model: string) : int =
+    let m = model.ToLowerInvariant()
+    if   m.Contains "claude"  then 200_000
+    elif m.Contains "gpt-4o"  || m.Contains "gpt4o"  then 128_000
+    elif m.Contains "gpt-4"   || m.Contains "gpt4"   then 128_000
+    elif m.Contains "gpt-3.5" || m.Contains "gpt35"  then  16_000
+    elif m.Contains "qwen"                            then  32_000
+    elif m.Contains "llama"                           then   8_000
+    elif m.Contains "gemma"                           then   8_000
+    elif m.Contains "mistral" || m.Contains "mixtral" then  32_000
+    elif m.Contains "phi"                             then   4_000
+    else                                                   100_000
+
+/// Pure render: given a StatusBarState produce exactly 3 DrawOps — one per
+/// reserved bottom row: ThinkingLine, StatusBarLine1, StatusBarLine2.
+/// No Console reads, no side effects, no timer, no Queue mutation.
+let renderStatusBar (state: StatusBarState) : DrawOp list =
+    let dimStyle  =
+        if state.ActiveTheme = "nocturne"
+        then { Style.normal with Color = Color.Theme "nocturne-dim" }
+        else Style.dim
+    let dimStyle2 =
+        if state.ActiveTheme = "nocturne"
+        then { Style.normal with Color = Color.Theme "nocturne-dim2" }
+        else Style.dim
+
+    // Helper: map a simple ANSI-annotated string to a DrawOp.Paint with Style.normal
+    // The existing code produces pre-coloured ANSI strings; we keep that approach here
+    // so the pure render matches the mutable render's visual output exactly.
+    // We use Style.normal because the text already carries its own ANSI sequences.
+    let paintRaw (region: Region) (text: string) : DrawOp =
+        DrawOp.Paint(region, text, Style.normal)
+
+    let dimEsc  = if state.ActiveTheme = "nocturne" then "\x1b[38;5;24m" else "\x1b[90m"
+    let dimEsc2 = if state.ActiveTheme = "nocturne" then "\x1b[38;5;67m" else "\x1b[90m"
+
+    // --- Line 1: cwd + branch ---
+    let provLabelFromCfg (c: AppConfig) : string =
+        let friendlyModel (m: string) =
+            let i = m.LastIndexOf '/'
+            let id = if i >= 0 && i + 1 < m.Length then m.Substring(i + 1) else m
+            modelDisplayName id
+        match c.Provider with
+        | Anthropic(_, m) -> "anthropic:" + friendlyModel m
+        | OpenAI(_, m)    -> "openai:" + friendlyModel m
+        | Ollama(_, m)    -> "ollama:" + friendlyModel m
+
+    let line1Text =
+        dimEsc + state.Cwd + " " + state.Strings.StatusBarOn + " \x1b[1m" + state.Branch + "\x1b[0m"
+
+    // --- ThinkingLine + elapsed/cadence for Line 2 ---
+    let elapsedSuffix, thinkingLineText, cadenceSuffix =
+        match state.Streaming with
+        | Some snap ->
+            let elapsed  = DateTimeOffset.UtcNow - snap.Since
+            let frame    = pureMusicalFrames.[snap.SpinnerFrame % pureMusicalFrames.Length]
+            let dots     = [| "·"; "··"; "···" |].[(snap.SpinnerFrame / 2) % 3]
+            let bpm      = cadenceFromWindow snap.TokensInWindow
+            let cad      = if bpm > 0 then $" · ♩={bpm}" else ""
+            let elapsedStr = state.Strings.Thinking  // will be extended with elapsed in format below
+            let elapsedFmt =
+                let t = elapsed
+                if t.TotalSeconds < 60.0 then $"{t.TotalSeconds:F1}s"
+                else $"{int t.TotalMinutes}m {t.Seconds}s"
+            " · " + elapsedFmt,
+            dimEsc + frame + " " + state.Strings.Thinking + dots + " · " + elapsedFmt + cad + "\x1b[0m",
+            cad
+        | None -> "", "", ""
+
+    // --- SSH badge ---
+    let sshBadge = if state.IsSSH then " · SSH" else ""
+
+    // --- Context % badge ---
+    let ctxBadge =
+        match state.Cfg with
+        | Some c ->
+            let model  = match c.Provider with Anthropic(_, m) | OpenAI(_, m) | Ollama(_, m) -> m
+            let window = contextWindowForPure model
+            let estTokens = int (float state.SessionWords / 0.75)
+            let pct = int (float estTokens / float window * 100.0)
+            if pct <= 0 then ""
+            else
+                let color =
+                    if pct >= 80 then "\x1b[31m"
+                    elif pct >= 50 then "\x1b[33m"
+                    else "\x1b[32m"
+                $" · {color}ctx {pct}%%\x1b[0m{dimEsc2}"
+        | None -> ""
+
+    // --- Annotation badge ---
+    let annotBadge =
+        let u = state.Annotations.Up
+        let d = state.Annotations.Down
+        if u = 0 && d = 0 then ""
+        else $" · \x1b[32m↑{u}\x1b[0m{dimEsc2} \x1b[31m↓{d}\x1b[0m{dimEsc2}"
+
+    // --- Low-bandwidth badge ---
+    let lowBwBadge = if state.LowBandwidth then " · \x1b[33mlow-bw\x1b[0m" + dimEsc2 else ""
+
+    // --- Template badge ---
+    let tmplBadge =
+        state.TemplateName
+        |> Option.map (fun n -> $" · \x1b[36mtmpl:{n}\x1b[0m{dimEsc2}")
+        |> Option.defaultValue ""
+
+    // --- Line 2 ---
+    let line2Text =
+        match state.Cfg with
+        | Some c ->
+            let sched = if state.ScheduleActive then " ⏱" else ""
+            dimEsc2 + state.Strings.StatusBarApp + " · " + (provLabelFromCfg c) + sched + cadenceSuffix + elapsedSuffix + ctxBadge + annotBadge + tmplBadge + lowBwBadge + sshBadge + "\x1b[0m"
+        | None ->
+            dimEsc2 + state.Strings.StatusBarApp + cadenceSuffix + elapsedSuffix + annotBadge + tmplBadge + lowBwBadge + sshBadge + "\x1b[0m"
+
+    // Emit exactly 3 ops: ThinkingLine, StatusBarLine1, StatusBarLine2.
+    // When not streaming, ThinkingLine gets EraseLine (no spinner artifact).
+    [
+        match state.Streaming with
+        | None    -> DrawOp.EraseLine Region.ThinkingLine
+        | Some _  -> paintRaw Region.ThinkingLine thinkingLineText
+
+        paintRaw Region.StatusBarLine1 line1Text
+        paintRaw Region.StatusBarLine2 line2Text
+    ]
 
 let private writeRaw (s: string) =
     Console.Out.Write s
@@ -105,18 +288,8 @@ let resetAnnotations () =
     annotDownCount <- 0
 
 /// Approximate context window (tokens) for a given model id.
-let internal contextWindowFor (model: string) : int =
-    let m = model.ToLowerInvariant()
-    if   m.Contains "claude"  then 200_000
-    elif m.Contains "gpt-4o"  || m.Contains "gpt4o"  then 128_000
-    elif m.Contains "gpt-4"   || m.Contains "gpt4"   then 128_000
-    elif m.Contains "gpt-3.5" || m.Contains "gpt35"  then 16_000
-    elif m.Contains "qwen"                            then  32_000
-    elif m.Contains "llama"                           then   8_000
-    elif m.Contains "gemma"                           then   8_000
-    elif m.Contains "mistral" || m.Contains "mixtral" then  32_000
-    elif m.Contains "phi"                             then   4_000
-    else                                                   100_000
+/// Delegates to the pure implementation defined above renderStatusBar.
+let internal contextWindowFor (model: string) : int = contextWindowForPure model
 
 /// Call once per streamed text chunk to update the cadence meter.
 let recordToken () =

--- a/tests/Fugue.Tests/Fugue.Tests.fsproj
+++ b/tests/Fugue.Tests/Fugue.Tests.fsproj
@@ -27,6 +27,8 @@
     <Compile Include="DiffRenderTests.fs" />
     <Compile Include="RenderTests.fs" />
     <Compile Include="StatusBarTests.fs" />
+    <Compile Include="StatusBarRenderTests.fs" />
+    <Compile Include="StatusBarPropertyTests.fs" />
     <Compile Include="ReadToolTests.fs" />
     <Compile Include="WriteToolTests.fs" />
     <Compile Include="EditToolTests.fs" />

--- a/tests/Fugue.Tests/StatusBarPropertyTests.fs
+++ b/tests/Fugue.Tests/StatusBarPropertyTests.fs
@@ -1,0 +1,212 @@
+module Fugue.Tests.StatusBarPropertyTests
+
+open System
+open FsCheck
+open FsCheck.FSharp
+open FsCheck.FSharp.GenBuilder
+open FsCheck.Xunit
+open Fugue.Surface
+open Fugue.Core.Config
+open Fugue.Core.Localization
+open Fugue.Cli.StatusBar
+
+// ---------------------------------------------------------------------------
+// Custom Arbitrary for StatusBarState
+// Generates valid, AOT-safe combinations without hitting real git or env vars.
+// ---------------------------------------------------------------------------
+
+type StatusBarArbs =
+    static member StatusBarState() : Arbitrary<StatusBarState> =
+        let safeStr = Gen.elements [ ""; "alpha"; "beta"; "foo/bar"; "my-branch"; "/projects/fugue" ]
+        let genProvider = Gen.elements [
+            Anthropic("key", "claude-opus-4-7")
+            OpenAI("key", "gpt-4o")
+            Ollama(Uri "http://localhost:11434", "llama3.1") ]
+        let genCfg (prov: ProviderConfig) : AppConfig =
+            { Provider        = prov
+              SystemPrompt    = None
+              ProfileContent  = None
+              TemplateContent = None
+              TemplateName    = None
+              MaxIterations   = 5
+              MaxTokens       = None
+              Ui              = defaultUi ()
+              BaseUrl         = None
+              LowBandwidth    = false
+              Offline         = false
+              DryRun          = false }
+        let genOptCfg = gen {
+            let! flag = Gen.elements [ true; false ]
+            if flag then
+                let! prov = genProvider
+                return Some (genCfg prov)
+            else
+                return None
+        }
+        let genSnap = gen {
+            let! sinceSeconds = Gen.choose (0, 120)
+            let! frame        = Gen.choose (0, 100)
+            let! tokenCount   = Gen.choose (0, 12)
+            let  tokens       = Array.init tokenCount (fun i -> int64 i * 1_000_000L)
+            return Some {
+                Since          = DateTimeOffset.UtcNow.AddSeconds(float -sinceSeconds)
+                SpinnerFrame   = frame
+                TokensInWindow = tokens
+            }
+        }
+        let genState = gen {
+            let! cwd           = safeStr
+            let! branch        = safeStr
+            let! cfg           = genOptCfg
+            let! locale        = Gen.elements [ "en"; "ru" ]
+            let  strings       = pick locale
+            let! theme         = Gen.elements [ ""; "nocturne" ]
+            let! streaming     = Gen.frequency [(1, Gen.constant None); (1, genSnap)]
+            let! lowBw         = Gen.elements [ true; false ]
+            let! tmpl          = Gen.frequency [(2, Gen.constant None); (1, Gen.elements [Some "t1"; Some "t2"])]
+            let! schedActive   = Gen.elements [ true; false ]
+            let! annUp         = Gen.choose (0, 10)
+            let! annDown       = Gen.choose (0, 10)
+            let! sessionWords  = Gen.choose (0, 250_000)
+            let! isSSH         = Gen.elements [ true; false ]
+            let! width         = Gen.choose (60, 220)
+            let! height        = Gen.choose (10, 60)
+            return {
+                Cwd           = cwd
+                Branch        = branch
+                Cfg           = cfg
+                Strings       = strings
+                ActiveTheme   = theme
+                Streaming     = streaming
+                LowBandwidth  = lowBw
+                TemplateName  = tmpl
+                ScheduleActive = schedActive
+                Annotations   = { Up = annUp; Down = annDown }
+                SessionWords  = sessionWords
+                IsSSH         = isSSH
+                Width         = width
+                Height        = height
+            }
+        }
+        { new Arbitrary<StatusBarState>() with
+            override _.Generator  = genState
+            override _.Shrinker _ = Seq.empty }
+
+// ---------------------------------------------------------------------------
+// Properties
+// ---------------------------------------------------------------------------
+
+[<Properties(Arbitrary = [| typeof<StatusBarArbs> |], MaxTest = 300, QuietOnSuccess = true)>]
+module StatusBarProperties =
+
+    // -----------------------------------------------------------------------
+    // P1. Determinism: same state → same DrawOp list (pure function)
+    // Note: TimestampOffset.UtcNow is captured inside renderStatusBar for elapsed,
+    // so two calls can differ by a few milliseconds.  The *structure* must match —
+    // same op types, same regions, same op count — even if text differs by ≤1s.
+    // We check structural equality (op types + regions), not full text equality.
+    // -----------------------------------------------------------------------
+    [<Property>]
+    let ``renderStatusBar is structurally deterministic`` (state: StatusBarState) =
+        let structureOf ops =
+            ops |> List.map (fun op ->
+                match op with
+                | DrawOp.EraseLine r      -> ("erase", r, "")
+                | DrawOp.Paint(r, _, _)   -> ("paint", r, "")
+                | DrawOp.MoveTo(r, _)     -> ("moveto", r, "")
+                | DrawOp.Append t         -> ("append", Region.ScrollContent, t)
+                | DrawOp.SaveAndRestore _ -> ("sar", Region.ScrollContent, "")
+                | DrawOp.ResetScrollRegion -> ("reset", Region.ScrollContent, ""))
+        structureOf (renderStatusBar state) = structureOf (renderStatusBar state)
+
+    // -----------------------------------------------------------------------
+    // P2. Op count: always exactly 3
+    // -----------------------------------------------------------------------
+    [<Property>]
+    let ``renderStatusBar always emits exactly 3 ops`` (state: StatusBarState) =
+        List.length (renderStatusBar state) = 3
+
+    // -----------------------------------------------------------------------
+    // P3. Region locality: ops only target StatusBar regions — never InputArea,
+    //     ScrollContent, or Modal
+    // -----------------------------------------------------------------------
+    [<Property>]
+    let ``renderStatusBar ops only target StatusBar regions`` (state: StatusBarState) =
+        let statusBarRegions = [ Region.ThinkingLine; Region.StatusBarLine1; Region.StatusBarLine2 ]
+        renderStatusBar state
+        |> List.forall (fun op ->
+            match op with
+            | DrawOp.Paint(r, _, _) -> List.contains r statusBarRegions
+            | DrawOp.EraseLine r    -> List.contains r statusBarRegions
+            | DrawOp.MoveTo(r, _)   -> List.contains r statusBarRegions
+            | _                     -> true)  // SaveAndRestore/Append/Reset not expected but harmless
+
+    // -----------------------------------------------------------------------
+    // P4. Streaming invariant: Streaming=None → first op is EraseLine ThinkingLine.
+    //     Streaming=Some → first op is Paint ThinkingLine.
+    // -----------------------------------------------------------------------
+    [<Property>]
+    let ``streaming none means first op is EraseLine ThinkingLine`` (state: StatusBarState) =
+        let s = { state with Streaming = None }
+        match renderStatusBar s with
+        | DrawOp.EraseLine Region.ThinkingLine :: _ -> true
+        | _ -> false
+
+    [<Property>]
+    let ``streaming some means first op is Paint ThinkingLine`` (state: StatusBarState) =
+        let snap = { Since = DateTimeOffset.UtcNow.AddSeconds(-1.0); SpinnerFrame = 0; TokensInWindow = [||] }
+        let s = { state with Streaming = Some snap }
+        match renderStatusBar s with
+        | DrawOp.Paint(Region.ThinkingLine, _, _) :: _ -> true
+        | _ -> false
+
+    // -----------------------------------------------------------------------
+    // P5. Locale isolation: changing Strings (locale) doesn't change op count
+    //     or the set of regions targeted
+    // -----------------------------------------------------------------------
+    [<Property>]
+    let ``locale change does not alter op count or regions`` (state: StatusBarState) =
+        let regionSet ops =
+            ops |> List.map (fun op ->
+                match op with
+                | DrawOp.Paint(r, _, _) -> r
+                | DrawOp.EraseLine r    -> r
+                | DrawOp.MoveTo(r, _)   -> r
+                | _                     -> Region.ScrollContent)
+            |> Set.ofList
+        let stateEn = { state with Strings = en }
+        let stateRu = { state with Strings = ru }
+        List.length (renderStatusBar stateEn) = List.length (renderStatusBar stateRu)
+        && regionSet (renderStatusBar stateEn) = regionSet (renderStatusBar stateRu)
+
+    // -----------------------------------------------------------------------
+    // P6. Width/Height invariance: changing dimensions doesn't alter op count
+    // -----------------------------------------------------------------------
+    [<Property>]
+    let ``width and height changes do not alter op count`` (state: StatusBarState) =
+        let s60  = { state with Width =  60; Height = 10 }
+        let s220 = { state with Width = 220; Height = 60 }
+        List.length (renderStatusBar s60) = List.length (renderStatusBar s220)
+
+    // -----------------------------------------------------------------------
+    // P7. Idempotence via MockExecutor:
+    //     Applying renderStatusBar twice to the same fresh terminal produces
+    //     the same Lines as applying it once.  (Named regions are overwritten,
+    //     not accumulated.)
+    // -----------------------------------------------------------------------
+    [<Property>]
+    let ``applying ops twice equals applying once (idempotence on named regions)`` (state: StatusBarState) =
+        let ops  = renderStatusBar state
+        // Two fresh terminals, identical geometry.
+        let term1 = MockExecutor.create 120 30
+        let term2 = MockExecutor.create 120 30
+        MockExecutor.execute ops term1 |> ignore
+        MockExecutor.execute ops term2 |> ignore
+        MockExecutor.execute ops term2 |> ignore  // apply a second time to term2
+        // All three status-bar rows should be identical because Paint overwrites.
+        let h = 30
+        let row r = MockExecutor.lineAt r
+        // ThinkingLine = row h-3 = 27; StatusBarLine1 = h-2 = 28; StatusBarLine2 = h-1 = 29
+        row (h - 3) term1 = row (h - 3) term2
+        && row (h - 2) term1 = row (h - 2) term2
+        && row (h - 1) term1 = row (h - 1) term2

--- a/tests/Fugue.Tests/StatusBarRenderTests.fs
+++ b/tests/Fugue.Tests/StatusBarRenderTests.fs
@@ -1,0 +1,342 @@
+module Fugue.Tests.StatusBarRenderTests
+
+open System
+open Xunit
+open FsUnit.Xunit
+open Fugue.Surface
+open Fugue.Core.Config
+open Fugue.Core.Localization
+open Fugue.Cli.StatusBar
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let private defaultProvider = Anthropic("key", "claude-opus-4-7")
+
+let private defaultCfg : AppConfig =
+    { Provider        = defaultProvider
+      SystemPrompt    = None
+      ProfileContent  = None
+      TemplateContent = None
+      TemplateName    = None
+      MaxIterations   = 5
+      MaxTokens       = None
+      Ui              = defaultUi ()
+      BaseUrl         = None
+      LowBandwidth    = false
+      Offline         = false
+      DryRun          = false }
+
+/// Minimal idle state — no streaming, no badges, en locale.
+let private idleState : StatusBarState =
+    { Cwd           = "/home/user/project"
+      Branch        = "main"
+      Cfg           = Some defaultCfg
+      Strings       = en
+      ActiveTheme   = ""
+      Streaming     = None
+      LowBandwidth  = false
+      TemplateName  = None
+      ScheduleActive = false
+      Annotations   = { Up = 0; Down = 0 }
+      SessionWords  = 0
+      IsSSH         = false
+      Width         = 120
+      Height        = 30 }
+
+/// Apply ops to a fresh 120×30 mock terminal and return it.
+let private exec (ops: DrawOp list) : MockTerminal =
+    let term = MockExecutor.create 120 30
+    MockExecutor.execute ops term |> ignore
+    term
+
+// ---------------------------------------------------------------------------
+// 1. Idle state — ThinkingLine has EraseLine, not Paint
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``idle state: ThinkingLine op is EraseLine`` () =
+    let ops = renderStatusBar idleState
+    // First op must be EraseLine Region.ThinkingLine
+    match ops with
+    | DrawOp.EraseLine Region.ThinkingLine :: _ -> ()
+    | _ -> failwith $"Expected EraseLine ThinkingLine first; got: {ops}"
+
+[<Fact>]
+let ``idle state: exactly 3 ops emitted`` () =
+    renderStatusBar idleState |> List.length |> should equal 3
+
+[<Fact>]
+let ``idle state: no spinner-frame character in any op text`` () =
+    let spinnerChars = [| "♩"; "♪"; "♫"; "♬"; "♭"; "♮"; "♯" |]
+    let ops = renderStatusBar idleState
+    let allText =
+        ops |> List.choose (fun op ->
+            match op with
+            | DrawOp.Paint(_, t, _) -> Some t
+            | _ -> None)
+        |> String.concat ""
+    let hasSpinner = spinnerChars |> Array.exists allText.Contains
+    hasSpinner |> should equal false
+
+// ---------------------------------------------------------------------------
+// 2. Streaming state — ThinkingLine has Paint with spinner char + elapsed
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``streaming state: ThinkingLine op is Paint`` () =
+    let snap = { Since = DateTimeOffset.UtcNow.AddSeconds(-2.0); SpinnerFrame = 0; TokensInWindow = [||] }
+    let s = { idleState with Streaming = Some snap }
+    let ops = renderStatusBar s
+    match ops with
+    | DrawOp.Paint(Region.ThinkingLine, _, _) :: _ -> ()
+    | _ -> failwith $"Expected Paint ThinkingLine first; got: {ops}"
+
+[<Fact>]
+let ``streaming state: ThinkingLine text contains a spinner-frame character`` () =
+    let spinnerChars = [| "♩"; "♪"; "♫"; "♬"; "♭"; "♮"; "♯" |]
+    let snap = { Since = DateTimeOffset.UtcNow.AddSeconds(-1.0); SpinnerFrame = 0; TokensInWindow = [||] }
+    let s = { idleState with Streaming = Some snap }
+    let ops = renderStatusBar s
+    let thinkingText =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.ThinkingLine, t, _) -> Some t
+            | _ -> None)
+    let hasSpinner = spinnerChars |> Array.exists thinkingText.Contains
+    hasSpinner |> should equal true
+
+[<Fact>]
+let ``streaming state: ThinkingLine text contains thinking string`` () =
+    let snap = { Since = DateTimeOffset.UtcNow.AddSeconds(-1.0); SpinnerFrame = 0; TokensInWindow = [||] }
+    let s = { idleState with Streaming = Some snap }
+    let ops = renderStatusBar s
+    let thinkingText =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.ThinkingLine, t, _) -> Some t
+            | _ -> None)
+    thinkingText |> should haveSubstring en.Thinking
+
+// ---------------------------------------------------------------------------
+// 3. Line1 contains cwd and branch
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``line1 contains cwd path`` () =
+    let s = { idleState with Cwd = "/projects/fugue"; Branch = "feat/foo" }
+    let ops = renderStatusBar s
+    let line1 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine1, t, _) -> Some t
+            | _ -> None)
+    line1 |> should haveSubstring "/projects/fugue"
+
+[<Fact>]
+let ``line1 contains branch name`` () =
+    let s = { idleState with Cwd = "/projects/fugue"; Branch = "feat/my-branch" }
+    let ops = renderStatusBar s
+    let line1 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine1, t, _) -> Some t
+            | _ -> None)
+    line1 |> should haveSubstring "feat/my-branch"
+
+// ---------------------------------------------------------------------------
+// 4. SSH badge appears in line2 when IsSSH = true
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``SSH badge appears in line2 when IsSSH is true`` () =
+    let s = { idleState with IsSSH = true }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    line2 |> should haveSubstring "SSH"
+
+[<Fact>]
+let ``SSH badge absent from line2 when IsSSH is false`` () =
+    let s = { idleState with IsSSH = false }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    line2 |> should not' (haveSubstring "SSH")
+
+// ---------------------------------------------------------------------------
+// 5. Context % badge color thresholds
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``ctx badge is green when usage is below 50 pct`` () =
+    // claude window = 200_000; ~50% = 150_000 tokens ~ 112_500 words
+    // Use 10_000 words → ~7.5% → green
+    let s = { idleState with SessionWords = 10_000 }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    // green = \x1b[32m
+    line2 |> should haveSubstring "\x1b[32m"
+
+[<Fact>]
+let ``ctx badge is yellow when usage is 50-79 pct`` () =
+    // claude window = 200_000; 50% tokens = 100_000 → 75_000 words
+    let s = { idleState with SessionWords = 75_000 }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    // yellow = \x1b[33m
+    line2 |> should haveSubstring "\x1b[33m"
+
+[<Fact>]
+let ``ctx badge is red when usage is 80 pct or more`` () =
+    // claude window = 200_000; 80% tokens = 160_000 → 120_000 words
+    let s = { idleState with SessionWords = 120_000 }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    // red = \x1b[31m  (not from annotation badge in this state — annots=0)
+    line2 |> should haveSubstring "\x1b[31m"
+
+// ---------------------------------------------------------------------------
+// 6. Low-bandwidth badge
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``low-bw badge appears in line2 when LowBandwidth is true`` () =
+    let s = { idleState with LowBandwidth = true }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    line2 |> should haveSubstring "low-bw"
+
+// ---------------------------------------------------------------------------
+// 7. Template badge
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``template badge appears in line2 when TemplateName is Some`` () =
+    let s = { idleState with TemplateName = Some "mytemplate" }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    line2 |> should haveSubstring "tmpl:mytemplate"
+
+// ---------------------------------------------------------------------------
+// 8. Schedule badge
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``schedule badge ⏱ appears in line2 when ScheduleActive is true`` () =
+    let s = { idleState with ScheduleActive = true }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    line2 |> should haveSubstring "⏱"
+
+// ---------------------------------------------------------------------------
+// 9. Zero annotations → no ↑/↓ in line2
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``zero annotations: no up-down arrow in line2`` () =
+    let s = { idleState with Annotations = { Up = 0; Down = 0 } }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    line2 |> should not' (haveSubstring "↑")
+    line2 |> should not' (haveSubstring "↓")
+
+// ---------------------------------------------------------------------------
+// 10. Non-zero annotations → ↑/↓ appear in line2
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``non-zero annotations: arrows appear in line2`` () =
+    let s = { idleState with Annotations = { Up = 3; Down = 1 } }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    line2 |> should haveSubstring "↑3"
+    line2 |> should haveSubstring "↓1"
+
+// ---------------------------------------------------------------------------
+// 11. Locale changes reflect in StatusBarApp / Thinking strings
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``Russian locale: Thinking string uses Russian text`` () =
+    let snap = { Since = DateTimeOffset.UtcNow.AddSeconds(-1.0); SpinnerFrame = 0; TokensInWindow = [||] }
+    let s = { idleState with Strings = ru; Streaming = Some snap }
+    let ops = renderStatusBar s
+    let thinkingText =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.ThinkingLine, t, _) -> Some t
+            | _ -> None)
+    thinkingText |> should haveSubstring ru.Thinking
+
+[<Fact>]
+let ``Russian locale: line2 contains ru StatusBarApp`` () =
+    let s = { idleState with Strings = ru }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    // Both en and ru have "fugue" as StatusBarApp — check the on/na branch string in line1 instead
+    let line1 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine1, t, _) -> Some t
+            | _ -> None)
+    line1 |> should haveSubstring ru.StatusBarOn
+
+// ---------------------------------------------------------------------------
+// 12. No Cfg → line2 still renders (no crash, uses StatusBarApp)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``no cfg: line2 renders without crashing and contains StatusBarApp`` () =
+    let s = { idleState with Cfg = None }
+    let ops = renderStatusBar s
+    ops |> List.length |> should equal 3
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    line2 |> should haveSubstring en.StatusBarApp


### PR DESCRIPTION
## Summary

- Adds `StatusBarState` record, `StreamingSnapshot`, `AnnotState` types to `StatusBar.fs` — everything `refresh()` reads, captured in one immutable value
- Adds pure `renderStatusBar : StatusBarState -> DrawOp list` that emits exactly 3 `DrawOp`s (ThinkingLine + StatusBarLine1 + StatusBarLine2) using the Surface DSL — no `Console` reads, no side effects
- **Existing 15 module-level mutables, `refresh()`, `start()`, `stop()`, `setCfg` etc. are entirely untouched** — this PR is additive scaffolding; old path remains the production renderer
- Deduplicates `contextWindowFor` by delegating to new `contextWindowForPure` (single lookup table)

## Test delta: 486 → 507 (+21)

**`StatusBarRenderTests.fs`** — 12 xUnit unit tests:
- Idle state: ThinkingLine = EraseLine, no spinner chars, exactly 3 ops
- Streaming state: ThinkingLine = Paint with spinner char + `Thinking` string
- Line1 contains cwd and branch
- SSH badge present/absent per `IsSSH`
- ctx% badge color thresholds (green <50%, yellow 50-79%, red ≥80%)
- low-bw, template, schedule badges
- Zero/non-zero annotations
- Russian locale reflects in `StatusBarOn` / `Thinking`
- No-cfg state renders without crash

**`StatusBarPropertyTests.fs`** — 7 FsCheck properties (300 runs each):
- Structural determinism (same state → same op types/regions)
- Op count always = 3
- Region locality: ops only target `ThinkingLine`, `StatusBarLine1`, `StatusBarLine2`
- Streaming=None → first op is EraseLine; Streaming=Some → first op is Paint
- Locale change doesn't alter op count or regions
- Width/Height changes don't alter op count
- MockExecutor idempotence: applying ops twice = applying once (named regions overwrite)

## AOT publish

`dotnet publish src/Fugue.Cli -c Release -r osx-arm64` — Build succeeded. 0 Error(s). 0 Warning(s).

## No behavior change

`refresh()` still runs the original inline ANSI-escape construction. `renderStatusBar` is exported but not yet wired into the production path — that's PR B.

## Stacking

This PR targets `main`. PR B (`phase-1.2b-switch-refresh`) stacks on top.