### PR TITLE
feat(statusbar): wire RealExecutor MailboxProcessor actor — eliminates timer race (Phase 1.2c)

### DIFF
--- a/src/Fugue.Cli/Program.fs
+++ b/src/Fugue.Cli/Program.fs
@@ -5,6 +5,7 @@ open System.Diagnostics.CodeAnalysis
 open Microsoft.Agents.AI
 open Fugue.Core.Config
 open Fugue.Agent
+open Fugue.Surface
 
 let private noColor () =
     let isSet name = Environment.GetEnvironmentVariable name |> isNull |> not
@@ -127,16 +128,31 @@ let private runWithCfg (cfg: AppConfig) : int =
     // CreateSessionAsync and on each /new / /clear-history. Replaces an older
     // module-level mutable in GetConversationFn (#50).
     let sessionRef : (Microsoft.Agents.AI.AgentSession | null) ref = ref null
-    let agent = buildAgent cfg hooksConfig providerContext lastSummary sessionId sessionRef
+    let aiAgent = buildAgent cfg hooksConfig providerContext lastSummary sessionId sessionRef
+    // Start the Surface actor — serialises all terminal writes and eliminates the
+    // timer-thread race.  Wire it into StatusBar before start() is called.
+    let surfaceActor =
+        if Console.IsInputRedirected then None
+        else
+            let actor = RealExecutor.start ()
+            StatusBar.setAgent actor
+            Some actor
     let t =
-        if Console.IsInputRedirected then Repl.runHeadless agent cfg cwd
-        else Repl.run agent sessionRef cfg cwd lastSummary (fun newCfg -> buildAgent newCfg hooksConfig providerContext None sessionId sessionRef)
+        if Console.IsInputRedirected then Repl.runHeadless aiAgent cfg cwd
+        else Repl.run aiAgent sessionRef cfg cwd lastSummary (fun newCfg -> buildAgent newCfg hooksConfig providerContext None sessionId sessionRef)
     try t.Wait()
     with
     | :? AggregateException as agg ->
         match agg.InnerException with
         | :? OperationCanceledException -> ()
         | _ -> raise agg
+    // Graceful shutdown: StatusBar.stop() already posted ExecuteAndAck for erase ops.
+    // Now shut down the actor so any remaining buffered ops flush before process exits.
+    match surfaceActor with
+    | Some actor ->
+        actor.PostAndAsyncReply(fun ch -> SurfaceMessage.Shutdown ch)
+        |> Async.RunSynchronously
+    | None -> ()
     0
 
 [<EntryPoint>]

--- a/src/Fugue.Cli/StatusBar.fs
+++ b/src/Fugue.Cli/StatusBar.fs
@@ -212,8 +212,6 @@ let mutable private scheduleActive = false
 let mutable private spinnerTimer  : System.Threading.Timer option = None
 let mutable private onTick        : (unit -> unit) = fun () -> ()
 
-let private musicalFrames = [| "♩"; "♪"; "♫"; "♬"; "♭"; "♮"; "♯" |]
-
 // Cadence — rolling window of token arrival timestamps for tok/s display.
 let private tokenQueue = System.Collections.Generic.Queue<int64>()
 let private tokenWindowSize = 12
@@ -254,16 +252,6 @@ let private homeRel (path: string) : string =
     if home <> "" && path.StartsWith home then "~" + path.Substring(home.Length)
     else path
 
-let private providerLabel (cfg: AppConfig) : string =
-    let friendlyModel (m: string) =
-        let i = m.LastIndexOf '/'
-        let id = if i >= 0 && i + 1 < m.Length then m.Substring(i + 1) else m
-        modelDisplayName id
-    match cfg.Provider with
-    | Anthropic(_, m) -> "anthropic:" + friendlyModel m
-    | OpenAI(_, m)    -> "openai:" + friendlyModel m
-    | Ollama(_, m)    -> "ollama:" + friendlyModel m
-
 let internal formatElapsed (t: TimeSpan) : string =
     if t.TotalSeconds < 60.0 then $"{t.TotalSeconds:F1}s"
     else $"{int t.TotalMinutes}m {t.Seconds}s"
@@ -297,14 +285,6 @@ let recordToken () =
     tokenQueue.Enqueue now
     if tokenQueue.Count > tokenWindowSize then tokenQueue.Dequeue() |> ignore
 
-let private cadenceTokPerSec () : int =
-    if tokenQueue.Count < 2 then 0
-    else
-        let arr = tokenQueue.ToArray()
-        let spanSec = float (arr.[arr.Length - 1] - arr.[0]) / float Stopwatch.Frequency
-        if spanSec <= 0.0 then 0
-        else int (float (arr.Length - 1) / spanSec)
-
 let startStreaming () =
     streamingSince <- Some DateTime.UtcNow
     tokenQueue.Clear()
@@ -321,69 +301,87 @@ let stopStreaming () =
     | Some t -> t.Dispose(); spinnerTimer <- None
     | None   -> ()
 
-let refresh () =
-    if not active || compactMode || not (Render.isColorEnabled ()) then () else
-    let height = Console.WindowHeight
+/// Read the 15 module-level mutables and build an immutable StatusBarState snapshot.
+/// Advances spinnerFrame as a side effect when streaming (mirrors old refresh behaviour).
+let private captureState () : StatusBarState =
     let strings =
         match cfg with
         | Some c -> Fugue.Core.Localization.pick c.Ui.Locale
         | None   -> Fugue.Core.Localization.en
-    let dimEsc = if activeTheme = "nocturne" then "\x1b[38;5;24m" else "\x1b[90m"
-    let line1 =
-        dimEsc + (homeRel cwd) + " " + strings.StatusBarOn + " \x1b[1m" + (branchOf cwd) + "\x1b[0m"
-    let elapsedSuffix, thinkingLine, cadenceSuffix =
+    let snap =
         match streamingSince with
+        | None -> None
         | Some since ->
-            let elapsed = DateTime.UtcNow - since
-            let frame = musicalFrames.[spinnerFrame % musicalFrames.Length]
-            spinnerFrame <- spinnerFrame + 1
-            let dots = [| "·"; "··"; "···" |].[(spinnerFrame / 2) % 3]
-            let bpm = cadenceTokPerSec ()
-            let cad = if bpm > 0 then $" · ♩={bpm}" else ""
-            " · " + formatElapsed elapsed,
-            dimEsc + frame + " " + strings.Thinking + dots + " · " + formatElapsed elapsed + cad + "\x1b[0m",
-            cad
-        | None -> "", "", ""
-    let sshBadge = if isSSH then " · SSH" else ""
-    let dimEsc2 = if activeTheme = "nocturne" then "\x1b[38;5;67m" else "\x1b[90m"
-    let ctxBadge =
-        match cfg with
-        | Some c ->
-            let model = match c.Provider with Anthropic(_, m) | OpenAI(_, m) | Ollama(_, m) -> m
-            let window = contextWindowFor model
-            let estTokens = int (float sessionWords / 0.75)
-            let pct = int (float estTokens / float window * 100.0)
-            if pct <= 0 then ""
-            else
-                let color =
-                    if pct >= 80 then "\x1b[31m"      // red
-                    elif pct >= 50 then "\x1b[33m"    // yellow
-                    else "\x1b[32m"                   // green
-                $" · {color}ctx {pct}%%\x1b[0m{dimEsc2}"
-        | None -> ""
-    let annotBadge =
-        if annotUpCount = 0 && annotDownCount = 0 then ""
-        else $" · \x1b[32m↑{annotUpCount}\x1b[0m{dimEsc2} \x1b[31m↓{annotDownCount}\x1b[0m{dimEsc2}"
-    let lowBwBadge = if lowBandwidthMode then " · \x1b[33mlow-bw\x1b[0m" + dimEsc2 else ""
-    let tmplBadge = templateName |> Option.map (fun n -> $" · \x1b[36mtmpl:{n}\x1b[0m{dimEsc2}") |> Option.defaultValue ""
-    let line2 =
-        match cfg with
-        | Some c ->
-            let sched = if scheduleActive then " ⏱" else ""
-            dimEsc2 + strings.StatusBarApp + " · " + (providerLabel c) + sched + cadenceSuffix + elapsedSuffix + ctxBadge + annotBadge + tmplBadge + lowBwBadge + sshBadge + "\x1b[0m"
-        | None   -> dimEsc2 + strings.StatusBarApp + cadenceSuffix + elapsedSuffix + annotBadge + tmplBadge + lowBwBadge + sshBadge + "\x1b[0m"
-    // save cursor, paint 3 reserved bottom lines: thinking@h-2, status1@h-1, status2@h
+            let frame = spinnerFrame
+            spinnerFrame <- spinnerFrame + 1   // advance spinner — same as old refresh
+            Some {
+                Since          = DateTimeOffset(since.ToUniversalTime(), TimeSpan.Zero)
+                SpinnerFrame   = frame
+                TokensInWindow = tokenQueue.ToArray()
+            }
+    { Cwd           = homeRel cwd
+      Branch        = branchOf cwd
+      Cfg           = cfg
+      Strings       = strings
+      ActiveTheme   = activeTheme
+      Streaming     = snap
+      LowBandwidth  = lowBandwidthMode
+      TemplateName  = templateName
+      ScheduleActive = scheduleActive
+      Annotations   = { Up = annotUpCount; Down = annotDownCount }
+      SessionWords  = sessionWords
+      IsSSH         = isSSH
+      Width         = Console.WindowWidth
+      Height        = Console.WindowHeight }
+
+/// Walk a DrawOp list and emit ANSI escapes directly to Console.Out.
+/// Synchronous, no MailboxProcessor — PR B bridge.  PR C replaces this
+/// with agent.Post(SurfaceMessage.Execute ops).
+let private applyOpsDirectly (ops: DrawOp list) : unit =
+    let h = Console.WindowHeight
+    // Translate Region to 1-based ANSI row (same mapping as RealExecutor.ansiRow).
+    let ansiRow (region: Region) : int option =
+        match region with
+        | Region.ThinkingLine   -> Some (h - 2)
+        | Region.StatusBarLine1 -> Some (h - 1)
+        | Region.StatusBarLine2 -> Some h
+        | Region.InputArea r    -> Some (max 1 (h - 3 - r))
+        | Region.ScrollContent  -> None
+        | Region.Modal          -> Some 1
+    let rec applyOne (op: DrawOp) =
+        match op with
+        | DrawOp.Paint(region, text, _style) ->
+            match ansiRow region with
+            | Some row -> writeRaw $"\x1b[{row};1H\x1b[2K{text}"
+            | None     -> writeRaw text
+        | DrawOp.EraseLine region ->
+            match ansiRow region with
+            | Some row -> writeRaw $"\x1b[{row};1H\x1b[2K"
+            | None     -> writeRaw "\x1b[2K"
+        | DrawOp.MoveTo(region, col) ->
+            let col1 = col + 1
+            match ansiRow region with
+            | Some row -> writeRaw $"\x1b[{row};{col1}H"
+            | None     -> writeRaw $"\x1b[{col1}G"
+        | DrawOp.SaveAndRestore inner ->
+            writeRaw "\x1b[s"
+            for innerOp in inner do applyOne innerOp
+            writeRaw "\x1b[u"
+        | DrawOp.Append text ->
+            writeRaw text
+            writeRaw "\r\n"
+        | DrawOp.ResetScrollRegion ->
+            let w = Console.WindowWidth
+            writeRaw $"\x1b[1;{h}r\x1b[{h};{w}H"
     writeRaw "\x1b[s"
-    writeRaw ("\x1b[" + string (height - 2) + ";1H")
-    writeRaw "\x1b[2K"
-    writeRaw thinkingLine
-    writeRaw ("\x1b[" + string (height - 1) + ";1H")
-    writeRaw "\x1b[2K"
-    writeRaw line1
-    writeRaw ("\x1b[" + string height + ";1H")
-    writeRaw "\x1b[2K"
-    writeRaw line2
+    for op in ops do applyOne op
     writeRaw "\x1b[u"
+
+let refresh () =
+    if not active || compactMode || not (Render.isColorEnabled ()) then () else
+    let state = captureState ()
+    let ops   = renderStatusBar state
+    applyOpsDirectly ops
 
 /// Update the config the status bar reads from. Use after `/model set` and
 /// other config-mutating commands. `start` early-returns once the bar is

--- a/src/Fugue.Cli/StatusBar.fs
+++ b/src/Fugue.Cli/StatusBar.fs
@@ -212,6 +212,15 @@ let mutable private scheduleActive = false
 let mutable private spinnerTimer  : System.Threading.Timer option = None
 let mutable private onTick        : (unit -> unit) = fun () -> ()
 
+/// The Surface MailboxProcessor actor — set once by Program.fs before Repl.run.
+/// When set, refresh() posts DrawOps via the actor (serialises all writes).
+/// When None, falls back to applyOpsDirectly (sync, used in tests / headless).
+let mutable private surfaceAgent : MailboxProcessor<SurfaceMessage> option = None
+
+/// Wire the Surface actor.  Call once before StatusBar.start.
+let setAgent (agent: MailboxProcessor<SurfaceMessage>) : unit =
+    surfaceAgent <- Some agent
+
 // Cadence — rolling window of token arrival timestamps for tok/s display.
 let private tokenQueue = System.Collections.Generic.Queue<int64>()
 let private tokenWindowSize = 12
@@ -381,7 +390,9 @@ let refresh () =
     if not active || compactMode || not (Render.isColorEnabled ()) then () else
     let state = captureState ()
     let ops   = renderStatusBar state
-    applyOpsDirectly ops
+    match surfaceAgent with
+    | Some agent -> agent.Post(SurfaceMessage.Execute ops)   // serialised — no race
+    | None       -> applyOpsDirectly ops                     // fallback (headless / tests)
 
 /// Update the config the status bar reads from. Use after `/model set` and
 /// other config-mutating commands. `start` early-returns once the bar is
@@ -414,13 +425,30 @@ let stop () : unit =
     if not active || not (Render.isColorEnabled ()) then () else
     if not compactMode then
         let height = Console.WindowHeight
-        writeRaw "\x1b[r"          // reset scroll region
-        writeRaw ("\x1b[" + string (height - 2) + ";1H")
-        writeRaw "\x1b[2K"
-        writeRaw ("\x1b[" + string (height - 1) + ";1H")
-        writeRaw "\x1b[2K"
-        writeRaw ("\x1b[" + string height + ";1H")
-        writeRaw "\x1b[2K"
-        writeRaw "\x1b[u"
+        // Erase the 3 reserved rows and reset scroll region.
+        // If the Surface agent is running, use ExecuteAndAck so the terminal is
+        // fully clean before Program.fs exits and the agent is shut down.
+        let eraseOps = [
+            DrawOp.EraseLine Region.ThinkingLine
+            DrawOp.EraseLine Region.StatusBarLine1
+            DrawOp.EraseLine Region.StatusBarLine2
+            DrawOp.ResetScrollRegion
+        ]
+        match surfaceAgent with
+        | Some agent ->
+            // Synchronous barrier: wait for the agent to flush the erase ops
+            // before we proceed to shut it down.
+            agent.PostAndAsyncReply(fun ch -> SurfaceMessage.ExecuteAndAck(eraseOps, ch))
+            |> Async.RunSynchronously
+        | None ->
+            // Fallback: erase directly (headless / tests / no agent wired).
+            writeRaw "\x1b[r"          // reset scroll region
+            writeRaw ("\x1b[" + string (height - 2) + ";1H")
+            writeRaw "\x1b[2K"
+            writeRaw ("\x1b[" + string (height - 1) + ";1H")
+            writeRaw "\x1b[2K"
+            writeRaw ("\x1b[" + string height + ";1H")
+            writeRaw "\x1b[2K"
+            writeRaw "\x1b[u"
     active <- false
     compactMode <- false

--- a/src/Fugue.Cli/StatusBar.fs
+++ b/src/Fugue.Cli/StatusBar.fs
@@ -5,6 +5,189 @@ open System.Diagnostics
 open System.IO
 open Fugue.Core.Localization
 open Fugue.Core.Config
+open Fugue.Surface
+
+// ---------------------------------------------------------------------------
+// Pure render types — used by renderStatusBar (no Console dependency)
+// ---------------------------------------------------------------------------
+
+/// Annotation counts for thumbs-up / thumbs-down turn ratings.
+type AnnotState = { Up: int; Down: int }
+
+/// Snapshot of the streaming meter — all values needed to render the
+/// ThinkingLine without touching any global mutable.
+type StreamingSnapshot = {
+    /// Wall-clock time when streaming started (for elapsed display).
+    Since:           DateTimeOffset
+    /// Current spinner frame index (caller advances this).
+    SpinnerFrame:    int
+    /// Ring-buffer of Stopwatch timestamps (last N token arrivals for tok/s).
+    TokensInWindow:  int64 array
+}
+
+/// Immutable snapshot of everything the status bar needs to render one frame.
+/// Populated by captureState () from the 15 module-level mutables;
+/// can also be constructed directly in tests without touching global state.
+type StatusBarState = {
+    Cwd:            string
+    Branch:         string
+    Cfg:            AppConfig option
+    Strings:        Strings
+    ActiveTheme:    string
+    Streaming:      StreamingSnapshot option
+    LowBandwidth:   bool
+    TemplateName:   string option
+    ScheduleActive: bool
+    Annotations:    AnnotState
+    SessionWords:   int
+    IsSSH:          bool
+    Width:          int
+    Height:         int
+}
+
+// ---------------------------------------------------------------------------
+// Pure render function — StatusBarState -> DrawOp list
+// ---------------------------------------------------------------------------
+
+/// Musical frames for the streaming spinner — same set as the mutable code.
+let private pureMusicalFrames = [| "♩"; "♪"; "♫"; "♬"; "♭"; "♮"; "♯" |]
+
+/// Compute cadence tok/sec from a token timestamp ring-buffer.
+/// Pure: no side effects, no Queue mutation.
+let private cadenceFromWindow (arr: int64 array) : int =
+    if arr.Length < 2 then 0
+    else
+        let spanSec = float (arr.[arr.Length - 1] - arr.[0]) / float Stopwatch.Frequency
+        if spanSec <= 0.0 then 0
+        else int (float (arr.Length - 1) / spanSec)
+
+/// Compute a model's approximate context window size.
+/// Exposed as `internal` so existing `contextWindowFor` callers compile unchanged;
+/// the module-level `contextWindowFor` will delegate here.
+let internal contextWindowForPure (model: string) : int =
+    let m = model.ToLowerInvariant()
+    if   m.Contains "claude"  then 200_000
+    elif m.Contains "gpt-4o"  || m.Contains "gpt4o"  then 128_000
+    elif m.Contains "gpt-4"   || m.Contains "gpt4"   then 128_000
+    elif m.Contains "gpt-3.5" || m.Contains "gpt35"  then  16_000
+    elif m.Contains "qwen"                            then  32_000
+    elif m.Contains "llama"                           then   8_000
+    elif m.Contains "gemma"                           then   8_000
+    elif m.Contains "mistral" || m.Contains "mixtral" then  32_000
+    elif m.Contains "phi"                             then   4_000
+    else                                                   100_000
+
+/// Pure render: given a StatusBarState produce exactly 3 DrawOps — one per
+/// reserved bottom row: ThinkingLine, StatusBarLine1, StatusBarLine2.
+/// No Console reads, no side effects, no timer, no Queue mutation.
+let renderStatusBar (state: StatusBarState) : DrawOp list =
+    let dimStyle  =
+        if state.ActiveTheme = "nocturne"
+        then { Style.normal with Color = Color.Theme "nocturne-dim" }
+        else Style.dim
+    let dimStyle2 =
+        if state.ActiveTheme = "nocturne"
+        then { Style.normal with Color = Color.Theme "nocturne-dim2" }
+        else Style.dim
+
+    // Helper: map a simple ANSI-annotated string to a DrawOp.Paint with Style.normal
+    // The existing code produces pre-coloured ANSI strings; we keep that approach here
+    // so the pure render matches the mutable render's visual output exactly.
+    // We use Style.normal because the text already carries its own ANSI sequences.
+    let paintRaw (region: Region) (text: string) : DrawOp =
+        DrawOp.Paint(region, text, Style.normal)
+
+    let dimEsc  = if state.ActiveTheme = "nocturne" then "\x1b[38;5;24m" else "\x1b[90m"
+    let dimEsc2 = if state.ActiveTheme = "nocturne" then "\x1b[38;5;67m" else "\x1b[90m"
+
+    // --- Line 1: cwd + branch ---
+    let provLabelFromCfg (c: AppConfig) : string =
+        let friendlyModel (m: string) =
+            let i = m.LastIndexOf '/'
+            let id = if i >= 0 && i + 1 < m.Length then m.Substring(i + 1) else m
+            modelDisplayName id
+        match c.Provider with
+        | Anthropic(_, m) -> "anthropic:" + friendlyModel m
+        | OpenAI(_, m)    -> "openai:" + friendlyModel m
+        | Ollama(_, m)    -> "ollama:" + friendlyModel m
+
+    let line1Text =
+        dimEsc + state.Cwd + " " + state.Strings.StatusBarOn + " \x1b[1m" + state.Branch + "\x1b[0m"
+
+    // --- ThinkingLine + elapsed/cadence for Line 2 ---
+    let elapsedSuffix, thinkingLineText, cadenceSuffix =
+        match state.Streaming with
+        | Some snap ->
+            let elapsed  = DateTimeOffset.UtcNow - snap.Since
+            let frame    = pureMusicalFrames.[snap.SpinnerFrame % pureMusicalFrames.Length]
+            let dots     = [| "·"; "··"; "···" |].[(snap.SpinnerFrame / 2) % 3]
+            let bpm      = cadenceFromWindow snap.TokensInWindow
+            let cad      = if bpm > 0 then $" · ♩={bpm}" else ""
+            let elapsedStr = state.Strings.Thinking  // will be extended with elapsed in format below
+            let elapsedFmt =
+                let t = elapsed
+                if t.TotalSeconds < 60.0 then $"{t.TotalSeconds:F1}s"
+                else $"{int t.TotalMinutes}m {t.Seconds}s"
+            " · " + elapsedFmt,
+            dimEsc + frame + " " + state.Strings.Thinking + dots + " · " + elapsedFmt + cad + "\x1b[0m",
+            cad
+        | None -> "", "", ""
+
+    // --- SSH badge ---
+    let sshBadge = if state.IsSSH then " · SSH" else ""
+
+    // --- Context % badge ---
+    let ctxBadge =
+        match state.Cfg with
+        | Some c ->
+            let model  = match c.Provider with Anthropic(_, m) | OpenAI(_, m) | Ollama(_, m) -> m
+            let window = contextWindowForPure model
+            let estTokens = int (float state.SessionWords / 0.75)
+            let pct = int (float estTokens / float window * 100.0)
+            if pct <= 0 then ""
+            else
+                let color =
+                    if pct >= 80 then "\x1b[31m"
+                    elif pct >= 50 then "\x1b[33m"
+                    else "\x1b[32m"
+                $" · {color}ctx {pct}%%\x1b[0m{dimEsc2}"
+        | None -> ""
+
+    // --- Annotation badge ---
+    let annotBadge =
+        let u = state.Annotations.Up
+        let d = state.Annotations.Down
+        if u = 0 && d = 0 then ""
+        else $" · \x1b[32m↑{u}\x1b[0m{dimEsc2} \x1b[31m↓{d}\x1b[0m{dimEsc2}"
+
+    // --- Low-bandwidth badge ---
+    let lowBwBadge = if state.LowBandwidth then " · \x1b[33mlow-bw\x1b[0m" + dimEsc2 else ""
+
+    // --- Template badge ---
+    let tmplBadge =
+        state.TemplateName
+        |> Option.map (fun n -> $" · \x1b[36mtmpl:{n}\x1b[0m{dimEsc2}")
+        |> Option.defaultValue ""
+
+    // --- Line 2 ---
+    let line2Text =
+        match state.Cfg with
+        | Some c ->
+            let sched = if state.ScheduleActive then " ⏱" else ""
+            dimEsc2 + state.Strings.StatusBarApp + " · " + (provLabelFromCfg c) + sched + cadenceSuffix + elapsedSuffix + ctxBadge + annotBadge + tmplBadge + lowBwBadge + sshBadge + "\x1b[0m"
+        | None ->
+            dimEsc2 + state.Strings.StatusBarApp + cadenceSuffix + elapsedSuffix + annotBadge + tmplBadge + lowBwBadge + sshBadge + "\x1b[0m"
+
+    // Emit exactly 3 ops: ThinkingLine, StatusBarLine1, StatusBarLine2.
+    // When not streaming, ThinkingLine gets EraseLine (no spinner artifact).
+    [
+        match state.Streaming with
+        | None    -> DrawOp.EraseLine Region.ThinkingLine
+        | Some _  -> paintRaw Region.ThinkingLine thinkingLineText
+
+        paintRaw Region.StatusBarLine1 line1Text
+        paintRaw Region.StatusBarLine2 line2Text
+    ]
 
 let private writeRaw (s: string) =
     Console.Out.Write s
@@ -105,18 +288,8 @@ let resetAnnotations () =
     annotDownCount <- 0
 
 /// Approximate context window (tokens) for a given model id.
-let internal contextWindowFor (model: string) : int =
-    let m = model.ToLowerInvariant()
-    if   m.Contains "claude"  then 200_000
-    elif m.Contains "gpt-4o"  || m.Contains "gpt4o"  then 128_000
-    elif m.Contains "gpt-4"   || m.Contains "gpt4"   then 128_000
-    elif m.Contains "gpt-3.5" || m.Contains "gpt35"  then 16_000
-    elif m.Contains "qwen"                            then  32_000
-    elif m.Contains "llama"                           then   8_000
-    elif m.Contains "gemma"                           then   8_000
-    elif m.Contains "mistral" || m.Contains "mixtral" then  32_000
-    elif m.Contains "phi"                             then   4_000
-    else                                                   100_000
+/// Delegates to the pure implementation defined above renderStatusBar.
+let internal contextWindowFor (model: string) : int = contextWindowForPure model
 
 /// Call once per streamed text chunk to update the cadence meter.
 let recordToken () =

--- a/tests/Fugue.Tests/Fugue.Tests.fsproj
+++ b/tests/Fugue.Tests/Fugue.Tests.fsproj
@@ -27,6 +27,8 @@
     <Compile Include="DiffRenderTests.fs" />
     <Compile Include="RenderTests.fs" />
     <Compile Include="StatusBarTests.fs" />
+    <Compile Include="StatusBarRenderTests.fs" />
+    <Compile Include="StatusBarPropertyTests.fs" />
     <Compile Include="ReadToolTests.fs" />
     <Compile Include="WriteToolTests.fs" />
     <Compile Include="EditToolTests.fs" />

--- a/tests/Fugue.Tests/Fugue.Tests.fsproj
+++ b/tests/Fugue.Tests/Fugue.Tests.fsproj
@@ -29,6 +29,7 @@
     <Compile Include="StatusBarTests.fs" />
     <Compile Include="StatusBarRenderTests.fs" />
     <Compile Include="StatusBarPropertyTests.fs" />
+    <Compile Include="StatusBarActorTests.fs" />
     <Compile Include="ReadToolTests.fs" />
     <Compile Include="WriteToolTests.fs" />
     <Compile Include="EditToolTests.fs" />

--- a/tests/Fugue.Tests/StatusBarActorTests.fs
+++ b/tests/Fugue.Tests/StatusBarActorTests.fs
@@ -1,0 +1,113 @@
+module Fugue.Tests.StatusBarActorTests
+
+/// PR C — MailboxProcessor actor integration tests.
+///
+/// These tests verify that the Surface actor:
+///   1. Serialises concurrent posts (fire-and-forget Execute from multiple threads)
+///      without crashing or losing messages.
+///   2. ExecuteAndAck provides a synchronous barrier — the reply only arrives
+///      after the ops have been processed.
+///   3. The actor shuts down cleanly via Shutdown even when the queue is non-empty.
+///
+/// We use MockExecutor (in-memory) rather than RealExecutor so tests are
+/// TTY-free and CI-safe.  The structural assertions are on the actor's
+/// message-processing semantics, not on terminal escape sequences.
+
+open System
+open System.Threading
+open Xunit
+open FsUnit.Xunit
+open Fugue.Surface
+
+// ---------------------------------------------------------------------------
+// Helpers: a minimal MailboxProcessor-based actor using MockExecutor
+// ---------------------------------------------------------------------------
+
+/// Creates a test actor backed by a MockTerminal (120×30).
+/// Returns (actor, term) — term is mutated by the actor when it processes ops.
+let private startMockActor () : MailboxProcessor<SurfaceMessage> * MockTerminal =
+    let term = MockExecutor.create 120 30
+    let actor =
+        MailboxProcessor.Start(fun inbox ->
+            let rec loop () = async {
+                let! msg = inbox.Receive()
+                match msg with
+                | SurfaceMessage.Execute ops ->
+                    MockExecutor.execute ops term |> ignore
+                    return! loop ()
+                | SurfaceMessage.ExecuteHighPriority ops ->
+                    MockExecutor.execute ops term |> ignore
+                    return! loop ()
+                | SurfaceMessage.ExecuteAndAck(ops, reply) ->
+                    MockExecutor.execute ops term |> ignore
+                    reply.Reply()
+                    return! loop ()
+                | SurfaceMessage.Resize _ ->
+                    return! loop ()
+                | SurfaceMessage.Shutdown reply ->
+                    reply.Reply()
+                // loop exits — actor terminates
+            }
+            loop ())
+    (actor, term)
+
+// ---------------------------------------------------------------------------
+// Test 1. Fire-and-forget Execute: all messages eventually processed
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``Execute ops from multiple threads are all processed via actor`` () =
+    let (actor, term) = startMockActor ()
+    let count = 20
+    // Simulate timer-thread + main-thread posts.
+    let threads =
+        Array.init count (fun _ ->
+            Thread(fun () ->
+                let ops = [ DrawOp.Append "tick" ]
+                actor.Post(SurfaceMessage.Execute ops)))
+    for t in threads do t.Start()
+    for t in threads do t.Join()
+    // Drain via ExecuteAndAck — waits for all queued Execute to finish.
+    actor.PostAndAsyncReply(fun ch -> SurfaceMessage.ExecuteAndAck([], ch))
+    |> Async.RunSynchronously
+    // WriteLog must have ≥ count Append ops (may also have the empty ack op).
+    let appendCount =
+        term.WriteLog
+        |> List.filter (fun op -> match op with DrawOp.Append _ -> true | _ -> false)
+        |> List.length
+    appendCount |> should be (greaterThanOrEqualTo count)
+
+// ---------------------------------------------------------------------------
+// Test 2. ExecuteAndAck provides synchronous barrier
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``ExecuteAndAck reply arrives only after ops are applied`` () =
+    let (actor, term) = startMockActor ()
+    let ops = [
+        DrawOp.Paint(Region.StatusBarLine1, "barrier-test", Style.normal)
+    ]
+    // PostAndAsyncReply blocks until reply.Reply() is called, which happens
+    // only after MockExecutor.execute ops term has run.
+    actor.PostAndAsyncReply(fun ch -> SurfaceMessage.ExecuteAndAck(ops, ch))
+    |> Async.RunSynchronously
+    // After the ack we can safely inspect term.
+    // StatusBarLine1 → row (height-2) = 28 in a 30-row terminal.
+    let line = MockExecutor.regionContent Region.StatusBarLine1 term
+    line |> should haveSubstring "barrier-test"
+
+// ---------------------------------------------------------------------------
+// Test 3. Shutdown drains and terminates cleanly
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``actor shuts down cleanly after Shutdown message`` () =
+    let (actor, _term) = startMockActor ()
+    // Post a few normal messages then shut down.
+    for _ in 1..5 do
+        actor.Post(SurfaceMessage.Execute [ DrawOp.Append "pre-shutdown" ])
+    // Shutdown waits for reply — reply only comes after the loop exits.
+    let timeout = TimeSpan.FromSeconds 3.0
+    let task = actor.PostAndAsyncReply(fun ch -> SurfaceMessage.Shutdown ch) |> Async.StartAsTask
+    let completed = task.Wait(timeout)
+    completed |> should equal true

--- a/tests/Fugue.Tests/StatusBarPropertyTests.fs
+++ b/tests/Fugue.Tests/StatusBarPropertyTests.fs
@@ -1,0 +1,212 @@
+module Fugue.Tests.StatusBarPropertyTests
+
+open System
+open FsCheck
+open FsCheck.FSharp
+open FsCheck.FSharp.GenBuilder
+open FsCheck.Xunit
+open Fugue.Surface
+open Fugue.Core.Config
+open Fugue.Core.Localization
+open Fugue.Cli.StatusBar
+
+// ---------------------------------------------------------------------------
+// Custom Arbitrary for StatusBarState
+// Generates valid, AOT-safe combinations without hitting real git or env vars.
+// ---------------------------------------------------------------------------
+
+type StatusBarArbs =
+    static member StatusBarState() : Arbitrary<StatusBarState> =
+        let safeStr = Gen.elements [ ""; "alpha"; "beta"; "foo/bar"; "my-branch"; "/projects/fugue" ]
+        let genProvider = Gen.elements [
+            Anthropic("key", "claude-opus-4-7")
+            OpenAI("key", "gpt-4o")
+            Ollama(Uri "http://localhost:11434", "llama3.1") ]
+        let genCfg (prov: ProviderConfig) : AppConfig =
+            { Provider        = prov
+              SystemPrompt    = None
+              ProfileContent  = None
+              TemplateContent = None
+              TemplateName    = None
+              MaxIterations   = 5
+              MaxTokens       = None
+              Ui              = defaultUi ()
+              BaseUrl         = None
+              LowBandwidth    = false
+              Offline         = false
+              DryRun          = false }
+        let genOptCfg = gen {
+            let! flag = Gen.elements [ true; false ]
+            if flag then
+                let! prov = genProvider
+                return Some (genCfg prov)
+            else
+                return None
+        }
+        let genSnap = gen {
+            let! sinceSeconds = Gen.choose (0, 120)
+            let! frame        = Gen.choose (0, 100)
+            let! tokenCount   = Gen.choose (0, 12)
+            let  tokens       = Array.init tokenCount (fun i -> int64 i * 1_000_000L)
+            return Some {
+                Since          = DateTimeOffset.UtcNow.AddSeconds(float -sinceSeconds)
+                SpinnerFrame   = frame
+                TokensInWindow = tokens
+            }
+        }
+        let genState = gen {
+            let! cwd           = safeStr
+            let! branch        = safeStr
+            let! cfg           = genOptCfg
+            let! locale        = Gen.elements [ "en"; "ru" ]
+            let  strings       = pick locale
+            let! theme         = Gen.elements [ ""; "nocturne" ]
+            let! streaming     = Gen.frequency [(1, Gen.constant None); (1, genSnap)]
+            let! lowBw         = Gen.elements [ true; false ]
+            let! tmpl          = Gen.frequency [(2, Gen.constant None); (1, Gen.elements [Some "t1"; Some "t2"])]
+            let! schedActive   = Gen.elements [ true; false ]
+            let! annUp         = Gen.choose (0, 10)
+            let! annDown       = Gen.choose (0, 10)
+            let! sessionWords  = Gen.choose (0, 250_000)
+            let! isSSH         = Gen.elements [ true; false ]
+            let! width         = Gen.choose (60, 220)
+            let! height        = Gen.choose (10, 60)
+            return {
+                Cwd           = cwd
+                Branch        = branch
+                Cfg           = cfg
+                Strings       = strings
+                ActiveTheme   = theme
+                Streaming     = streaming
+                LowBandwidth  = lowBw
+                TemplateName  = tmpl
+                ScheduleActive = schedActive
+                Annotations   = { Up = annUp; Down = annDown }
+                SessionWords  = sessionWords
+                IsSSH         = isSSH
+                Width         = width
+                Height        = height
+            }
+        }
+        { new Arbitrary<StatusBarState>() with
+            override _.Generator  = genState
+            override _.Shrinker _ = Seq.empty }
+
+// ---------------------------------------------------------------------------
+// Properties
+// ---------------------------------------------------------------------------
+
+[<Properties(Arbitrary = [| typeof<StatusBarArbs> |], MaxTest = 300, QuietOnSuccess = true)>]
+module StatusBarProperties =
+
+    // -----------------------------------------------------------------------
+    // P1. Determinism: same state → same DrawOp list (pure function)
+    // Note: TimestampOffset.UtcNow is captured inside renderStatusBar for elapsed,
+    // so two calls can differ by a few milliseconds.  The *structure* must match —
+    // same op types, same regions, same op count — even if text differs by ≤1s.
+    // We check structural equality (op types + regions), not full text equality.
+    // -----------------------------------------------------------------------
+    [<Property>]
+    let ``renderStatusBar is structurally deterministic`` (state: StatusBarState) =
+        let structureOf ops =
+            ops |> List.map (fun op ->
+                match op with
+                | DrawOp.EraseLine r      -> ("erase", r, "")
+                | DrawOp.Paint(r, _, _)   -> ("paint", r, "")
+                | DrawOp.MoveTo(r, _)     -> ("moveto", r, "")
+                | DrawOp.Append t         -> ("append", Region.ScrollContent, t)
+                | DrawOp.SaveAndRestore _ -> ("sar", Region.ScrollContent, "")
+                | DrawOp.ResetScrollRegion -> ("reset", Region.ScrollContent, ""))
+        structureOf (renderStatusBar state) = structureOf (renderStatusBar state)
+
+    // -----------------------------------------------------------------------
+    // P2. Op count: always exactly 3
+    // -----------------------------------------------------------------------
+    [<Property>]
+    let ``renderStatusBar always emits exactly 3 ops`` (state: StatusBarState) =
+        List.length (renderStatusBar state) = 3
+
+    // -----------------------------------------------------------------------
+    // P3. Region locality: ops only target StatusBar regions — never InputArea,
+    //     ScrollContent, or Modal
+    // -----------------------------------------------------------------------
+    [<Property>]
+    let ``renderStatusBar ops only target StatusBar regions`` (state: StatusBarState) =
+        let statusBarRegions = [ Region.ThinkingLine; Region.StatusBarLine1; Region.StatusBarLine2 ]
+        renderStatusBar state
+        |> List.forall (fun op ->
+            match op with
+            | DrawOp.Paint(r, _, _) -> List.contains r statusBarRegions
+            | DrawOp.EraseLine r    -> List.contains r statusBarRegions
+            | DrawOp.MoveTo(r, _)   -> List.contains r statusBarRegions
+            | _                     -> true)  // SaveAndRestore/Append/Reset not expected but harmless
+
+    // -----------------------------------------------------------------------
+    // P4. Streaming invariant: Streaming=None → first op is EraseLine ThinkingLine.
+    //     Streaming=Some → first op is Paint ThinkingLine.
+    // -----------------------------------------------------------------------
+    [<Property>]
+    let ``streaming none means first op is EraseLine ThinkingLine`` (state: StatusBarState) =
+        let s = { state with Streaming = None }
+        match renderStatusBar s with
+        | DrawOp.EraseLine Region.ThinkingLine :: _ -> true
+        | _ -> false
+
+    [<Property>]
+    let ``streaming some means first op is Paint ThinkingLine`` (state: StatusBarState) =
+        let snap = { Since = DateTimeOffset.UtcNow.AddSeconds(-1.0); SpinnerFrame = 0; TokensInWindow = [||] }
+        let s = { state with Streaming = Some snap }
+        match renderStatusBar s with
+        | DrawOp.Paint(Region.ThinkingLine, _, _) :: _ -> true
+        | _ -> false
+
+    // -----------------------------------------------------------------------
+    // P5. Locale isolation: changing Strings (locale) doesn't change op count
+    //     or the set of regions targeted
+    // -----------------------------------------------------------------------
+    [<Property>]
+    let ``locale change does not alter op count or regions`` (state: StatusBarState) =
+        let regionSet ops =
+            ops |> List.map (fun op ->
+                match op with
+                | DrawOp.Paint(r, _, _) -> r
+                | DrawOp.EraseLine r    -> r
+                | DrawOp.MoveTo(r, _)   -> r
+                | _                     -> Region.ScrollContent)
+            |> Set.ofList
+        let stateEn = { state with Strings = en }
+        let stateRu = { state with Strings = ru }
+        List.length (renderStatusBar stateEn) = List.length (renderStatusBar stateRu)
+        && regionSet (renderStatusBar stateEn) = regionSet (renderStatusBar stateRu)
+
+    // -----------------------------------------------------------------------
+    // P6. Width/Height invariance: changing dimensions doesn't alter op count
+    // -----------------------------------------------------------------------
+    [<Property>]
+    let ``width and height changes do not alter op count`` (state: StatusBarState) =
+        let s60  = { state with Width =  60; Height = 10 }
+        let s220 = { state with Width = 220; Height = 60 }
+        List.length (renderStatusBar s60) = List.length (renderStatusBar s220)
+
+    // -----------------------------------------------------------------------
+    // P7. Idempotence via MockExecutor:
+    //     Applying renderStatusBar twice to the same fresh terminal produces
+    //     the same Lines as applying it once.  (Named regions are overwritten,
+    //     not accumulated.)
+    // -----------------------------------------------------------------------
+    [<Property>]
+    let ``applying ops twice equals applying once (idempotence on named regions)`` (state: StatusBarState) =
+        let ops  = renderStatusBar state
+        // Two fresh terminals, identical geometry.
+        let term1 = MockExecutor.create 120 30
+        let term2 = MockExecutor.create 120 30
+        MockExecutor.execute ops term1 |> ignore
+        MockExecutor.execute ops term2 |> ignore
+        MockExecutor.execute ops term2 |> ignore  // apply a second time to term2
+        // All three status-bar rows should be identical because Paint overwrites.
+        let h = 30
+        let row r = MockExecutor.lineAt r
+        // ThinkingLine = row h-3 = 27; StatusBarLine1 = h-2 = 28; StatusBarLine2 = h-1 = 29
+        row (h - 3) term1 = row (h - 3) term2
+        && row (h - 2) term1 = row (h - 2) term2
+        && row (h - 1) term1 = row (h - 1) term2

--- a/tests/Fugue.Tests/StatusBarRenderTests.fs
+++ b/tests/Fugue.Tests/StatusBarRenderTests.fs
@@ -340,3 +340,54 @@ let ``no cfg: line2 renders without crashing and contains StatusBarApp`` () =
             | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
             | _ -> None)
     line2 |> should haveSubstring en.StatusBarApp
+
+// ---------------------------------------------------------------------------
+// PR B integration: verify captureState→renderStatusBar pipeline convergence
+// These tests exercise renderStatusBar with state that mirrors what captureState
+// would produce from known inputs — ensuring no divergence between the pure
+// render and the old inline path's output contract.
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``renderStatusBar line2 contains provider label when cfg is present`` () =
+    let s = { idleState with Cfg = Some defaultCfg }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    // Provider label format: "anthropic:claude-opus-4-7" or display name
+    line2 |> should haveSubstring "anthropic:"
+
+[<Fact>]
+let ``renderStatusBar re-renders consistently after state change (cfg swap)`` () =
+    // Simulate what refresh() does after setCfg: build state with new cfg, re-render.
+    let cfg1 = defaultCfg
+    let cfg2 = { defaultCfg with Provider = OpenAI("key2", "gpt-4o") }
+    let s1 = { idleState with Cfg = Some cfg1 }
+    let s2 = { idleState with Cfg = Some cfg2 }
+    let ops1 = renderStatusBar s1
+    let ops2 = renderStatusBar s2
+    let line2Of ops =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    let text1 = line2Of ops1
+    let text2 = line2Of ops2
+    text1 |> should haveSubstring "anthropic:"
+    text2 |> should haveSubstring "openai:"
+
+[<Fact>]
+let ``renderStatusBar state snapshot preserves cwd home-relative form`` () =
+    // Verify that cwd passed in as-is ends up in line1 — no double-transformation.
+    // (captureState calls homeRel before building state; renderStatusBar uses Cwd verbatim.)
+    let s = { idleState with Cwd = "~/projects/myapp"; Branch = "develop" }
+    let ops = renderStatusBar s
+    let line1 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine1, t, _) -> Some t
+            | _ -> None)
+    line1 |> should haveSubstring "~/projects/myapp"

--- a/tests/Fugue.Tests/StatusBarRenderTests.fs
+++ b/tests/Fugue.Tests/StatusBarRenderTests.fs
@@ -1,0 +1,342 @@
+module Fugue.Tests.StatusBarRenderTests
+
+open System
+open Xunit
+open FsUnit.Xunit
+open Fugue.Surface
+open Fugue.Core.Config
+open Fugue.Core.Localization
+open Fugue.Cli.StatusBar
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let private defaultProvider = Anthropic("key", "claude-opus-4-7")
+
+let private defaultCfg : AppConfig =
+    { Provider        = defaultProvider
+      SystemPrompt    = None
+      ProfileContent  = None
+      TemplateContent = None
+      TemplateName    = None
+      MaxIterations   = 5
+      MaxTokens       = None
+      Ui              = defaultUi ()
+      BaseUrl         = None
+      LowBandwidth    = false
+      Offline         = false
+      DryRun          = false }
+
+/// Minimal idle state — no streaming, no badges, en locale.
+let private idleState : StatusBarState =
+    { Cwd           = "/home/user/project"
+      Branch        = "main"
+      Cfg           = Some defaultCfg
+      Strings       = en
+      ActiveTheme   = ""
+      Streaming     = None
+      LowBandwidth  = false
+      TemplateName  = None
+      ScheduleActive = false
+      Annotations   = { Up = 0; Down = 0 }
+      SessionWords  = 0
+      IsSSH         = false
+      Width         = 120
+      Height        = 30 }
+
+/// Apply ops to a fresh 120×30 mock terminal and return it.
+let private exec (ops: DrawOp list) : MockTerminal =
+    let term = MockExecutor.create 120 30
+    MockExecutor.execute ops term |> ignore
+    term
+
+// ---------------------------------------------------------------------------
+// 1. Idle state — ThinkingLine has EraseLine, not Paint
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``idle state: ThinkingLine op is EraseLine`` () =
+    let ops = renderStatusBar idleState
+    // First op must be EraseLine Region.ThinkingLine
+    match ops with
+    | DrawOp.EraseLine Region.ThinkingLine :: _ -> ()
+    | _ -> failwith $"Expected EraseLine ThinkingLine first; got: {ops}"
+
+[<Fact>]
+let ``idle state: exactly 3 ops emitted`` () =
+    renderStatusBar idleState |> List.length |> should equal 3
+
+[<Fact>]
+let ``idle state: no spinner-frame character in any op text`` () =
+    let spinnerChars = [| "♩"; "♪"; "♫"; "♬"; "♭"; "♮"; "♯" |]
+    let ops = renderStatusBar idleState
+    let allText =
+        ops |> List.choose (fun op ->
+            match op with
+            | DrawOp.Paint(_, t, _) -> Some t
+            | _ -> None)
+        |> String.concat ""
+    let hasSpinner = spinnerChars |> Array.exists allText.Contains
+    hasSpinner |> should equal false
+
+// ---------------------------------------------------------------------------
+// 2. Streaming state — ThinkingLine has Paint with spinner char + elapsed
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``streaming state: ThinkingLine op is Paint`` () =
+    let snap = { Since = DateTimeOffset.UtcNow.AddSeconds(-2.0); SpinnerFrame = 0; TokensInWindow = [||] }
+    let s = { idleState with Streaming = Some snap }
+    let ops = renderStatusBar s
+    match ops with
+    | DrawOp.Paint(Region.ThinkingLine, _, _) :: _ -> ()
+    | _ -> failwith $"Expected Paint ThinkingLine first; got: {ops}"
+
+[<Fact>]
+let ``streaming state: ThinkingLine text contains a spinner-frame character`` () =
+    let spinnerChars = [| "♩"; "♪"; "♫"; "♬"; "♭"; "♮"; "♯" |]
+    let snap = { Since = DateTimeOffset.UtcNow.AddSeconds(-1.0); SpinnerFrame = 0; TokensInWindow = [||] }
+    let s = { idleState with Streaming = Some snap }
+    let ops = renderStatusBar s
+    let thinkingText =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.ThinkingLine, t, _) -> Some t
+            | _ -> None)
+    let hasSpinner = spinnerChars |> Array.exists thinkingText.Contains
+    hasSpinner |> should equal true
+
+[<Fact>]
+let ``streaming state: ThinkingLine text contains thinking string`` () =
+    let snap = { Since = DateTimeOffset.UtcNow.AddSeconds(-1.0); SpinnerFrame = 0; TokensInWindow = [||] }
+    let s = { idleState with Streaming = Some snap }
+    let ops = renderStatusBar s
+    let thinkingText =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.ThinkingLine, t, _) -> Some t
+            | _ -> None)
+    thinkingText |> should haveSubstring en.Thinking
+
+// ---------------------------------------------------------------------------
+// 3. Line1 contains cwd and branch
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``line1 contains cwd path`` () =
+    let s = { idleState with Cwd = "/projects/fugue"; Branch = "feat/foo" }
+    let ops = renderStatusBar s
+    let line1 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine1, t, _) -> Some t
+            | _ -> None)
+    line1 |> should haveSubstring "/projects/fugue"
+
+[<Fact>]
+let ``line1 contains branch name`` () =
+    let s = { idleState with Cwd = "/projects/fugue"; Branch = "feat/my-branch" }
+    let ops = renderStatusBar s
+    let line1 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine1, t, _) -> Some t
+            | _ -> None)
+    line1 |> should haveSubstring "feat/my-branch"
+
+// ---------------------------------------------------------------------------
+// 4. SSH badge appears in line2 when IsSSH = true
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``SSH badge appears in line2 when IsSSH is true`` () =
+    let s = { idleState with IsSSH = true }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    line2 |> should haveSubstring "SSH"
+
+[<Fact>]
+let ``SSH badge absent from line2 when IsSSH is false`` () =
+    let s = { idleState with IsSSH = false }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    line2 |> should not' (haveSubstring "SSH")
+
+// ---------------------------------------------------------------------------
+// 5. Context % badge color thresholds
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``ctx badge is green when usage is below 50 pct`` () =
+    // claude window = 200_000; ~50% = 150_000 tokens ~ 112_500 words
+    // Use 10_000 words → ~7.5% → green
+    let s = { idleState with SessionWords = 10_000 }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    // green = \x1b[32m
+    line2 |> should haveSubstring "\x1b[32m"
+
+[<Fact>]
+let ``ctx badge is yellow when usage is 50-79 pct`` () =
+    // claude window = 200_000; 50% tokens = 100_000 → 75_000 words
+    let s = { idleState with SessionWords = 75_000 }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    // yellow = \x1b[33m
+    line2 |> should haveSubstring "\x1b[33m"
+
+[<Fact>]
+let ``ctx badge is red when usage is 80 pct or more`` () =
+    // claude window = 200_000; 80% tokens = 160_000 → 120_000 words
+    let s = { idleState with SessionWords = 120_000 }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    // red = \x1b[31m  (not from annotation badge in this state — annots=0)
+    line2 |> should haveSubstring "\x1b[31m"
+
+// ---------------------------------------------------------------------------
+// 6. Low-bandwidth badge
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``low-bw badge appears in line2 when LowBandwidth is true`` () =
+    let s = { idleState with LowBandwidth = true }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    line2 |> should haveSubstring "low-bw"
+
+// ---------------------------------------------------------------------------
+// 7. Template badge
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``template badge appears in line2 when TemplateName is Some`` () =
+    let s = { idleState with TemplateName = Some "mytemplate" }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    line2 |> should haveSubstring "tmpl:mytemplate"
+
+// ---------------------------------------------------------------------------
+// 8. Schedule badge
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``schedule badge ⏱ appears in line2 when ScheduleActive is true`` () =
+    let s = { idleState with ScheduleActive = true }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    line2 |> should haveSubstring "⏱"
+
+// ---------------------------------------------------------------------------
+// 9. Zero annotations → no ↑/↓ in line2
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``zero annotations: no up-down arrow in line2`` () =
+    let s = { idleState with Annotations = { Up = 0; Down = 0 } }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    line2 |> should not' (haveSubstring "↑")
+    line2 |> should not' (haveSubstring "↓")
+
+// ---------------------------------------------------------------------------
+// 10. Non-zero annotations → ↑/↓ appear in line2
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``non-zero annotations: arrows appear in line2`` () =
+    let s = { idleState with Annotations = { Up = 3; Down = 1 } }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    line2 |> should haveSubstring "↑3"
+    line2 |> should haveSubstring "↓1"
+
+// ---------------------------------------------------------------------------
+// 11. Locale changes reflect in StatusBarApp / Thinking strings
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``Russian locale: Thinking string uses Russian text`` () =
+    let snap = { Since = DateTimeOffset.UtcNow.AddSeconds(-1.0); SpinnerFrame = 0; TokensInWindow = [||] }
+    let s = { idleState with Strings = ru; Streaming = Some snap }
+    let ops = renderStatusBar s
+    let thinkingText =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.ThinkingLine, t, _) -> Some t
+            | _ -> None)
+    thinkingText |> should haveSubstring ru.Thinking
+
+[<Fact>]
+let ``Russian locale: line2 contains ru StatusBarApp`` () =
+    let s = { idleState with Strings = ru }
+    let ops = renderStatusBar s
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    // Both en and ru have "fugue" as StatusBarApp — check the on/na branch string in line1 instead
+    let line1 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine1, t, _) -> Some t
+            | _ -> None)
+    line1 |> should haveSubstring ru.StatusBarOn
+
+// ---------------------------------------------------------------------------
+// 12. No Cfg → line2 still renders (no crash, uses StatusBarApp)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``no cfg: line2 renders without crashing and contains StatusBarApp`` () =
+    let s = { idleState with Cfg = None }
+    let ops = renderStatusBar s
+    ops |> List.length |> should equal 3
+    let line2 =
+        ops |> List.pick (fun op ->
+            match op with
+            | DrawOp.Paint(Region.StatusBarLine2, t, _) -> Some t
+            | _ -> None)
+    line2 |> should haveSubstring en.StatusBarApp


### PR DESCRIPTION
## Summary

Replaces the synchronous `applyOpsDirectly` bridge from PR B with a `MailboxProcessor` actor (`RealExecutor.start()`). All `StatusBar.refresh()` calls now post `DrawOps` via the actor — the timer-thread write race (reported in architecture review §4) is **structurally eliminated**.

## What changed

**`StatusBar.fs`:**
- Added `surfaceAgent : MailboxProcessor<SurfaceMessage> option` module-level mutable
- Added `setAgent (agent: MailboxProcessor<SurfaceMessage>) : unit` — call once before `StatusBar.start`
- `refresh()`: routes through `agent.Post(SurfaceMessage.Execute ops)` when agent is set, falls back to `applyOpsDirectly` otherwise (headless / tests / no agent wired)
- `stop()`: uses `ExecuteAndAck` for a synchronous barrier — erase-and-reset ops are flushed before `Program.fs` shuts down the actor; fallback to direct ANSI writes when no agent

**`Program.fs`:**
- `open Fugue.Surface` added
- `runWithCfg`: starts `RealExecutor.start()` before `Repl.run`, wires it into `StatusBar` via `setAgent`, shuts down via `Shutdown` after the REPL task completes
- Guard: `Console.IsInputRedirected → None` (headless path unchanged)

## Race condition eliminated

Before: `spinnerTimer` fires `refresh()` from a `System.Threading.Timer` callback (background thread). Main thread also calls `refresh()` after tool calls, model changes, etc. Both write to `Console.Out` without locking → interleaved ANSI bytes.

After: Both paths call `agent.Post(Execute ops)`. The actor's `MailboxProcessor` inbox is a serial FIFO. Even if both posts arrive simultaneously, they are processed one at a time with `coalesce` deduplication of spinner frames.

## Shutdown protocol

```
Repl exits
  → StatusBar.stop() called from Repl
     → ExecuteAndAck([EraseLine×3; ResetScrollRegion]) → awaits reply
     → active ← false
  → Program.fs gets Task result
  → actor.PostAndAsyncReply(Shutdown) → awaits reply
  → process exits
```

This ensures: (1) the 3 reserved rows are erased, (2) scroll region is reset to full screen, (3) actor flushes and terminates cleanly — no garbage in terminal after exit.

## Test delta: 510 → 513 (+3)

**`StatusBarActorTests.fs`** — 3 integration tests using a MockExecutor-backed actor:
1. 20 concurrent `Execute` posts from separate threads — all processed, WriteLog count ≥ 20
2. `ExecuteAndAck` barrier: ops applied before reply arrives (asserts `regionContent` after ack)
3. Clean `Shutdown` within 3s timeout

## AOT publish

`dotnet publish src/Fugue.Cli -c Release -r osx-arm64` — Build succeeded. 0 Error(s). 0 Warning(s).
Binary smoke: `fugue --version` → `fugue 1.0.0+...` ✓

## Manual verification checklist (reviewer)

Before merging, please verify on a real TTY with a live provider:

- [ ] Start REPL, let it idle for 5s — status bar refreshes smoothly, no ANSI garbage
- [ ] Send a message that triggers streaming — spinner animates, no interleaved escape codes
- [ ] Run `/model set <other-model>` — status bar updates to new model name
- [ ] Trigger `/locale ru` — status bar switches language
- [ ] Exit via `/exit` — terminal is clean after exit (no leftover status bar rows, prompt at correct position)
- [ ] Exit via `Ctrl+D` — same as above
- [ ] Resize terminal window mid-session — status bar doesn't corrupt scroll region
- [ ] Run in a narrow terminal (< 60 cols) — compact mode, no status bar (expected)

## What wasn't tested (known gaps)

- **Interactive REPL with real provider** — not exercised; all tests are unit/integration with mock terminal
- **SIGWINCH resize** — no invalidation yet (tracked separately; `Resize` message is a stub in `RealExecutor`)
- **Concurrent streaming + keypress** — the `ExecuteHighPriority` path for keystrokes is not wired yet; `ReadLine.redraw` still writes directly
- **Headless `--print` path** — intentionally skips actor start; if `applyOpsDirectly` is ever removed, this path needs its own guard

## Stacking

This PR targets `phase-1.2b-switch-refresh`. Merge order: PR A → PR B → PR C.