### PR TITLE
feat(statusbar): wire RealExecutor MailboxProcessor actor — Phase 1.2c

### DIFF
--- a/src/Fugue.Cli/Program.fs
+++ b/src/Fugue.Cli/Program.fs
@@ -5,6 +5,7 @@ open System.Diagnostics.CodeAnalysis
 open Microsoft.Agents.AI
 open Fugue.Core.Config
 open Fugue.Agent
+open Fugue.Surface
 
 let private noColor () =
     let isSet name = Environment.GetEnvironmentVariable name |> isNull |> not
@@ -127,16 +128,31 @@ let private runWithCfg (cfg: AppConfig) : int =
     // CreateSessionAsync and on each /new / /clear-history. Replaces an older
     // module-level mutable in GetConversationFn (#50).
     let sessionRef : (Microsoft.Agents.AI.AgentSession | null) ref = ref null
-    let agent = buildAgent cfg hooksConfig providerContext lastSummary sessionId sessionRef
+    let aiAgent = buildAgent cfg hooksConfig providerContext lastSummary sessionId sessionRef
+    // Start the Surface actor — serialises all terminal writes and eliminates the
+    // timer-thread race.  Wire it into StatusBar before start() is called.
+    let surfaceActor =
+        if Console.IsInputRedirected then None
+        else
+            let actor = RealExecutor.start ()
+            StatusBar.setAgent actor
+            Some actor
     let t =
-        if Console.IsInputRedirected then Repl.runHeadless agent cfg cwd
-        else Repl.run agent sessionRef cfg cwd lastSummary (fun newCfg -> buildAgent newCfg hooksConfig providerContext None sessionId sessionRef)
+        if Console.IsInputRedirected then Repl.runHeadless aiAgent cfg cwd
+        else Repl.run aiAgent sessionRef cfg cwd lastSummary (fun newCfg -> buildAgent newCfg hooksConfig providerContext None sessionId sessionRef)
     try t.Wait()
     with
     | :? AggregateException as agg ->
         match agg.InnerException with
         | :? OperationCanceledException -> ()
         | _ -> raise agg
+    // Graceful shutdown: StatusBar.stop() already posted ExecuteAndAck for erase ops.
+    // Now shut down the actor so any remaining buffered ops flush before process exits.
+    match surfaceActor with
+    | Some actor ->
+        actor.PostAndAsyncReply(fun ch -> SurfaceMessage.Shutdown ch)
+        |> Async.RunSynchronously
+    | None -> ()
     0
 
 [<EntryPoint>]

--- a/src/Fugue.Cli/StatusBar.fs
+++ b/src/Fugue.Cli/StatusBar.fs
@@ -212,6 +212,15 @@ let mutable private scheduleActive = false
 let mutable private spinnerTimer  : System.Threading.Timer option = None
 let mutable private onTick        : (unit -> unit) = fun () -> ()
 
+/// The Surface MailboxProcessor actor — set once by Program.fs before Repl.run.
+/// When set, refresh() posts DrawOps via the actor (serialises all writes).
+/// When None, falls back to applyOpsDirectly (sync, used in tests / headless).
+let mutable private surfaceAgent : MailboxProcessor<SurfaceMessage> option = None
+
+/// Wire the Surface actor.  Call once before StatusBar.start.
+let setAgent (agent: MailboxProcessor<SurfaceMessage>) : unit =
+    surfaceAgent <- Some agent
+
 // Cadence — rolling window of token arrival timestamps for tok/s display.
 let private tokenQueue = System.Collections.Generic.Queue<int64>()
 let private tokenWindowSize = 12
@@ -381,7 +390,9 @@ let refresh () =
     if not active || compactMode || not (Render.isColorEnabled ()) then () else
     let state = captureState ()
     let ops   = renderStatusBar state
-    applyOpsDirectly ops
+    match surfaceAgent with
+    | Some agent -> agent.Post(SurfaceMessage.Execute ops)   // serialised — no race
+    | None       -> applyOpsDirectly ops                     // fallback (headless / tests)
 
 /// Update the config the status bar reads from. Use after `/model set` and
 /// other config-mutating commands. `start` early-returns once the bar is
@@ -414,13 +425,30 @@ let stop () : unit =
     if not active || not (Render.isColorEnabled ()) then () else
     if not compactMode then
         let height = Console.WindowHeight
-        writeRaw "\x1b[r"          // reset scroll region
-        writeRaw ("\x1b[" + string (height - 2) + ";1H")
-        writeRaw "\x1b[2K"
-        writeRaw ("\x1b[" + string (height - 1) + ";1H")
-        writeRaw "\x1b[2K"
-        writeRaw ("\x1b[" + string height + ";1H")
-        writeRaw "\x1b[2K"
-        writeRaw "\x1b[u"
+        // Erase the 3 reserved rows and reset scroll region.
+        // If the Surface agent is running, use ExecuteAndAck so the terminal is
+        // fully clean before Program.fs exits and the agent is shut down.
+        let eraseOps = [
+            DrawOp.EraseLine Region.ThinkingLine
+            DrawOp.EraseLine Region.StatusBarLine1
+            DrawOp.EraseLine Region.StatusBarLine2
+            DrawOp.ResetScrollRegion
+        ]
+        match surfaceAgent with
+        | Some agent ->
+            // Synchronous barrier: wait for the agent to flush the erase ops
+            // before we proceed to shut it down.
+            agent.PostAndAsyncReply(fun ch -> SurfaceMessage.ExecuteAndAck(eraseOps, ch))
+            |> Async.RunSynchronously
+        | None ->
+            // Fallback: erase directly (headless / tests / no agent wired).
+            writeRaw "\x1b[r"          // reset scroll region
+            writeRaw ("\x1b[" + string (height - 2) + ";1H")
+            writeRaw "\x1b[2K"
+            writeRaw ("\x1b[" + string (height - 1) + ";1H")
+            writeRaw "\x1b[2K"
+            writeRaw ("\x1b[" + string height + ";1H")
+            writeRaw "\x1b[2K"
+            writeRaw "\x1b[u"
     active <- false
     compactMode <- false

--- a/tests/Fugue.Tests/Fugue.Tests.fsproj
+++ b/tests/Fugue.Tests/Fugue.Tests.fsproj
@@ -29,6 +29,7 @@
     <Compile Include="StatusBarTests.fs" />
     <Compile Include="StatusBarRenderTests.fs" />
     <Compile Include="StatusBarPropertyTests.fs" />
+    <Compile Include="StatusBarActorTests.fs" />
     <Compile Include="ReadToolTests.fs" />
     <Compile Include="WriteToolTests.fs" />
     <Compile Include="EditToolTests.fs" />

--- a/tests/Fugue.Tests/StatusBarActorTests.fs
+++ b/tests/Fugue.Tests/StatusBarActorTests.fs
@@ -1,0 +1,113 @@
+module Fugue.Tests.StatusBarActorTests
+
+/// PR C — MailboxProcessor actor integration tests.
+///
+/// These tests verify that the Surface actor:
+///   1. Serialises concurrent posts (fire-and-forget Execute from multiple threads)
+///      without crashing or losing messages.
+///   2. ExecuteAndAck provides a synchronous barrier — the reply only arrives
+///      after the ops have been processed.
+///   3. The actor shuts down cleanly via Shutdown even when the queue is non-empty.
+///
+/// We use MockExecutor (in-memory) rather than RealExecutor so tests are
+/// TTY-free and CI-safe.  The structural assertions are on the actor's
+/// message-processing semantics, not on terminal escape sequences.
+
+open System
+open System.Threading
+open Xunit
+open FsUnit.Xunit
+open Fugue.Surface
+
+// ---------------------------------------------------------------------------
+// Helpers: a minimal MailboxProcessor-based actor using MockExecutor
+// ---------------------------------------------------------------------------
+
+/// Creates a test actor backed by a MockTerminal (120×30).
+/// Returns (actor, term) — term is mutated by the actor when it processes ops.
+let private startMockActor () : MailboxProcessor<SurfaceMessage> * MockTerminal =
+    let term = MockExecutor.create 120 30
+    let actor =
+        MailboxProcessor.Start(fun inbox ->
+            let rec loop () = async {
+                let! msg = inbox.Receive()
+                match msg with
+                | SurfaceMessage.Execute ops ->
+                    MockExecutor.execute ops term |> ignore
+                    return! loop ()
+                | SurfaceMessage.ExecuteHighPriority ops ->
+                    MockExecutor.execute ops term |> ignore
+                    return! loop ()
+                | SurfaceMessage.ExecuteAndAck(ops, reply) ->
+                    MockExecutor.execute ops term |> ignore
+                    reply.Reply()
+                    return! loop ()
+                | SurfaceMessage.Resize _ ->
+                    return! loop ()
+                | SurfaceMessage.Shutdown reply ->
+                    reply.Reply()
+                // loop exits — actor terminates
+            }
+            loop ())
+    (actor, term)
+
+// ---------------------------------------------------------------------------
+// Test 1. Fire-and-forget Execute: all messages eventually processed
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``Execute ops from multiple threads are all processed via actor`` () =
+    let (actor, term) = startMockActor ()
+    let count = 20
+    // Simulate timer-thread + main-thread posts.
+    let threads =
+        Array.init count (fun _ ->
+            Thread(fun () ->
+                let ops = [ DrawOp.Append "tick" ]
+                actor.Post(SurfaceMessage.Execute ops)))
+    for t in threads do t.Start()
+    for t in threads do t.Join()
+    // Drain via ExecuteAndAck — waits for all queued Execute to finish.
+    actor.PostAndAsyncReply(fun ch -> SurfaceMessage.ExecuteAndAck([], ch))
+    |> Async.RunSynchronously
+    // WriteLog must have ≥ count Append ops (may also have the empty ack op).
+    let appendCount =
+        term.WriteLog
+        |> List.filter (fun op -> match op with DrawOp.Append _ -> true | _ -> false)
+        |> List.length
+    appendCount |> should be (greaterThanOrEqualTo count)
+
+// ---------------------------------------------------------------------------
+// Test 2. ExecuteAndAck provides synchronous barrier
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``ExecuteAndAck reply arrives only after ops are applied`` () =
+    let (actor, term) = startMockActor ()
+    let ops = [
+        DrawOp.Paint(Region.StatusBarLine1, "barrier-test", Style.normal)
+    ]
+    // PostAndAsyncReply blocks until reply.Reply() is called, which happens
+    // only after MockExecutor.execute ops term has run.
+    actor.PostAndAsyncReply(fun ch -> SurfaceMessage.ExecuteAndAck(ops, ch))
+    |> Async.RunSynchronously
+    // After the ack we can safely inspect term.
+    // StatusBarLine1 → row (height-2) = 28 in a 30-row terminal.
+    let line = MockExecutor.regionContent Region.StatusBarLine1 term
+    line |> should haveSubstring "barrier-test"
+
+// ---------------------------------------------------------------------------
+// Test 3. Shutdown drains and terminates cleanly
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``actor shuts down cleanly after Shutdown message`` () =
+    let (actor, _term) = startMockActor ()
+    // Post a few normal messages then shut down.
+    for _ in 1..5 do
+        actor.Post(SurfaceMessage.Execute [ DrawOp.Append "pre-shutdown" ])
+    // Shutdown waits for reply — reply only comes after the loop exits.
+    let timeout = TimeSpan.FromSeconds 3.0
+    let task = actor.PostAndAsyncReply(fun ch -> SurfaceMessage.Shutdown ch) |> Async.StartAsTask
+    let completed = task.Wait(timeout)
+    completed |> should equal true


### PR DESCRIPTION
## Summary

Replaces the synchronous `applyOpsDirectly` bridge from PR B with a `MailboxProcessor` actor (`RealExecutor.start()`). All `StatusBar.refresh()` calls now post `DrawOps` via the actor — the timer-thread write race (reported in architecture review §4) is **structurally eliminated**.

## What changed

**`StatusBar.fs`:**
- Added `surfaceAgent : MailboxProcessor<SurfaceMessage> option` module-level mutable
- Added `setAgent (agent: MailboxProcessor<SurfaceMessage>) : unit` — call once before `StatusBar.start`
- `refresh()`: routes through `agent.Post(SurfaceMessage.Execute ops)` when agent is set, falls back to `applyOpsDirectly` otherwise (headless / tests / no agent wired)
- `stop()`: uses `ExecuteAndAck` for a synchronous barrier — erase-and-reset ops are flushed before `Program.fs` shuts down the actor; fallback to direct ANSI writes when no agent

**`Program.fs`:**
- `open Fugue.Surface` added
- `runWithCfg`: starts `RealExecutor.start()` before `Repl.run`, wires it into `StatusBar` via `setAgent`, shuts down via `Shutdown` after the REPL task completes
- Guard: `Console.IsInputRedirected → None` (headless path unchanged)

## Race condition eliminated

Before: `spinnerTimer` fires `refresh()` from a `System.Threading.Timer` callback (background thread). Main thread also calls `refresh()` after tool calls, model changes, etc. Both write to `Console.Out` without locking → interleaved ANSI bytes.

After: Both paths call `agent.Post(Execute ops)`. The actor's `MailboxProcessor` inbox is a serial FIFO. Even if both posts arrive simultaneously, they are processed one at a time with `coalesce` deduplication of spinner frames.

## Shutdown protocol

```
Repl exits
  → StatusBar.stop() called from Repl
     → ExecuteAndAck([EraseLine×3; ResetScrollRegion]) → awaits reply
     → active ← false
  → Program.fs gets Task result
  → actor.PostAndAsyncReply(Shutdown) → awaits reply
  → process exits
```

This ensures: (1) the 3 reserved rows are erased, (2) scroll region is reset to full screen, (3) actor flushes and terminates cleanly — no garbage in terminal after exit.

## Test delta: 510 → 513 (+3)

**`StatusBarActorTests.fs`** — 3 integration tests using a MockExecutor-backed actor:
1. 20 concurrent `Execute` posts from separate threads — all processed, WriteLog count ≥ 20
2. `ExecuteAndAck` barrier: ops applied before reply arrives (asserts `regionContent` after ack)
3. Clean `Shutdown` within 3s timeout

## AOT publish

`dotnet publish src/Fugue.Cli -c Release -r osx-arm64` — Build succeeded. 0 Error(s). 0 Warning(s).
Binary smoke: `fugue --version` → `fugue 1.0.0+...` ✓

## Manual verification checklist (reviewer)

Before merging, please verify on a real TTY with a live provider:

- [ ] Start REPL, let it idle for 5s — status bar refreshes smoothly, no ANSI garbage
- [ ] Send a message that triggers streaming — spinner animates, no interleaved escape codes
- [ ] Run `/model set <other-model>` — status bar updates to new model name
- [ ] Trigger `/locale ru` — status bar switches language
- [ ] Exit via `/exit` — terminal is clean after exit (no leftover status bar rows, prompt at correct position)
- [ ] Exit via `Ctrl+D` — same as above
- [ ] Resize terminal window mid-session — status bar doesn't corrupt scroll region
- [ ] Run in a narrow terminal (< 60 cols) — compact mode, no status bar (expected)

## What wasn't tested (known gaps)

- **Interactive REPL with real provider** — not exercised; all tests are unit/integration with mock terminal
- **SIGWINCH resize** — no invalidation yet (tracked separately; `Resize` message is a stub in `RealExecutor`)
- **Concurrent streaming + keypress** — the `ExecuteHighPriority` path for keystrokes is not wired yet; `ReadLine.redraw` still writes directly
- **Headless `--print` path** — intentionally skips actor start; if `applyOpsDirectly` is ever removed, this path needs its own guard

## Stacking

This PR targets `phase-1.2b-switch-refresh`. Merge order: PR A → PR B → PR C.
