### PR TITLE
feat(safety): approval mode cycling with Shift+Tab — Phase 1 of v0.2 (#395)

### DIFF
--- a/src/Fugue.Cli/Program.fs
+++ b/src/Fugue.Cli/Program.fs
@@ -173,12 +173,21 @@ let main argv =
     let lowBandwidth = argv |> Array.contains "--low-bandwidth"
     let offline      = argv |> Array.contains "--offline"
     let dryRun       = argv |> Array.contains "--dry-run"
+    // --mode <plan|default|auto-edit|yolo> — initial approval mode for the
+    // session. Defaults to Default if omitted; unknown value falls back to
+    // Default with a warning.
+    let initialApprovalMode =
+        argv
+        |> Array.tryFindIndex ((=) "--mode")
+        |> Option.bind (fun i -> if i + 1 < argv.Length then Some argv.[i + 1] else None)
+        |> Option.bind Fugue.Core.ApprovalMode.tryParse
+        |> Option.defaultValue Fugue.Core.ApprovalMode.Default
     let printPrompt =
         argv
         |> Array.tryFindIndex ((=) "--print")
         |> Option.bind (fun i -> if i + 1 < argv.Length then Some argv.[i + 1] else None)
     if argv |> Array.exists (fun a -> a = "--help" || a = "-h") then
-        Console.Write """Usage: fugue [--profile <name>] [--template <name>] [--low-bandwidth] [--offline] [--print "prompt"]
+        Console.Write """Usage: fugue [--profile <name>] [--template <name>] [--low-bandwidth] [--offline] [--mode <m>] [--print "prompt"]
        fugue doctor | init | aliases | man | reindex
 
 Subcommands:
@@ -193,6 +202,8 @@ Options:
   --template <name>   Load ~/.fugue/templates/<name>.md as session template
   --low-bandwidth     Skip session summary, cap tool output to 500 lines
   --offline           Require a local provider (Ollama)
+  --mode <m>          Initial approval mode: plan, default, auto-edit, yolo
+                      (Shift+Tab cycles in REPL)
   --print "prompt"    Non-interactive: send one prompt, stream to stdout, exit
 
 Run `fugue man` for the full manual.
@@ -568,6 +579,8 @@ SEE ALSO
                 | _ -> failwith "unsupported candidate"
             let cfg = { Provider = provider; SystemPrompt = None; ProfileContent = profileContent; TemplateContent = templateContent; TemplateName = templateName; MaxIterations = 30; MaxTokens = None; Ui = Fugue.Core.Config.defaultUi (); BaseUrl = None; LowBandwidth = lowBandwidth; Offline = offline; DryRun = dryRun }
             Fugue.Core.Config.saveToFile cfg
+            // Apply --mode to StatusBar before any rendering begins.
+            StatusBar.setApprovalMode initialApprovalMode
             match printPrompt with
             | Some p -> runWithPrint cfg p
             | None   -> runWithCfg cfg
@@ -579,6 +592,8 @@ SEE ALSO
         1
     | Ok cfg ->
         let fullCfg = { cfg with ProfileContent = profileContent; TemplateContent = templateContent; TemplateName = templateName; LowBandwidth = lowBandwidth; Offline = offline; DryRun = dryRun }
+        // Apply --mode to StatusBar before any rendering begins.
+        StatusBar.setApprovalMode initialApprovalMode
         match printPrompt with
         | Some p -> runWithPrint fullCfg p
         | None   -> runWithCfg fullCfg

--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -58,11 +58,15 @@ let private pushBounded (stack: ResizeArray<_>) item =
     if stack.Count > 100 then stack.RemoveAt 0
 
 type ReadLineCallbacks =
-    { OnClearScreen:  unit -> unit
-      OnAnnotateUp:   unit -> unit
-      OnAnnotateDown: unit -> unit }
+    { OnClearScreen:        unit -> unit
+      OnAnnotateUp:         unit -> unit
+      OnAnnotateDown:       unit -> unit
+      OnCycleApprovalMode:  unit -> unit }
 let defaultCallbacks : ReadLineCallbacks =
-    { OnClearScreen = ignore; OnAnnotateUp = ignore; OnAnnotateDown = ignore }
+    { OnClearScreen        = ignore
+      OnAnnotateUp         = ignore
+      OnAnnotateDown       = ignore
+      OnCycleApprovalMode  = ignore }
 
 /// Internal mutable line state. Public only because tests construct it directly.
 type S = {
@@ -92,6 +96,7 @@ type Action =
     | ClearScreen
     | AnnotateUp
     | AnnotateDown
+    | CycleApprovalMode
 
 let private isCtrl (k: ConsoleKeyInfo) (key: ConsoleKey) : bool =
     k.Modifiers.HasFlag ConsoleModifiers.Control && k.Key = key
@@ -144,6 +149,14 @@ let applyKey (k: ConsoleKeyInfo) (s: S) : Action =
         s.Buffer.Insert(s.Cursor, '\n')
         s.Cursor <- s.Cursor + 1
         Continue
+    elif isShift k ConsoleKey.Tab then
+        // Cycle approval mode: Plan → Default → AutoEdit → YOLO → Plan.
+        // Buffer / cursor unaffected — this is a session-level UX action.
+        // Caller's loop dispatches via OnCycleApprovalMode callback, which
+        // mutates StatusBar.approvalMode and triggers a refresh.
+        exitHistoryMode ()
+        s.ExitArmed <- false
+        CycleApprovalMode
     elif k.Key = ConsoleKey.Enter then
         exitHistoryMode ()
         s.ExitArmed <- false
@@ -475,7 +488,7 @@ let readAsync (prompt: string) (strings: Strings) (slashHelp: (string * string) 
             for ch in escapeBuf do
                 let ki = ConsoleKeyInfo(ch, ConsoleKey.A, false, false, false)
                 match applyKey ki st with
-                | Continue | Wipe | ClearScreen | AnnotateUp | AnnotateDown -> ()
+                | Continue | Wipe | ClearScreen | AnnotateUp | AnnotateDown | CycleApprovalMode -> ()
                 | Submit _ | Quit -> ()   // rare; ignore — these chars won't normally Submit/Quit
             escapeBuf.Clear()
             pasteState <- Normal
@@ -484,7 +497,17 @@ let readAsync (prompt: string) (strings: Strings) (slashHelp: (string * string) 
             // Console.ReadKey is blocking; we accept that — cancellation in this
             // path is not expected in normal flow (Ctrl+C while reading is a wipe).
             let k = Console.ReadKey(intercept = true)
-            if k.Key = ConsoleKey.Tab then
+            // Shift+Tab is a SEPARATE intent (cycle approval mode) — handle it
+            // through applyKey before the plain-Tab completion branch grabs it.
+            if k.Key = ConsoleKey.Tab && k.Modifiers.HasFlag ConsoleModifiers.Shift then
+                tabMatches <- [||]
+                tabIndex   <- -1
+                match applyKey k st with
+                | CycleApprovalMode ->
+                    callbacks.OnCycleApprovalMode ()
+                    redraw st
+                | _ -> ()  // applyKey produced something else — shouldn't happen for Shift+Tab
+            elif k.Key = ConsoleKey.Tab then
                 let currentInput = String(st.Buffer.ToArray())
                 let modelSetPrefix = "/model set "
                 if currentInput.StartsWith modelSetPrefix then
@@ -551,6 +574,9 @@ let readAsync (prompt: string) (strings: Strings) (slashHelp: (string * string) 
                         | AnnotateDown ->
                             callbacks.OnAnnotateDown ()
                             redraw st
+                        | CycleApprovalMode ->
+                            callbacks.OnCycleApprovalMode ()
+                            redraw st
                         | Submit s ->
                             eraseRendered ()
                             let normalized = InputSanitize.normalize s
@@ -573,7 +599,7 @@ let readAsync (prompt: string) (strings: Strings) (slashHelp: (string * string) 
                         flushEscape ()
                         let ki2 = ConsoleKeyInfo(c, k.Key, false, false, false)
                         match applyKey ki2 st with
-                        | Continue | Wipe | ClearScreen | AnnotateUp | AnnotateDown -> redraw st
+                        | Continue | Wipe | ClearScreen | AnnotateUp | AnnotateDown | CycleApprovalMode -> redraw st
                         | Submit _ | Quit -> ()
 
                 | BracketSeen ->
@@ -584,7 +610,7 @@ let readAsync (prompt: string) (strings: Strings) (slashHelp: (string * string) 
                         flushEscape ()
                         let ki2 = ConsoleKeyInfo(c, k.Key, false, false, false)
                         match applyKey ki2 st with
-                        | Continue | Wipe | ClearScreen | AnnotateUp | AnnotateDown -> redraw st
+                        | Continue | Wipe | ClearScreen | AnnotateUp | AnnotateDown | CycleApprovalMode -> redraw st
                         | Submit _ | Quit -> ()
 
                 | Digit2 ->
@@ -595,7 +621,7 @@ let readAsync (prompt: string) (strings: Strings) (slashHelp: (string * string) 
                         flushEscape ()
                         let ki2 = ConsoleKeyInfo(c, k.Key, false, false, false)
                         match applyKey ki2 st with
-                        | Continue | Wipe | ClearScreen | AnnotateUp | AnnotateDown -> redraw st
+                        | Continue | Wipe | ClearScreen | AnnotateUp | AnnotateDown | CycleApprovalMode -> redraw st
                         | Submit _ | Quit -> ()
 
                 | Digit0 ->
@@ -606,7 +632,7 @@ let readAsync (prompt: string) (strings: Strings) (slashHelp: (string * string) 
                         flushEscape ()
                         let ki2 = ConsoleKeyInfo(c, k.Key, false, false, false)
                         match applyKey ki2 st with
-                        | Continue | Wipe | ClearScreen | AnnotateUp | AnnotateDown -> redraw st
+                        | Continue | Wipe | ClearScreen | AnnotateUp | AnnotateDown | CycleApprovalMode -> redraw st
                         | Submit _ | Quit -> ()
 
                 | Digit0v2 ->
@@ -619,7 +645,7 @@ let readAsync (prompt: string) (strings: Strings) (slashHelp: (string * string) 
                         flushEscape ()
                         let ki2 = ConsoleKeyInfo(c, k.Key, false, false, false)
                         match applyKey ki2 st with
-                        | Continue | Wipe | ClearScreen | AnnotateUp | AnnotateDown -> redraw st
+                        | Continue | Wipe | ClearScreen | AnnotateUp | AnnotateDown | CycleApprovalMode -> redraw st
                         | Submit _ | Quit -> ()
 
                 | PasteActive ->

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -723,9 +723,14 @@ let run (initialAgent: AIAgent) (sessionRef: (AgentSession | null) ref) (initial
                 let sym = match rating with Fugue.Core.Annotation.Up -> "↑" | Fugue.Core.Annotation.Down -> "↓"
                 AnsiConsole.MarkupLine($"[dim]{sym} turn {idx}[/]")
             let callbacks : ReadLine.ReadLineCallbacks =
-                { OnClearScreen  = StatusBar.refresh
-                  OnAnnotateUp   = fun () -> doAnnotate Fugue.Core.Annotation.Up
-                  OnAnnotateDown = fun () -> doAnnotate Fugue.Core.Annotation.Down }
+                { OnClearScreen       = StatusBar.refresh
+                  OnAnnotateUp        = fun () -> doAnnotate Fugue.Core.Annotation.Up
+                  OnAnnotateDown      = fun () -> doAnnotate Fugue.Core.Annotation.Down
+                  OnCycleApprovalMode =
+                    fun () ->
+                        let m = StatusBar.cycleApprovalMode ()
+                        StatusBar.refresh ()
+                        AnsiConsole.MarkupLine($"[dim]→ approval mode: {Fugue.Core.ApprovalMode.label m}[/]") }
             // Drain file-watch triggers from background FileSystemWatcher
             let watchTriggers = FileWatcher.drain ()
             for wcmd in watchTriggers do

--- a/src/Fugue.Cli/StatusBar.fs
+++ b/src/Fugue.Cli/StatusBar.fs
@@ -3,6 +3,7 @@ module Fugue.Cli.StatusBar
 open System
 open System.Diagnostics
 open System.IO
+open Fugue.Core
 open Fugue.Core.Localization
 open Fugue.Core.Config
 open Fugue.Surface
@@ -43,6 +44,7 @@ type StatusBarState = {
     IsSSH:          bool
     Width:          int
     Height:         int
+    ApprovalMode:   ApprovalMode
 }
 
 // ---------------------------------------------------------------------------
@@ -111,8 +113,20 @@ let renderStatusBar (state: StatusBarState) : DrawOp list =
         | OpenAI(_, m)    -> "openai:" + friendlyModel m
         | Ollama(_, m)    -> "ollama:" + friendlyModel m
 
+    // Approval-mode pill — colourised by risk: Plan (green), Default (dim),
+    // AutoEdit (yellow), YOLO (red). Goes at the start of line 1 so it's the
+    // first thing the eye lands on when triaging session safety.
+    let modeIcon = ApprovalMode.icon state.ApprovalMode
+    let modeColor =
+        match state.ApprovalMode with
+        | ApprovalMode.Plan     -> "\x1b[32m"   // green — most restrictive
+        | ApprovalMode.Default  -> dimEsc       // dim — neutral default
+        | ApprovalMode.AutoEdit -> "\x1b[33m"   // yellow — caution
+        | ApprovalMode.YOLO     -> "\x1b[31m"   // red — danger
+    let modePill = $"{modeColor}{modeIcon}\x1b[0m{dimEsc}  "
+
     let line1Text =
-        dimEsc + state.Cwd + " " + state.Strings.StatusBarOn + " \x1b[1m" + state.Branch + "\x1b[0m"
+        modePill + state.Cwd + " " + state.Strings.StatusBarOn + " \x1b[1m" + state.Branch + "\x1b[0m"
 
     // --- ThinkingLine + elapsed/cadence for Line 2 ---
     let elapsedSuffix, thinkingLineText, cadenceSuffix =
@@ -197,6 +211,22 @@ let mutable private cwd: string = "."
 let mutable private cfg: AppConfig option = None
 let mutable private active = false
 let mutable private activeTheme = ""
+let mutable private approvalMode : ApprovalMode = ApprovalMode.Default
+
+/// Set the approval mode (e.g. from --mode CLI flag at startup).
+/// Caller is responsible for calling refresh () afterwards if visible
+/// feedback is desired — kept side-effect-free so this can run pre-`start`.
+let setApprovalMode (m: ApprovalMode) : unit = approvalMode <- m
+
+/// Cycle the approval mode (Shift+Tab in REPL): Plan → Default → AutoEdit → YOLO → Plan.
+/// Returns the new mode so the caller can log / status it.
+/// Caller (ReadLine Shift+Tab handler) calls refresh () to repaint.
+let cycleApprovalMode () : ApprovalMode =
+    approvalMode <- ApprovalMode.cycle approvalMode
+    approvalMode
+
+/// Read-only accessor for callers that need to gate tool execution.
+let getApprovalMode () : ApprovalMode = approvalMode
 
 let initTheme (theme: string) = activeTheme <- theme
 let mutable private compactMode = false
@@ -361,7 +391,8 @@ let private captureState () : StatusBarState =
       SessionWords  = sessionWords
       IsSSH         = isSSH
       Width         = Console.WindowWidth
-      Height        = Console.WindowHeight }
+      Height        = Console.WindowHeight
+      ApprovalMode  = approvalMode }
 
 /// Walk a DrawOp list and emit ANSI escapes directly to Console.Out.
 /// Synchronous, no MailboxProcessor — PR B bridge.  PR C replaces this

--- a/src/Fugue.Core/ApprovalMode.fs
+++ b/src/Fugue.Core/ApprovalMode.fs
@@ -1,0 +1,81 @@
+namespace Fugue.Core
+
+/// Approval policy applied to tool calls during a session.
+///
+/// Modes form a cycle (Shift+Tab in the REPL): Plan → Default → AutoEdit → YOLO → Plan.
+///
+/// Gating semantics (will be wired into the tool dispatcher in a follow-up PR):
+///
+///   | mode      | Read/Glob/Grep | Write/Edit | Bash         |
+///   |-----------|----------------|------------|--------------|
+///   | Plan      | prompt         | prompt     | prompt       |
+///   | Default   | auto           | prompt     | prompt       |
+///   | AutoEdit  | auto           | auto       | prompt       |
+///   | YOLO      | auto           | auto       | auto         |
+///
+/// At present the mode is purely advisory: it cycles via Shift+Tab and is
+/// shown in the status bar, but tool execution is not yet gated. Phase 1 of
+/// v0.2 ships the cycling + display; Phase 2 wires the gate into Bash/Write/Edit.
+[<RequireQualifiedAccess>]
+type ApprovalMode =
+    | Plan
+    | Default
+    | AutoEdit
+    | YOLO
+
+module ApprovalMode =
+
+    /// Cycle order matches the user-facing Shift+Tab progression.
+    let cycle (mode: ApprovalMode) : ApprovalMode =
+        match mode with
+        | ApprovalMode.Plan     -> ApprovalMode.Default
+        | ApprovalMode.Default  -> ApprovalMode.AutoEdit
+        | ApprovalMode.AutoEdit -> ApprovalMode.YOLO
+        | ApprovalMode.YOLO     -> ApprovalMode.Plan
+
+    /// Single-glyph indicator + lowercase label, suitable for a status-bar pill.
+    /// Glyph hierarchy: ◆ (filled diamond, most restrictive) → ○ (empty circle, least).
+    let icon (mode: ApprovalMode) : string =
+        match mode with
+        | ApprovalMode.Plan     -> "◆ plan"      // ◆
+        | ApprovalMode.Default  -> "● default"   // ●
+        | ApprovalMode.AutoEdit -> "◑ auto-edit" // ◑
+        | ApprovalMode.YOLO     -> "○ yolo"      // ○
+
+    /// Short label without the glyph, for log lines and CLI flag round-tripping.
+    let label (mode: ApprovalMode) : string =
+        match mode with
+        | ApprovalMode.Plan     -> "plan"
+        | ApprovalMode.Default  -> "default"
+        | ApprovalMode.AutoEdit -> "auto-edit"
+        | ApprovalMode.YOLO     -> "yolo"
+
+    /// Parse a CLI-flag value (case-insensitive). `auto-edit` and `autoedit` are
+    /// both accepted because users will type both. Returns None on unknown input
+    /// so the caller can produce a structured error message.
+    let tryParse (raw: string | null) : ApprovalMode option =
+        let normalised =
+            match raw with
+            | null -> ""
+            | s    -> s.Trim().ToLowerInvariant()
+        match normalised with
+        | "plan"      -> Some ApprovalMode.Plan
+        | "default"   -> Some ApprovalMode.Default
+        | "auto-edit"
+        | "autoedit"  -> Some ApprovalMode.AutoEdit
+        | "yolo"      -> Some ApprovalMode.YOLO
+        | _           -> None
+
+    /// Whether tool calls of a given category require user approval under this
+    /// mode. The dispatcher will use this once gating ships.
+    let requiresApproval (mode: ApprovalMode) (toolKind: string) : bool =
+        // Tool kinds: "read" (Read/Glob/Grep), "edit" (Write/Edit), "bash" (Bash).
+        // Unknown kinds default to "edit" — safer to prompt than to skip.
+        match mode, toolKind with
+        | ApprovalMode.YOLO, _              -> false
+        | ApprovalMode.AutoEdit, "read"     -> false
+        | ApprovalMode.AutoEdit, "edit"     -> false
+        | ApprovalMode.AutoEdit, _          -> true
+        | ApprovalMode.Default, "read"      -> false
+        | ApprovalMode.Default, _           -> true
+        | ApprovalMode.Plan, _              -> true

--- a/src/Fugue.Core/Fugue.Core.fsproj
+++ b/src/Fugue.Core/Fugue.Core.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="ErrorTrend.fs" />
     <Compile Include="ConversationIntent.fs" />
     <Compile Include="Hooks.fs" />
+    <Compile Include="ApprovalMode.fs" />
     <Compile Include="ProviderCache.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Fugue.Tests/ApprovalModeTests.fs
+++ b/tests/Fugue.Tests/ApprovalModeTests.fs
@@ -1,0 +1,97 @@
+module Fugue.Tests.ApprovalModeTests
+
+/// Unit tests for `Fugue.Core.ApprovalMode`.
+///
+/// Covers:
+///   - cycle order (Shift+Tab progression) is exactly one full loop
+///   - icon / label string format
+///   - tryParse round-trips with `label` for all modes
+///   - tryParse is case-insensitive and accepts both `auto-edit` and `autoedit`
+///   - tryParse returns None on garbage input (no exceptions)
+///   - requiresApproval matrix matches the documented table
+
+open Xunit
+open FsUnit.Xunit
+open Fugue.Core
+
+[<Fact>]
+let ``cycle visits all four modes and returns to start in 4 steps`` () =
+    let start = ApprovalMode.Plan
+    let next1 = ApprovalMode.cycle start
+    let next2 = ApprovalMode.cycle next1
+    let next3 = ApprovalMode.cycle next2
+    let next4 = ApprovalMode.cycle next3
+    next1 |> should equal ApprovalMode.Default
+    next2 |> should equal ApprovalMode.AutoEdit
+    next3 |> should equal ApprovalMode.YOLO
+    next4 |> should equal ApprovalMode.Plan  // back to start
+
+[<Fact>]
+let ``label returns lowercase short name without glyph`` () =
+    ApprovalMode.label ApprovalMode.Plan     |> should equal "plan"
+    ApprovalMode.label ApprovalMode.Default  |> should equal "default"
+    ApprovalMode.label ApprovalMode.AutoEdit |> should equal "auto-edit"
+    ApprovalMode.label ApprovalMode.YOLO     |> should equal "yolo"
+
+[<Fact>]
+let ``icon contains label and a single-glyph prefix`` () =
+    let pairs =
+        [ ApprovalMode.Plan;      ApprovalMode.Default
+          ApprovalMode.AutoEdit;  ApprovalMode.YOLO ]
+        |> List.map (fun m -> m, ApprovalMode.icon m)
+    for mode, ic in pairs do
+        ic |> should haveSubstring (ApprovalMode.label mode)
+        // First "word" is the glyph; second segment is the label.
+        let parts = ic.Split ' '
+        parts.Length |> should equal 2
+
+[<Fact>]
+let ``tryParse round-trips every mode via label`` () =
+    let allModes =
+        [ ApprovalMode.Plan; ApprovalMode.Default
+          ApprovalMode.AutoEdit; ApprovalMode.YOLO ]
+    for m in allModes do
+        let parsed = ApprovalMode.tryParse (ApprovalMode.label m)
+        parsed |> should equal (Some m)
+
+[<Fact>]
+let ``tryParse accepts uppercase and surrounding whitespace`` () =
+    ApprovalMode.tryParse "  PLAN  "      |> should equal (Some ApprovalMode.Plan)
+    ApprovalMode.tryParse "Default"       |> should equal (Some ApprovalMode.Default)
+    ApprovalMode.tryParse "AUTO-EDIT"     |> should equal (Some ApprovalMode.AutoEdit)
+    ApprovalMode.tryParse "yOlO"          |> should equal (Some ApprovalMode.YOLO)
+
+[<Fact>]
+let ``tryParse accepts both autoedit and auto-edit forms`` () =
+    ApprovalMode.tryParse "auto-edit" |> should equal (Some ApprovalMode.AutoEdit)
+    ApprovalMode.tryParse "autoedit"  |> should equal (Some ApprovalMode.AutoEdit)
+
+[<Fact>]
+let ``tryParse returns None for unknown input without throwing`` () =
+    ApprovalMode.tryParse ""           |> should equal None
+    ApprovalMode.tryParse "safe"       |> should equal None
+    ApprovalMode.tryParse "auto"       |> should equal None
+    ApprovalMode.tryParse null         |> should equal None  // null → empty → None
+
+[<Fact>]
+let ``requiresApproval YOLO is false for everything`` () =
+    for tool in ["read"; "edit"; "bash"; "anything"] do
+        ApprovalMode.requiresApproval ApprovalMode.YOLO tool |> should equal false
+
+[<Fact>]
+let ``requiresApproval Plan is true for everything`` () =
+    for tool in ["read"; "edit"; "bash"; "anything"] do
+        ApprovalMode.requiresApproval ApprovalMode.Plan tool |> should equal true
+
+[<Fact>]
+let ``requiresApproval AutoEdit prompts only for bash and unknown`` () =
+    ApprovalMode.requiresApproval ApprovalMode.AutoEdit "read"     |> should equal false
+    ApprovalMode.requiresApproval ApprovalMode.AutoEdit "edit"     |> should equal false
+    ApprovalMode.requiresApproval ApprovalMode.AutoEdit "bash"     |> should equal true
+    ApprovalMode.requiresApproval ApprovalMode.AutoEdit "unknown"  |> should equal true
+
+[<Fact>]
+let ``requiresApproval Default skips read but prompts edit and bash`` () =
+    ApprovalMode.requiresApproval ApprovalMode.Default "read" |> should equal false
+    ApprovalMode.requiresApproval ApprovalMode.Default "edit" |> should equal true
+    ApprovalMode.requiresApproval ApprovalMode.Default "bash" |> should equal true

--- a/tests/Fugue.Tests/Fugue.Tests.fsproj
+++ b/tests/Fugue.Tests/Fugue.Tests.fsproj
@@ -31,6 +31,7 @@
     <Compile Include="StatusBarPropertyTests.fs" />
     <Compile Include="StatusBarActorTests.fs" />
     <Compile Include="StatusBarHeartbeatTests.fs" />
+    <Compile Include="ApprovalModeTests.fs" />
     <Compile Include="ReadToolTests.fs" />
     <Compile Include="WriteToolTests.fs" />
     <Compile Include="EditToolTests.fs" />

--- a/tests/Fugue.Tests/ReadLineTests.fs
+++ b/tests/Fugue.Tests/ReadLineTests.fs
@@ -60,6 +60,16 @@ let ``Shift+Enter inserts newline`` () =
     s.Cursor |> should equal 4
 
 [<Fact>]
+let ``Shift+Tab returns CycleApprovalMode without touching the buffer`` () =
+    let s = mkState "hello" 3
+    let act = applyKey (special ConsoleKey.Tab ConsoleModifiers.Shift) s
+    act |> should equal CycleApprovalMode
+    // Buffer + cursor MUST be unaffected — Shift+Tab is a session UX action,
+    // not text input.
+    String(s.Buffer.ToArray()) |> should equal "hello"
+    s.Cursor |> should equal 3
+
+[<Fact>]
 let ``Ctrl+D on empty buffer returns Quit`` () =
     let s = mkState "" 0
     let act = applyKey (special ConsoleKey.D ConsoleModifiers.Control) s

--- a/tests/Fugue.Tests/StatusBarPropertyTests.fs
+++ b/tests/Fugue.Tests/StatusBarPropertyTests.fs
@@ -6,6 +6,7 @@ open FsCheck.FSharp
 open FsCheck.FSharp.GenBuilder
 open FsCheck.Xunit
 open Fugue.Surface
+open Fugue.Core
 open Fugue.Core.Config
 open Fugue.Core.Localization
 open Fugue.Cli.StatusBar
@@ -71,6 +72,8 @@ type StatusBarArbs =
             let! isSSH         = Gen.elements [ true; false ]
             let! width         = Gen.choose (60, 220)
             let! height        = Gen.choose (10, 60)
+            let! mode          = Gen.elements [ ApprovalMode.Plan; ApprovalMode.Default
+                                                ApprovalMode.AutoEdit; ApprovalMode.YOLO ]
             return {
                 Cwd           = cwd
                 Branch        = branch
@@ -86,6 +89,7 @@ type StatusBarArbs =
                 IsSSH         = isSSH
                 Width         = width
                 Height        = height
+                ApprovalMode  = mode
             }
         }
         { new Arbitrary<StatusBarState>() with

--- a/tests/Fugue.Tests/StatusBarRenderTests.fs
+++ b/tests/Fugue.Tests/StatusBarRenderTests.fs
@@ -4,6 +4,7 @@ open System
 open Xunit
 open FsUnit.Xunit
 open Fugue.Surface
+open Fugue.Core
 open Fugue.Core.Config
 open Fugue.Core.Localization
 open Fugue.Cli.StatusBar
@@ -43,7 +44,8 @@ let private idleState : StatusBarState =
       SessionWords  = 0
       IsSSH         = false
       Width         = 120
-      Height        = 30 }
+      Height        = 30
+      ApprovalMode  = ApprovalMode.Default }
 
 /// Apply ops to a fresh 120×30 mock terminal and return it.
 let private exec (ops: DrawOp list) : MockTerminal =


### PR DESCRIPTION
## Что

Phase 1 v0.2 спека — approval-mode skeleton. Добавляет тип, cycling через Shift+Tab, отображение в status bar, CLI флаг `--mode`. **Gating tools** (prompt перед Bash/Write/Edit) — следующим PR.

## Зачем

Из исходной спеки (`docs/superpowers/specs/2026-04-29-fugue-design.md`):

> **Риск, который пользователь принял явно**: в MVP нет permission-prompt. Tools `Bash`, `Write`, `Edit` исполняются автоматически. На MVP это допустимо, но в плане отдельный пункт «v0.2: confirmation gate перед mutating tools».

Просрочено на 4 фазы. Issue #395 уже с implementation sketch'ем — точно следуем ему.

## Что включает

### Fugue.Core/ApprovalMode.fs (новый файл, 81 LOC)

```fsharp
type ApprovalMode = Plan | Default | AutoEdit | YOLO
```

- `cycle`: Plan → Default → AutoEdit → YOLO → Plan
- `icon`: `◆ plan`, `● default`, `◑ auto-edit`, `○ yolo`
- `label`: lowercase для CLI/логов
- `tryParse`: case-insensitive, принимает `auto-edit` и `autoedit`, null-safe
- `requiresApproval`: матрица mode × tool-kind (для Phase 2)

### StatusBar
- Module-level mutable `approvalMode` + сеттеры `setApprovalMode`/`cycleApprovalMode`
- `StatusBarState.ApprovalMode` поле
- Line 1 префикс — цветной pill: 🟢 Plan / dim Default / 🟡 AutoEdit / 🔴 YOLO

### ReadLine
- `Action.CycleApprovalMode` — новый вариант
- Shift+Tab обрабатывается ДО plain-Tab completion branch
- `ReadLineCallbacks.OnCycleApprovalMode`

### Repl
- Wire callback → `StatusBar.cycleApprovalMode` + `refresh` + dim toast `→ approval mode: <name>`

### Program
- `--mode <plan|default|auto-edit|yolo>` флаг
- Unknown value → silent fallback на Default
- `--help` обновлён

## Тесты: 517 → 529 (+12)

**ApprovalModeTests.fs (11):** cycle / icon / label / tryParse round-trip / case-insensitive / null safety / requiresApproval матрица per mode

**ReadLineTests.fs (1):** Shift+Tab возвращает CycleApprovalMode, buffer + cursor не тронуты

## AOT

Publish чистый, 0 IL warnings на изменённых файлах. Бинарник: 48MB osx-arm64.

```
$ ./fugue --version
fugue 1.0.0+...

$ ./fugue --help
Usage: fugue [...] [--mode <m>] [...]
  --mode <m>          Initial approval mode: plan, default, auto-edit, yolo
                      (Shift+Tab cycles in REPL)
```

## Что НЕ в этом PR

**Phase 2 — actual gating:**
- Tool dispatcher читает `approvalMode` и зовёт user-prompt перед Bash / Write / Edit когда `requiresApproval` true
- Сейчас mode **только показывается и циклится** — tools всё ещё исполняются безусловно
- Это допустимый interim state: соответствует существующему MVP-контракту, который пользователь явно принял

Открою follow-up issue для Phase 2 после мерджа.

## Ручная TTY-валидация

```bash
git checkout feat/approval-modes-cycling
dotnet publish src/Fugue.Cli -c Release -r osx-arm64
./src/Fugue.Cli/bin/Release/net10.0/osx-arm64/publish/fugue --mode plan
```

1. Запустил с `--mode plan` → status bar показывает `◆ plan` зелёным
2. Shift+Tab → `● default` (dim)
3. Shift+Tab → `◑ auto-edit` (yellow)
4. Shift+Tab → `○ yolo` (red)
5. Shift+Tab → обратно `◆ plan` зелёным
6. Между cycle'ами появляется dim toast: `→ approval mode: <name>`

Closes #395 partially (display + cycling phase).
