### PR TITLE
feat(safety): wire approval-mode gate into tool dispatcher — Phase 2 of v0.2 (#395)

### DIFF
--- a/src/Fugue.Cli/ApprovalPrompt.fs
+++ b/src/Fugue.Cli/ApprovalPrompt.fs
@@ -1,0 +1,68 @@
+module Fugue.Cli.ApprovalPrompt
+
+open System
+open Fugue.Core
+
+/// Map an AIFunction tool name to an approval-mode kind:
+///   - "read"  → Read / Glob / Grep / Tree / GetConversation
+///   - "edit"  → Write / WriteBatch / Edit
+///   - "bash"  → Bash
+///   - "edit"  → unknown (safer to prompt)
+let toolKind (toolName: string) : string =
+    match toolName with
+    | "Read" | "Glob" | "Grep" | "Tree" | "GetConversation" -> "read"
+    | "Write" | "WriteBatch" | "Edit"                       -> "edit"
+    | "Bash"                                                -> "bash"
+    | _                                                     -> "edit"
+
+/// Truncate a long argument summary so the prompt stays on one line.
+let private trim (s: string) (max: int) : string =
+    if s.Length <= max then s
+    else s.Substring(0, max - 1) + "…"
+
+/// Headless / non-TTY default: in YOLO allow everything; otherwise deny
+/// (no UI to prompt, safer to fail closed than to silently auto-execute).
+let private headlessGate (mode: ApprovalMode) (toolName: string) : Async<bool> =
+    async {
+        if not (ApprovalMode.requiresApproval mode (toolKind toolName)) then
+            return true
+        else
+            // Non-interactive context — fail closed. Agent will see "[denied]".
+            return false
+    }
+
+/// Interactive prompt — reads a single key (y / n / Enter), echoes the choice,
+/// returns true on y/Y. Anything else = deny.
+/// Pre-condition: caller is on the REPL thread (Console is not in use elsewhere).
+/// The Surface actor must NOT be writing to Console concurrently — at the moment
+/// the gate fires, the agent is between tool calls so the actor queue is idle.
+let private interactivePrompt (toolName: string) (argsJson: string) : Async<bool> =
+    async {
+        let summary = trim argsJson 80
+        Console.Out.WriteLine ()
+        Console.Out.WriteLine (sprintf "\x1b[33m? approve %s(%s) [y/N]\x1b[0m" toolName summary)
+        Console.Out.Flush ()
+        let key = Console.ReadKey(intercept = true)
+        let approved = key.KeyChar = 'y' || key.KeyChar = 'Y'
+        let label = if approved then "\x1b[32mallow\x1b[0m" else "\x1b[31mdeny\x1b[0m"
+        Console.Out.WriteLine (sprintf "  → %s" label)
+        Console.Out.Flush ()
+        return approved
+    }
+
+/// Build the gate to install via `DelegatedFn.setApprovalGate`.
+/// `getMode` is a closure that returns the current ApprovalMode — passing it
+/// as a thunk (rather than a captured value) lets Shift+Tab cycle take effect
+/// for the very next tool call.
+let buildGate (getMode: unit -> ApprovalMode) (interactive: bool) : string -> string -> Async<bool> =
+    fun toolName argsJson ->
+        async {
+            let mode = getMode ()
+            let kind = toolKind toolName
+            if not (ApprovalMode.requiresApproval mode kind) then
+                return true
+            elif interactive then
+                return! interactivePrompt toolName argsJson
+            else
+                return! headlessGate mode toolName
+        }

--- a/src/Fugue.Cli/Fugue.Cli.fsproj
+++ b/src/Fugue.Cli/Fugue.Cli.fsproj
@@ -59,6 +59,7 @@
     <Compile Include="StackTraceRender.fs" />
     <Compile Include="Render.fs" />
     <Compile Include="StatusBar.fs" />
+    <Compile Include="ApprovalPrompt.fs" />
     <Compile Include="FileWatcher.fs" />
     <Compile Include="ClipRing.fs" />
     <Compile Include="Macros.fs" />

--- a/src/Fugue.Cli/Program.fs
+++ b/src/Fugue.Cli/Program.fs
@@ -581,6 +581,11 @@ SEE ALSO
             Fugue.Core.Config.saveToFile cfg
             // Apply --mode to StatusBar before any rendering begins.
             StatusBar.setApprovalMode initialApprovalMode
+            // Install approval gate before tools are invoked. Interactive iff stdin
+            // is a TTY (matches the Surface-actor allocation rule).
+            let interactive = not Console.IsInputRedirected
+            Fugue.Tools.AiFunctions.DelegatedFn.setApprovalGate
+                (Fugue.Cli.ApprovalPrompt.buildGate StatusBar.getApprovalMode interactive)
             match printPrompt with
             | Some p -> runWithPrint cfg p
             | None   -> runWithCfg cfg
@@ -594,6 +599,11 @@ SEE ALSO
         let fullCfg = { cfg with ProfileContent = profileContent; TemplateContent = templateContent; TemplateName = templateName; LowBandwidth = lowBandwidth; Offline = offline; DryRun = dryRun }
         // Apply --mode to StatusBar before any rendering begins.
         StatusBar.setApprovalMode initialApprovalMode
+        // Install approval gate before tools are invoked. Interactive iff stdin
+        // is a TTY (matches the Surface-actor allocation rule).
+        let interactive = not Console.IsInputRedirected
+        Fugue.Tools.AiFunctions.DelegatedFn.setApprovalGate
+            (Fugue.Cli.ApprovalPrompt.buildGate StatusBar.getApprovalMode interactive)
         match printPrompt with
         | Some p -> runWithPrint fullCfg p
         | None   -> runWithCfg fullCfg

--- a/src/Fugue.Tools/AiFunctions/DelegatedFn.fs
+++ b/src/Fugue.Tools/AiFunctions/DelegatedFn.fs
@@ -26,6 +26,19 @@ let private argsToJson (args: AIFunctionArguments) : string =
             yield "\"" + esc kvp.Key + "\":" + valueStr ]
     "{" + String.concat "," pairs + "}"
 
+/// Module-level approval gate. Set by Repl at session startup so every tool
+/// call routes through the same prompt logic. Defaults to "always allow" so
+/// tests and headless use exercise the existing paths without prompting.
+///
+/// Signature: toolName -> argsJson -> Async<bool>
+///   true  = approve, run the tool
+///   false = deny, return "[denied]" to the agent
+let mutable approvalGate : string -> string -> Async<bool> =
+    fun _ _ -> async { return true }
+
+let setApprovalGate (gate: string -> string -> Async<bool>) : unit =
+    approvalGate <- gate
+
 /// Single concrete AIFunction subclass parametrised by name/desc/schema/body.
 /// All six tools instantiate this with different bodies — no subclass per tool.
 /// AOT-clean: no reflection on parameter types.
@@ -47,6 +60,15 @@ type DelegatedAIFunction(
             | Some reason ->
                 return box ("[circuit-open] " + reason)
             | None ->
+                // ── Approval gate (v0.2 Phase 2) ──────────────────────────
+                // Run before any side-effects: hooks, circuit-breaker bookkeeping,
+                // tool invocation. If the user denies, the agent sees a [denied]
+                // string and can choose to abandon or change approach.
+                let argsJson0 = argsToJson args
+                let! approved = approvalGate name argsJson0
+                if not approved then
+                    return box ("[denied] User declined to run " + name)
+                else
                 // ── PreToolUse ────────────────────────────────────────────
                 let argsJson = argsToJson args
                 let! preResult = Fugue.Core.Hooks.runPreToolUse name argsJson sessionId hooksConfig

--- a/tests/Fugue.Tests/ApprovalPromptTests.fs
+++ b/tests/Fugue.Tests/ApprovalPromptTests.fs
@@ -1,0 +1,87 @@
+module Fugue.Tests.ApprovalPromptTests
+
+/// Tests for the approval-prompt gate. We exercise:
+///   - tool-name → kind mapping
+///   - buildGate skips the prompt when the mode doesn't require approval
+///   - buildGate denies in non-interactive mode when approval is required
+///     (fail closed — no UI to ask)
+///   - buildGate reads the *current* mode each call (Shift+Tab cycle is honored)
+///
+/// The interactive prompt itself is NOT tested here — it reads from
+/// Console.ReadKey, which can't be driven from xUnit. Manual TTY validation
+/// is the only honest way to exercise that path.
+
+open System
+open Xunit
+open FsUnit.Xunit
+open Fugue.Core
+open Fugue.Cli.ApprovalPrompt
+
+let private run (a: Async<bool>) : bool = Async.RunSynchronously a
+
+[<Fact>]
+let ``toolKind maps Read tools to read`` () =
+    toolKind "Read" |> should equal "read"
+    toolKind "Glob" |> should equal "read"
+    toolKind "Grep" |> should equal "read"
+    toolKind "Tree" |> should equal "read"
+    toolKind "GetConversation" |> should equal "read"
+
+[<Fact>]
+let ``toolKind maps mutating tools to edit`` () =
+    toolKind "Write"      |> should equal "edit"
+    toolKind "WriteBatch" |> should equal "edit"
+    toolKind "Edit"       |> should equal "edit"
+
+[<Fact>]
+let ``toolKind maps Bash to bash`` () =
+    toolKind "Bash" |> should equal "bash"
+
+[<Fact>]
+let ``toolKind defaults unknown tools to edit (fail safer)`` () =
+    toolKind "MysteryTool"  |> should equal "edit"
+    toolKind ""             |> should equal "edit"
+
+[<Fact>]
+let ``buildGate skips prompt for read tools in Default mode`` () =
+    let mutable mode = ApprovalMode.Default
+    let gate = buildGate (fun () -> mode) false  // non-interactive
+    gate "Read" "{}" |> run |> should equal true
+
+[<Fact>]
+let ``buildGate denies in non-interactive when approval required`` () =
+    let gate = buildGate (fun () -> ApprovalMode.Default) false
+    // Default mode requires approval for "edit" and "bash"
+    gate "Write" "{}" |> run |> should equal false
+    gate "Bash"  "{}" |> run |> should equal false
+
+[<Fact>]
+let ``buildGate allows everything in YOLO regardless of interactive`` () =
+    let gateInt = buildGate (fun () -> ApprovalMode.YOLO) true
+    let gateNoInt = buildGate (fun () -> ApprovalMode.YOLO) false
+    for tool in ["Read"; "Write"; "Bash"; "Edit"] do
+        gateInt   tool "{}" |> run |> should equal true
+        gateNoInt tool "{}" |> run |> should equal true
+
+[<Fact>]
+let ``buildGate denies everything except read in Plan mode (non-interactive)`` () =
+    let gate = buildGate (fun () -> ApprovalMode.Plan) false
+    // Plan requires approval for ALL kinds — including read
+    gate "Read"  "{}" |> run |> should equal false
+    gate "Write" "{}" |> run |> should equal false
+    gate "Bash"  "{}" |> run |> should equal false
+
+[<Fact>]
+let ``buildGate honors live mode cycling via getMode closure`` () =
+    let mutable mode = ApprovalMode.YOLO
+    let gate = buildGate (fun () -> mode) false
+    // YOLO → allow
+    gate "Bash" "{}" |> run |> should equal true
+    // Cycle to Plan → deny
+    mode <- ApprovalMode.Plan
+    gate "Bash" "{}" |> run |> should equal false
+    // Cycle to AutoEdit → deny bash, allow read/edit
+    mode <- ApprovalMode.AutoEdit
+    gate "Bash"  "{}" |> run |> should equal false
+    gate "Write" "{}" |> run |> should equal true
+    gate "Read"  "{}" |> run |> should equal true

--- a/tests/Fugue.Tests/Fugue.Tests.fsproj
+++ b/tests/Fugue.Tests/Fugue.Tests.fsproj
@@ -32,6 +32,7 @@
     <Compile Include="StatusBarActorTests.fs" />
     <Compile Include="StatusBarHeartbeatTests.fs" />
     <Compile Include="ApprovalModeTests.fs" />
+    <Compile Include="ApprovalPromptTests.fs" />
     <Compile Include="ReadToolTests.fs" />
     <Compile Include="WriteToolTests.fs" />
     <Compile Include="EditToolTests.fs" />


### PR DESCRIPTION
## Что

**Phase 2** v0.2 спека — actual gating tools. Phase 1 (#914) добавил cycling + display; этот PR закрывает контур, **блокируя tool execution** когда mode требует подтверждения.

## Поведение

| mode      | Read/Glob/Grep/Tree/GetConv | Write/WriteBatch/Edit | Bash         |
|-----------|-----------------------------|------------------------|--------------|
| **Plan**     | prompt                   | prompt                 | prompt       |
| **Default**  | auto                     | prompt                 | prompt       |
| **AutoEdit** | auto                     | auto                   | prompt       |
| **YOLO**     | auto                     | auto                   | auto         |

Промпт: жёлтый `? approve <Tool>(<args>) [y/N]`, single keypress, echo `allow` (зелёный) / `deny` (красный).

При **denied** агент получает `[denied] User declined to run <Tool>` и сам решает что делать (бросить или поменять подход).

## Реализация

### `Fugue.Tools.AiFunctions.DelegatedFn`
- Module-level `approvalGate: string -> string -> Async<bool>` + `setApprovalGate`
- Дефолт = always allow → существующие тесты/headless не ломаются
- `InvokeCoreAsync` зовёт gate **первым делом**, до circuit-breaker и hooks
- Denied → `[denied] User declined to run <Tool>` к агенту

### `Fugue.Cli.ApprovalPrompt` (новый файл, 68 LOC)
- `toolKind`: tool name → `read` / `edit` / `bash`. Unknown → `edit` (fail-safer).
- `buildGate (getMode, interactive)`:
  - `getMode` — **thunk**, не captured value → Shift+Tab cycle действует на следующий же tool call
  - Сначала `ApprovalMode.requiresApproval` — если false, allow без интеракции
  - Interactive: `Console.ReadKey` (intercept), один клавиш
  - **Non-interactive** (headless / `--print`): **fail closed** — deny если approval required. YOLO обходит полностью.

### `Fugue.Cli.Program`
- После `--mode` парса и StatusBar init: `setApprovalGate (buildGate getApprovalMode (not IsInputRedirected))`
- Та же allocation rule что у Surface-actor'а

## Тесты: 528 → 538 (+10)

`ApprovalPromptTests.fs`:
- toolKind полный mapping + unknown → edit fallback
- buildGate skip промпта для read в Default
- buildGate deny non-interactively когда approval required
- buildGate всё allow в YOLO независимо от interactive
- buildGate всё deny в Plan
- **buildGate live-cycling через getMode closure** — ключевая property, делает Shift+Tab отзывчивым

Сам interactive prompt (Console.ReadKey path) **НЕ unit-тестирован** — нельзя из xUnit. Honest path — ручная TTY-валидация.

## AOT

Publish чистый, 0 IL warnings. Бинарь 48MB osx-arm64.

## Ручная TTY-валидация

```bash
git checkout feat/approval-modes-gating
dotnet publish src/Fugue.Cli -c Release -r osx-arm64
./src/Fugue.Cli/bin/Release/net10.0/osx-arm64/publish/fugue --mode plan
```

1. `--mode plan` → попроси модель прочитать файл (`Read`)
   - Должен появиться `? approve Read({"path":"..."}) [y/N]`
   - `y` → файл прочитан, `n` → агент видит `[denied]`
2. `Shift+Tab` → переключи в YOLO
   - Все tool calls идут без вопросов
3. `Shift+Tab → Default` → прочитать файл проходит молча, write/bash спрашивает
4. `--print "..."` (headless) с `--mode default` → запросы на write/bash сразу `[denied]` (fail closed)
5. `--print "..."` с `--mode yolo` → всё проходит

Closes #395 fully.

---

⚠️ **Не мержить без явной TTY-валидации** — fix может уронить UX в реальном терминале если actor конфликтует с Console.ReadKey в gate. Все автотесты зелёные, но это новый interactive path который unit-тестами не покрыть.
