### PR TITLE
feat(surface): full migration to actor — Phase 1.3 (#913, #910)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -35,12 +35,19 @@ test-only filter:
 publish target="osx-arm64":
     dotnet publish src/Fugue.Cli -c Release -r {{target}}
 
-# Build + publish + run the binary. The fastest one-shot path from clean tree
-# to interactive REPL — what you want during local UX iteration.
-run target="osx-arm64": (publish target)
+# Run via JIT — fastest path for UX iteration. ~10s build, ~300ms cold-start.
+# Functionally identical to AOT for 99% of features; use this for any tweak
+# loop that doesn't need to measure cold-start, RSS, or AOT-specific bugs.
+run *args:
+    dotnet run --project src/Fugue.Cli -c Release -- {{args}}
+
+# Same as `run` but explicit name for the AOT path. ~60-90s (full publish)
+# but ~40ms cold-start and 47MB single-file binary. Use for cold-start /
+# RSS / binary-size measurement and AOT-specific regression checks.
+run-aot target="osx-arm64": (publish target)
     ./src/Fugue.Cli/bin/Release/net10.0/{{target}}/publish/fugue
 
-# Run the binary with an explicit approval mode (plan / default / auto-edit /
+# Run the AOT binary with an explicit approval mode (plan / default / auto-edit /
 # yolo). Useful for testing the gate.
 run-mode mode target="osx-arm64": (publish target)
     ./src/Fugue.Cli/bin/Release/net10.0/{{target}}/publish/fugue --mode {{mode}}

--- a/src/Fugue.Cli/Program.fs
+++ b/src/Fugue.Cli/Program.fs
@@ -79,6 +79,28 @@ let private runWithCfg (cfg: AppConfig) : int =
         Console.Error.WriteLine("--offline requires a local provider (Ollama). Set FUGUE_PROVIDER=ollama or update ~/.fugue/config.json.")
         1
     else
+    // Phase 1.3c: start the Surface actor and redirect Console.Out / Error
+    // BEFORE any rendering init (Render / Spectre / Markdig). Spectre.AnsiConsole
+    // captures Console.Out at first use — if we redirect later, Spectre will
+    // already hold the original stdout reference and bypass our actor. Doing
+    // SetOut here ensures every downstream init wires Spectre to the actor.
+    let surfaceActor =
+        if Console.IsInputRedirected then None
+        else
+            let actor = RealExecutor.start ()
+            StatusBar.setAgent actor
+            // ReadLine routes structured RawAnsi through actor (Phase 1.3b).
+            ReadLine.setAgent actor
+            // Phase 1.3c: redirect Console.Out / Error so all third-party
+            // writers (Spectre, Markdig, plain Console.WriteLine, our direct
+            // AnsiConsole.MarkupLine in slash commands / approval prompt /
+            // exit message) automatically funnel through the same mailbox.
+            // RealExecutor captured the real stdout at module load (above
+            // RealExecutor.start), so its own writes don't recurse.
+            let actorWriter = new ActorWriter(actor)
+            Console.SetOut   actorWriter
+            Console.SetError actorWriter
+            Some actor
     let isClassic = cfg.Ui.Theme = "fugue-classic" || cfg.Ui.Theme = "monochrome"
     Render.initColor (not (noColor () || isClassic))
     let emojiEnabled =
@@ -129,14 +151,6 @@ let private runWithCfg (cfg: AppConfig) : int =
     // module-level mutable in GetConversationFn (#50).
     let sessionRef : (Microsoft.Agents.AI.AgentSession | null) ref = ref null
     let aiAgent = buildAgent cfg hooksConfig providerContext lastSummary sessionId sessionRef
-    // Start the Surface actor — serialises all terminal writes and eliminates the
-    // timer-thread race.  Wire it into StatusBar before start() is called.
-    let surfaceActor =
-        if Console.IsInputRedirected then None
-        else
-            let actor = RealExecutor.start ()
-            StatusBar.setAgent actor
-            Some actor
     let t =
         if Console.IsInputRedirected then Repl.runHeadless aiAgent cfg cwd
         else Repl.run aiAgent sessionRef cfg cwd lastSummary (fun newCfg -> buildAgent newCfg hooksConfig providerContext None sessionId sessionRef)

--- a/src/Fugue.Cli/ReadLine.fs
+++ b/src/Fugue.Cli/ReadLine.fs
@@ -5,6 +5,20 @@ open System.Collections.Generic
 open System.Threading
 open System.Threading.Tasks
 open Fugue.Core.Localization
+open Fugue.Surface
+
+/// Optional Surface MailboxProcessor — when set, every ReadLine write is posted
+/// through it instead of going straight to Console.Out. Serialises ReadLine
+/// against StatusBar / Picker / heartbeat paints, eliminating cursor races
+/// (closes #913 and the timing half of #910).
+///
+/// Set once by Program.fs, before the first call to `read`. Headless / tests
+/// keep the direct-write fallback (None).
+let mutable private surfaceAgent : MailboxProcessor<SurfaceMessage> option = None
+
+/// Wire the Surface actor for ReadLine. Idempotent.
+let setAgent (agent: MailboxProcessor<SurfaceMessage>) : unit =
+    surfaceAgent <- Some agent
 
 // Bracketed paste mode escape sequences.
 let private pasteBeginSeq = "\x1b[200~"
@@ -326,9 +340,32 @@ let applyPastedText (text: string) (s: S) : unit =
     s.Buffer.AddRange(normalized.ToCharArray())
     s.Cursor <- s.Buffer.Count
 
+/// Write a raw ANSI-bearing string. When the Surface actor is wired,
+/// the write is queued as a `RawAnsi` DrawOp so it's serialised against
+/// concurrent paints from StatusBar / heartbeat / Picker. Otherwise we fall
+/// back to direct Console.Out (headless / tests).
+///
+/// Note: even with the actor, we keep `Console.Out.Flush()` on the fallback
+/// path because some terminals buffer until newline; the actor's executor
+/// already flushes after each batch.
 let private writeRaw (s: string) =
-    Console.Out.Write s
-    Console.Out.Flush()
+    match surfaceAgent with
+    | Some agent ->
+        agent.Post(SurfaceMessage.Execute [ DrawOp.RawAnsi s ])
+    | None ->
+        Console.Out.Write s
+        Console.Out.Flush()
+
+/// Synchronous flush barrier — ensures any pending ReadLine writes have been
+/// applied before the caller proceeds. Used at points where we need to read
+/// the real cursor position or hand off to another renderer (e.g. before
+/// asking the user for approval). Becomes a no-op when no actor is wired.
+let private flushBarrier () : unit =
+    match surfaceAgent with
+    | Some agent ->
+        agent.PostAndAsyncReply(fun ch -> SurfaceMessage.ExecuteAndAck([], ch))
+        |> Async.RunSynchronously
+    | None -> ()
 
 /// Clear `count` rows starting at the cursor's current row and moving downward.
 /// Cursor is left at column 0 of the top row of the cleared area.
@@ -346,7 +383,7 @@ let private eraseLines (count: int) : unit =
         if count > 1 then writeRaw ("\x1b[" + string (count - 1) + "A")
         writeRaw "\r"
 
-let private redraw (st: S) =
+let internal redraw (st: S) =
     // 1. cursor up to start of our previous render, clear per-line (not full screen end)
     // Before erasing, move cursor to the bottom of the previously-rendered area so
     // eraseLines (which walks UP count-1 rows) starts from the correct position.

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -791,9 +791,14 @@ let run (initialAgent: AIAgent) (sessionRef: (AgentSession | null) ref) (initial
             | _ -> ()
             match processedLine with
             | None ->
+                // Show "exiting…" so the brief shutdown blocking on actor flush
+                // doesn't look like a hang. Goes straight to Console.Out — actor
+                // is about to be drained and shut down anyway.
+                AnsiConsole.MarkupLine($"[dim italic]{Markup.Escape liveStrings.ExitingMessage}[/]")
                 cancelSrc.RequestQuit()
             | Some s when System.String.IsNullOrWhiteSpace s -> ()
             | Some s when s = "/exit" || s = "/quit" ->
+                AnsiConsole.MarkupLine($"[dim italic]{Markup.Escape liveStrings.ExitingMessage}[/]")
                 cancelSrc.RequestQuit()
             | Some s when s = "/help" ->
                 AnsiConsole.Write(Markup("[bold]" + Markup.Escape liveStrings.HelpHeader + "[/]"))

--- a/src/Fugue.Cli/StatusBar.fs
+++ b/src/Fugue.Cli/StatusBar.fs
@@ -433,6 +433,9 @@ let private applyOpsDirectly (ops: DrawOp list) : unit =
         | DrawOp.ResetScrollRegion ->
             let w = Console.WindowWidth
             writeRaw $"\x1b[1;{h}r\x1b[{h};{w}H"
+        | DrawOp.RawAnsi text ->
+            // Fallback path mirrors the actor: write verbatim.
+            writeRaw text
     writeRaw "\x1b[s"
     for op in ops do applyOne op
     writeRaw "\x1b[u"
@@ -442,8 +445,15 @@ let refresh () =
     let state = captureState ()
     let ops   = renderStatusBar state
     match surfaceAgent with
-    | Some agent -> agent.Post(SurfaceMessage.Execute ops)   // serialised — no race
-    | None       -> applyOpsDirectly ops                     // fallback (headless / tests)
+    | Some agent ->
+        // Phase 1.3c: with Console.Out redirected through ActorWriter, the
+        // actor is the SOLE writer to the real terminal. SaveAndRestore is
+        // therefore safe in all states — no parallel Repl thread can interject
+        // between save and restore, because Repl's streams now go through the
+        // same mailbox and are serialised by construction.
+        agent.Post(SurfaceMessage.Execute [ DrawOp.SaveAndRestore ops ])
+    | None ->
+        applyOpsDirectly ops                                 // fallback (headless / tests)
 
 /// Update the config the status bar reads from. Use after `/model set` and
 /// other config-mutating commands. `start` early-returns once the bar is

--- a/src/Fugue.Core/Localization.fs
+++ b/src/Fugue.Core/Localization.fs
@@ -176,6 +176,11 @@ type Strings =
       // Streaming waiting label
       Thinking: string
 
+      // Shown between user-requested exit (Ctrl+D, double Ctrl+C) and actual
+      // process termination, so the brief shutdown delay (actor flush + scroll
+      // region reset) doesn't look like a hang.
+      ExitingMessage: string
+
       // /watch command
       CmdWatchDesc:  string
       WatchAdded:    string
@@ -332,6 +337,7 @@ let en : Strings =
       TestFileHint          = "[test file found: {0} — include it with @{1}]"
       InputPlaceholder      = "Type a message or /help"
       Thinking              = "thinking"
+      ExitingMessage        = "exiting…"
       CmdWatchDesc          = "watch a file and re-run a command on save"
       WatchAdded            = "watching {0} → will run: {1}"
       WatchRemoved          = "stopped watching {0}"
@@ -471,6 +477,7 @@ let ru : Strings =
       TestFileHint          = "[найден тест-файл: {0} — подключите его через @{1}]"
       InputPlaceholder      = "Введите сообщение или /help"
       Thinking              = "думаю"
+      ExitingMessage        = "выхожу…"
       CmdWatchDesc          = "следить за файлом и перезапускать команду при сохранении"
       WatchAdded            = "слежу за {0} → запущу: {1}"
       WatchRemoved          = "перестал следить за {0}"

--- a/src/Fugue.Surface/ActorWriter.fs
+++ b/src/Fugue.Surface/ActorWriter.fs
@@ -1,0 +1,62 @@
+namespace Fugue.Surface
+
+open System
+open System.IO
+open System.Text
+
+/// TextWriter that funnels every Write call into the Surface actor as a
+/// `RawAnsi` DrawOp. Installed as `Console.Out` (and `Console.Error`) at
+/// startup so EVERY writer in the process — Spectre.Console, Markdig,
+/// AnsiConsole.MarkupLine, our internal `writeRaw`, raw Console.WriteLine
+/// from third-party libraries — automatically serialises through the
+/// actor's mailbox queue.
+///
+/// This is the missing piece for Phase 1.3c: with ReadLine routed through
+/// the actor (Phase 1.3b) but streaming tokens / markdown / slash-command
+/// output still going direct to Console.Out, races between heartbeat paints
+/// and stream tokens caused visible flicker / overlap. With this writer
+/// installed, the actor is the SOLE consumer of the real terminal stdout.
+///
+/// CRITICAL: the actor's own writes (RealExecutor.write) MUST go through the
+/// captured original stdout, NOT through this writer. Otherwise every actor
+/// write posts a message to itself → mailbox grows forever, no progress.
+/// `RealExecutor.originalStdout` captures Console.Out at module load
+/// (which happens at `RealExecutor.start ()` from Program.fs) BEFORE this
+/// writer is installed.
+type ActorWriter(agent: MailboxProcessor<SurfaceMessage>) =
+    inherit TextWriter()
+
+    /// Surrogate object that turns a string write into one Execute message.
+    /// Centralised so Write/WriteLine/Write(char) all funnel here.
+    let post (s: string) =
+        if not (String.IsNullOrEmpty s) then
+            agent.Post(SurfaceMessage.Execute [ DrawOp.RawAnsi s ])
+
+    override _.Encoding = Encoding.UTF8
+
+    override _.Write(value: string | null) = post (match value with null -> "" | s -> s)
+    override this.Write(value: char) = post (string value)
+    override this.Write(buffer: char[] | null) =
+        match buffer with
+        | null -> ()
+        | b    -> post (String b)
+    override this.Write(buffer: char[] | null, index: int, count: int) =
+        match buffer with
+        | null -> ()
+        | b    -> post (String(b, index, count))
+
+    override this.WriteLine() = post "\n"
+    override this.WriteLine(value: string | null) =
+        match value with
+        | null -> post "\n"
+        | s    -> post (s + "\n")
+    override this.WriteLine(value: char) = post (string value + "\n")
+
+    /// Flush is a no-op: the actor processes its queue independently.
+    /// Callers that need a hard barrier should post `ExecuteAndAck` directly.
+    override _.Flush() = ()
+
+    /// Don't dispose the underlying writer — that's owned elsewhere
+    /// (Console's original stdout) and we never created it.
+    override _.Dispose(disposing: bool) =
+        base.Dispose(disposing)

--- a/src/Fugue.Surface/Domain.fs
+++ b/src/Fugue.Surface/Domain.fs
@@ -41,6 +41,11 @@ type DrawOp =
     | Append      of text: string
     /// Reset scroll region to full screen — call on shutdown.
     | ResetScrollRegion
+    /// Verbatim ANSI escape string. Escape hatch for callers (ReadLine,
+    /// Picker) that build complex compound sequences with cursor-relative
+    /// motion that doesn't fit the structured ops above. The actor writes
+    /// it as-is — coalesce does NOT touch RawAnsi (no region key).
+    | RawAnsi     of text: string
 
 module Style =
     let normal : Style = { Bold = false; Italic = false; Color = Color.Default }

--- a/src/Fugue.Surface/Fugue.Surface.fsproj
+++ b/src/Fugue.Surface/Fugue.Surface.fsproj
@@ -8,5 +8,6 @@
     <Compile Include="Builder.fs" />
     <Compile Include="MockExecutor.fs" />
     <Compile Include="RealExecutor.fs" />
+    <Compile Include="ActorWriter.fs" />
   </ItemGroup>
 </Project>

--- a/src/Fugue.Surface/MockExecutor.fs
+++ b/src/Fugue.Surface/MockExecutor.fs
@@ -115,6 +115,11 @@ module MockExecutor =
             // No-op for mock — no real scroll region to reset.
             ()
 
+        | DrawOp.RawAnsi _ ->
+            // Mock cannot interpret arbitrary ANSI; recording in WriteLog (above)
+            // is enough for tests that only assert "the actor processed it".
+            ()
+
     /// Apply a list of DrawOps to the mock terminal.
     /// Mutates term.Lines, term.CursorRow/Col, term.WriteLog in place.
     /// Returns the same terminal for convenient chaining.

--- a/src/Fugue.Surface/RealExecutor.fs
+++ b/src/Fugue.Surface/RealExecutor.fs
@@ -25,9 +25,20 @@ module RealExecutor =
     // ANSI helpers
     // -----------------------------------------------------------------------
 
+    /// Original Console.Out captured at module load. Used by `write` so the
+    /// actor's own output bypasses any `ActorWriter` redirect that gets
+    /// installed later (which would otherwise post the actor's writes back
+    /// to itself, growing the mailbox without bound).
+    ///
+    /// This value is captured the FIRST time the module is touched. Program.fs
+    /// must call `RealExecutor.start ()` BEFORE redirecting Console.Out, which
+    /// is the natural order anyway (you need the actor before you can build
+    /// an ActorWriter that wraps it).
+    let private originalStdout : System.IO.TextWriter = Console.Out
+
     let private write (s: string) =
-        Console.Out.Write s
-        Console.Out.Flush ()
+        originalStdout.Write s
+        originalStdout.Flush ()
 
     let private termWidth  () = Console.WindowWidth
     let private termHeight () = Console.WindowHeight
@@ -150,6 +161,11 @@ module RealExecutor =
                 let w = termWidth  ()
                 // Reset scroll region to full screen, move cursor to bottom.
                 write $"\x1b[1;{h}r\x1b[{h};{w}H"
+
+            | DrawOp.RawAnsi text ->
+                // Caller pre-built a compound ANSI sequence (typically ReadLine
+                // redrawing the prompt + buffer + cursor). Write as-is.
+                write text
         for op in ops do applyOne op
 
     // -----------------------------------------------------------------------
@@ -184,15 +200,22 @@ module RealExecutor =
                     // Now drain any additional pending Execute batches and coalesce.
                     let pending = drainExecute inbox
                     let all     = coalesce (ops :: pending)
-                    applyOps all
+                    // try/catch: a Console.Out write throwing (e.g. terminal
+                    // detached, IO closed) MUST NOT kill the actor — that would
+                    // cause subsequent ExecuteAndAck / Shutdown to hang their
+                    // PostAndAsyncReply callers, manifesting as the user
+                    // having to SIGINT-kill fugue (#918).
+                    try applyOps all with _ -> ()
                     return! loop ()
 
                 | SurfaceMessage.ExecuteHighPriority ops ->
-                    applyOps ops
+                    try applyOps ops with _ -> ()
                     return! loop ()
 
                 | SurfaceMessage.ExecuteAndAck(ops, reply) ->
-                    applyOps ops
+                    try applyOps ops with _ -> ()
+                    // ALWAYS reply — even on exception. Caller is blocked on
+                    // PostAndAsyncReply; never not-replying is not an option.
                     reply.Reply ()
                     return! loop ()
 
@@ -204,7 +227,8 @@ module RealExecutor =
                     return! loop ()
 
                 | SurfaceMessage.Shutdown reply ->
-                    applyOps [ DrawOp.ResetScrollRegion ]
+                    try applyOps [ DrawOp.ResetScrollRegion ] with _ -> ()
+                    // ALWAYS reply — see comment on ExecuteAndAck above.
                     reply.Reply ()
                     // Loop exits — agent terminates.
             }

--- a/tests/Fugue.Tests/ActorWriterTests.fs
+++ b/tests/Fugue.Tests/ActorWriterTests.fs
@@ -1,0 +1,119 @@
+module Fugue.Tests.ActorWriterTests
+
+/// Phase 1.3c — verify ActorWriter funnels Console writes through the actor.
+///
+/// Architectural property under test:
+///   Once `Console.SetOut(new ActorWriter(actor))` is called, EVERY downstream
+///   write (Spectre, Markdig, Console.WriteLine, raw Console.Write of byte
+///   sequences) lands in the actor's WriteLog as a `RawAnsi` op — no path
+///   bypasses the actor, no path overrides the redirect.
+///
+/// We exercise the writer directly (not via Console.SetOut, which would clobber
+/// the test runner's stdout) by calling its Write methods. The contract proven
+/// is the same: each Write() call → one Execute message with one RawAnsi op.
+
+open System
+open Xunit
+open FsUnit.Xunit
+open Fugue.Surface
+
+let private startMockActor () : MailboxProcessor<SurfaceMessage> * MockTerminal =
+    let term = MockExecutor.create 120 30
+    let actor =
+        MailboxProcessor.Start(fun inbox ->
+            let rec loop () = async {
+                let! msg = inbox.Receive()
+                match msg with
+                | SurfaceMessage.Execute ops ->
+                    MockExecutor.execute ops term |> ignore
+                    return! loop ()
+                | SurfaceMessage.ExecuteHighPriority ops ->
+                    MockExecutor.execute ops term |> ignore
+                    return! loop ()
+                | SurfaceMessage.ExecuteAndAck(ops, reply) ->
+                    MockExecutor.execute ops term |> ignore
+                    reply.Reply()
+                    return! loop ()
+                | SurfaceMessage.Resize _ -> return! loop ()
+                | SurfaceMessage.Shutdown reply -> reply.Reply()
+            }
+            loop ())
+    (actor, term)
+
+/// Block until the actor has processed everything queued so far.
+let private drain (actor: MailboxProcessor<SurfaceMessage>) =
+    actor.PostAndAsyncReply(fun ch -> SurfaceMessage.ExecuteAndAck([], ch))
+    |> Async.RunSynchronously
+
+let private rawAnsiCount (term: MockTerminal) : int =
+    term.WriteLog
+    |> List.filter (fun op -> match op with DrawOp.RawAnsi _ -> true | _ -> false)
+    |> List.length
+
+let private rawAnsiTexts (term: MockTerminal) : string list =
+    term.WriteLog
+    |> List.choose (fun op -> match op with DrawOp.RawAnsi t -> Some t | _ -> None)
+
+[<Fact>]
+let ``Write(string) posts one Execute with RawAnsi to the actor`` () =
+    let (actor, term) = startMockActor ()
+    use writer = new ActorWriter(actor)
+    writer.Write("hello")
+    drain actor
+    rawAnsiTexts term |> should equal ["hello"]
+    actor.PostAndAsyncReply(fun ch -> SurfaceMessage.Shutdown ch)
+    |> Async.RunSynchronously
+
+[<Fact>]
+let ``WriteLine appends newline`` () =
+    let (actor, term) = startMockActor ()
+    use writer = new ActorWriter(actor)
+    writer.WriteLine("hello")
+    drain actor
+    rawAnsiTexts term |> should equal ["hello\n"]
+    actor.PostAndAsyncReply(fun ch -> SurfaceMessage.Shutdown ch)
+    |> Async.RunSynchronously
+
+[<Fact>]
+let ``Write(char) posts a single-character RawAnsi`` () =
+    let (actor, term) = startMockActor ()
+    use writer = new ActorWriter(actor)
+    writer.Write('a')
+    writer.Write('b')
+    drain actor
+    rawAnsiTexts term |> should equal ["a"; "b"]
+    actor.PostAndAsyncReply(fun ch -> SurfaceMessage.Shutdown ch)
+    |> Async.RunSynchronously
+
+[<Fact>]
+let ``empty / null writes are dropped silently — no zero-length ops`` () =
+    let (actor, term) = startMockActor ()
+    use writer = new ActorWriter(actor)
+    writer.Write(null : string | null)
+    writer.Write("")
+    drain actor
+    rawAnsiCount term |> should equal 0
+    actor.PostAndAsyncReply(fun ch -> SurfaceMessage.Shutdown ch)
+    |> Async.RunSynchronously
+
+[<Fact>]
+let ``many writes preserve order — no coalescing of RawAnsi`` () =
+    let (actor, term) = startMockActor ()
+    use writer = new ActorWriter(actor)
+    let chunks = [ "alpha"; "beta"; "gamma"; "delta"; "epsilon" ]
+    for c in chunks do writer.Write(c)
+    drain actor
+    rawAnsiTexts term |> should equal chunks
+    actor.PostAndAsyncReply(fun ch -> SurfaceMessage.Shutdown ch)
+    |> Async.RunSynchronously
+
+[<Fact>]
+let ``Write(buffer, index, count) writes the slice`` () =
+    let (actor, term) = startMockActor ()
+    use writer = new ActorWriter(actor)
+    let buf = "abcdef".ToCharArray()
+    writer.Write(buf, 1, 3)  // "bcd"
+    drain actor
+    rawAnsiTexts term |> should equal ["bcd"]
+    actor.PostAndAsyncReply(fun ch -> SurfaceMessage.Shutdown ch)
+    |> Async.RunSynchronously

--- a/tests/Fugue.Tests/Fugue.Tests.fsproj
+++ b/tests/Fugue.Tests/Fugue.Tests.fsproj
@@ -31,6 +31,8 @@
     <Compile Include="StatusBarPropertyTests.fs" />
     <Compile Include="StatusBarActorTests.fs" />
     <Compile Include="StatusBarHeartbeatTests.fs" />
+    <Compile Include="ReadLineActorRoutingTests.fs" />
+    <Compile Include="ActorWriterTests.fs" />
     <Compile Include="ApprovalModeTests.fs" />
     <Compile Include="ApprovalPromptTests.fs" />
     <Compile Include="ReadToolTests.fs" />

--- a/tests/Fugue.Tests/ReadLineActorRoutingTests.fs
+++ b/tests/Fugue.Tests/ReadLineActorRoutingTests.fs
@@ -1,0 +1,122 @@
+module Fugue.Tests.ReadLineActorRoutingTests
+
+/// Phase 1.3b — verify ReadLine writes route through the Surface actor when one
+/// is wired. The race we eliminated: ReadLine and StatusBar both writing to
+/// Console.Out concurrently, producing interleaved escape sequences and cursor
+/// drift (#913, #910 timing half).
+///
+/// We test the routing contract:
+///   1. setAgent + a single keystroke produces at least one Execute message
+///      with a RawAnsi op in the actor's WriteLog.
+///   2. Multiple keystrokes produce multiple Execute messages — they are NOT
+///      coalesced (RawAnsi has no region key, so each one stands).
+///   3. Without setAgent, ReadLine falls back to direct Console.Out (we can't
+///      assert directly without capturing stdout, but the test harness still
+///      produces no exception — fallback path is exercised in headless tests).
+///
+/// We use a mock actor (same shape as StatusBarActorTests) because the real
+/// executor writes ANSI to Console.Out which can't be captured cleanly in
+/// xUnit. The structural assertion is "did the message arrive at the actor?",
+/// not "what did it render to the terminal?".
+
+open System
+open Xunit
+open FsUnit.Xunit
+open Fugue.Surface
+open Fugue.Cli.ReadLine
+
+/// Spin up a mailbox-backed actor over a MockTerminal and return both.
+let private startMockActor () : MailboxProcessor<SurfaceMessage> * MockTerminal =
+    let term = MockExecutor.create 120 30
+    let actor =
+        MailboxProcessor.Start(fun inbox ->
+            let rec loop () = async {
+                let! msg = inbox.Receive()
+                match msg with
+                | SurfaceMessage.Execute ops ->
+                    MockExecutor.execute ops term |> ignore
+                    return! loop ()
+                | SurfaceMessage.ExecuteHighPriority ops ->
+                    MockExecutor.execute ops term |> ignore
+                    return! loop ()
+                | SurfaceMessage.ExecuteAndAck(ops, reply) ->
+                    MockExecutor.execute ops term |> ignore
+                    reply.Reply()
+                    return! loop ()
+                | SurfaceMessage.Resize _ ->
+                    return! loop ()
+                | SurfaceMessage.Shutdown reply ->
+                    reply.Reply()
+            }
+            loop ())
+    (actor, term)
+
+/// Drain pending messages by posting an ExecuteAndAck with empty ops.
+/// Returns once the actor has processed everything queued before this call.
+let private drain (actor: MailboxProcessor<SurfaceMessage>) : unit =
+    actor.PostAndAsyncReply(fun ch -> SurfaceMessage.ExecuteAndAck([], ch))
+    |> Async.RunSynchronously
+
+let private mkState (text: string) (cursor: int) : S =
+    { Buffer          = ResizeArray<char>(text.ToCharArray())
+      Cursor          = cursor
+      LinesRendered   = 0
+      ExitArmed       = false
+      RowsBelowCursor = 0
+      HistoryIdx      = -1
+      SavedBuffer     = None
+      PromptText      = "> "
+      PromptVisLen    = 2
+      HintWhenArmed   = ""
+      Placeholder     = ""
+      ColorEnabled    = false
+      Width           = 80
+      SlashHelp       = []
+      ModelCompleter  = fun _ -> ([], false) }
+
+[<Fact>]
+let ``setAgent + redraw routes RawAnsi ops through the actor`` () =
+    let (actor, term) = startMockActor ()
+    setAgent actor
+    try
+        let s = mkState "hello" 5
+        // redraw is the prompt-rendering path that emits multiple writeRaw calls
+        redraw s
+        drain actor
+        // After redraw, the actor's WriteLog should contain at least one
+        // RawAnsi op — that's the proof writes were serialised through
+        // the mailbox rather than going straight to Console.Out.
+        let rawCount =
+            term.WriteLog
+            |> List.filter (fun op -> match op with DrawOp.RawAnsi _ -> true | _ -> false)
+            |> List.length
+        rawCount |> should be (greaterThan 0)
+    finally
+        // Don't leave the mutable agent set across tests.
+        actor.PostAndAsyncReply(fun ch -> SurfaceMessage.Shutdown ch)
+        |> Async.RunSynchronously
+
+[<Fact>]
+let ``RawAnsi ops are not coalesced — multiple writes all reach the actor`` () =
+    let (actor, term) = startMockActor ()
+    setAgent actor
+    try
+        let s = mkState "" 0
+        // Three back-to-back redraws on the same state — coalesce SHOULD NOT
+        // collapse them, because RawAnsi has no region key. Every keystroke's
+        // worth of writes must land.
+        redraw s
+        redraw s
+        redraw s
+        drain actor
+        let rawCount =
+            term.WriteLog
+            |> List.filter (fun op -> match op with DrawOp.RawAnsi _ -> true | _ -> false)
+            |> List.length
+        // Each redraw emits multiple RawAnsi ops; 3 redraws should produce
+        // strictly more ops than a single redraw would. We assert >= 3 as a
+        // weak lower bound that is robust to redraw's internal op count.
+        rawCount |> should be (greaterThanOrEqualTo 3)
+    finally
+        actor.PostAndAsyncReply(fun ch -> SurfaceMessage.Shutdown ch)
+        |> Async.RunSynchronously

--- a/tests/Fugue.Tests/StatusBarPropertyTests.fs
+++ b/tests/Fugue.Tests/StatusBarPropertyTests.fs
@@ -120,7 +120,8 @@ module StatusBarProperties =
                 | DrawOp.MoveTo(r, _)     -> ("moveto", r, "")
                 | DrawOp.Append t         -> ("append", Region.ScrollContent, t)
                 | DrawOp.SaveAndRestore _ -> ("sar", Region.ScrollContent, "")
-                | DrawOp.ResetScrollRegion -> ("reset", Region.ScrollContent, ""))
+                | DrawOp.ResetScrollRegion -> ("reset", Region.ScrollContent, "")
+                | DrawOp.RawAnsi t        -> ("rawansi", Region.ScrollContent, t))
         structureOf (renderStatusBar state) = structureOf (renderStatusBar state)
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Что

Завершает Phase 1.3 — все писатели через Surface actor. До этого PR'а:

- StatusBar, Picker, ReadLine → через actor (Phase 1.2c, 1.3b)
- **Streaming tokens, Markdown, ApprovalPrompt, slash-команды, third-party libs → direct в Console.Out**

Из-за этого actor конкурировал с прямыми writers за порядок ANSI-байтов → curseur drift, флэш на вводе при heartbeat, потеря streaming-токенов когда я попробовал `SaveAndRestore`.

## Решение

`Console.SetOut(new ActorWriter(actor))` в самом начале сессии. ActorWriter — `TextWriter` подкласс который каждый `Write*` отправляет как `SurfaceMessage.Execute [DrawOp.RawAnsi s]` в actor. Все downstream writers (Spectre, Markdig, `printfn`, raw `Console.WriteLine`) — без изменений в callsites — автоматически попадают в ту же mailbox-очередь.

Actor — теперь **единственный** writer в реальный stdout.

## Архитектура после Phase 1.3

| Writer | Путь |
|---|---|
| StatusBar (heartbeat / spinner) | setAgent → структурированные DrawOps (coalesce работает) |
| Picker (modal) | setAgent → структурированные DrawOps |
| ReadLine (prompt, cursor) | setAgent → RawAnsi |
| **Streaming tokens (agent)** | Console.Out → ActorWriter → RawAnsi |
| **Markdown render** | Console.Out → ActorWriter → RawAnsi |
| **Tool output / slash commands** | Console.Out → ActorWriter → RawAnsi |
| **ApprovalPrompt y/N** | Console.Out → ActorWriter → RawAnsi |
| **`exiting…` message** | Console.Out → ActorWriter → RawAnsi |
| **Any 3rd-party Console.Write** | Console.Out → ActorWriter → RawAnsi |

`Actor → real stdout` через захваченный `originalStdout` (escape hatch — не петляет через Console.Out).

## Антипетля

`RealExecutor` сохраняет `Console.Out` в module-level `let private originalStdout = Console.Out`. F# evaluates это **в момент module load** — первое обращение от Program.fs (`RealExecutor.start ()`). Только потом происходит `Console.SetOut(ActorWriter)`. Так что:

- `originalStdout` указывает на **реальный** stdout (захвачен ДО SetOut)
- `Console.Out` теперь = ActorWriter (для всех остальных)
- Actor пишет через `originalStdout` → байты в TTY, не петляют обратно

## Поломал бы Spectre

Spectre.AnsiConsole **lazy-инициализирует** свой `IAnsiConsole` при первом доступе. Если SetOut происходит ПОСЛЕ первой `AnsiConsole.MarkupLine`, Spectre уже закэшировал real stdout и обходит actor.

Поэтому surfaceActor allocation перенесён в самое начало `runWithCfg`, ДО `Render.initColor` / `MarkdownRender.init` / любых AnsiConsole-touching путей.

## Что упрощено

В `StatusBar.refresh()` был conditional save/restore (wrap только в idle, чтобы не race'илась со streaming). После 1.3c — wrap всегда. Streaming идёт через тот же actor, никаких параллельных writers, race невозможен.

```fsharp
// До:
let messageOps =
    match streamingSince with
    | Some _ -> ops                          // streaming: don't wrap
    | None   -> [ DrawOp.SaveAndRestore ops ]  // idle: wrap

// После:
agent.Post(SurfaceMessage.Execute [ DrawOp.SaveAndRestore ops ])
```

## Тесты: 540 → 546 (+6)

`ActorWriterTests.fs`:
- Write(string) → один RawAnsi op в WriteLog
- WriteLine appends `\n`
- Write(char) → single-char RawAnsi
- Empty / null → silently dropped
- Multiple writes preserve order — RawAnsi не coalesces
- Write(buffer, index, count) — slice writing

Plus прежние 540 — все зелёные. AOT publish чистый, 0 IL warnings. Binary 48MB osx-arm64.

## Ручная TTY-валидация

```bash
git checkout phase-1.3b-readline-actor && git pull --force
just run     # JIT, ~10s до интерактивного REPL
```

Что проверить (главные сценарии):

1. **Idle 30с** — heartbeat обновляет status bar, prompt/курсор НЕ съезжают
2. **Длинный prompt → стрим** — токены льются, ничего не теряется (был баг в моём предыдущем save/restore варианте — теперь должно работать)
3. **`Shift+Tab`** — mode pill циклится без артефактов
4. **`/help`, `/tools`** — markdown рендерится корректно
5. **`/exit` / Ctrl+C ×2** — `выхожу…` появляется, чистый exit без `Interrupted by SIGINT`

Closes #913 (heartbeat overlap on input).
Closes #910 timing half (cursor drift on heartbeat).
Phase 1.3 done.
