### PR TITLE
fix(cli): snapshot Console.IsOutputRedirected before Phase 1.3c SetOut

### DIFF
--- a/src/Fugue.Cli/Program.fs
+++ b/src/Fugue.Cli/Program.fs
@@ -7,11 +7,18 @@ open Fugue.Core.Config
 open Fugue.Agent
 open Fugue.Surface
 
+/// Snapshot of `Console.IsOutputRedirected` taken at module load, before
+/// Phase 1.3c installs `Console.SetOut(ActorWriter)`. After that SetOut runs,
+/// the runtime always reports stdout as redirected (we redirected it!), which
+/// would force `noColor () = true` and disable the entire TUI. Capturing here
+/// preserves the real terminal-vs-pipe answer.
+let private originalIsOutputRedirected : bool = Console.IsOutputRedirected
+
 let private noColor () =
     let isSet name = Environment.GetEnvironmentVariable name |> isNull |> not
     isSet "NO_COLOR" || isSet "FUGUE_NO_COLOR"
     || Environment.GetEnvironmentVariable "TERM" = "dumb"
-    || Console.IsOutputRedirected
+    || originalIsOutputRedirected
     || Console.IsInputRedirected
 
 [<System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Calls ToolRegistry.buildAll which uses AgentSessionExtensions over STJ state")>]


### PR DESCRIPTION
## Что и зачем

Critical hotfix к Phase 1.3c (#916). После мерджа `just run` показывал пустой экран и выходил без UI.

## Root cause

`Console.SetOut(ActorWriter)` в Phase 1.3c делает `Console.IsOutputRedirected = true`. Это используется в `noColor ()`:

```fsharp
let private noColor () =
    ... 
    || Console.IsOutputRedirected   // ← всегда true после нашего SetOut
    ...
```

→ `colorEnabled = false`
→ `StatusBar.start ()` early-returns на `not (Render.isColorEnabled ())`
→ Status bar не рисуется
→ Repl видит "не TTY" → ничего не печатает

## Fix

Захватить `IsOutputRedirected` ДО SetOut'а. Снимок в module-level let:

```fsharp
// Snapshot taken at module load, before Phase 1.3c installs SetOut.
let private originalIsOutputRedirected : bool = Console.IsOutputRedirected

let private noColor () =
    ...
    || originalIsOutputRedirected   // правильный ответ — TTY или pipe реально
    ...
```

Тот же паттерн что `RealExecutor.originalStdout` — изолируем себя от побочных эффектов своего же SetOut.

## Тесты

546/546 (без изменений). AOT clean.

## Ручная валидация

```bash
git checkout fix/preserve-isoutputredirected-snapshot
just run
```

Должен открыться нормальный TUI с prompt.
