### PR TITLE
fix(cli): /model set persistence + no-content warning + atomic stream-finalise batch

### DIFF
--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -715,10 +715,15 @@ let run (initialAgent: AIAgent) (sessionRef: (AgentSession | null) ref) (initial
                   OnAnnotateUp        = fun () -> doAnnotate Fugue.Core.Annotation.Up
                   OnAnnotateDown      = fun () -> doAnnotate Fugue.Core.Annotation.Down
                   OnCycleApprovalMode =
+                    // Status bar already shows the mode icon + risk colour
+                    // (◆ plan / ● default / ◑ auto-edit / ○ yolo).  An inline
+                    // toast collides with the active ReadLine prompt area
+                    // (its newline isn't accounted for by st.LinesRendered,
+                    // so the next redraw erases the wrong rows — visible
+                    // as a stack of accumulated "→ approval mode:" lines).
                     fun () ->
-                        let m = StatusBar.cycleApprovalMode ()
-                        StatusBar.refresh ()
-                        Surface.markupLine($"[dim]→ approval mode: {Fugue.Core.ApprovalMode.label m}[/]") }
+                        StatusBar.cycleApprovalMode () |> ignore
+                        StatusBar.refresh () }
             // Drain file-watch triggers from background FileSystemWatcher
             let watchTriggers = FileWatcher.drain ()
             for wcmd in watchTriggers do

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -1665,8 +1665,14 @@ let run (initialAgent: AIAgent) (sessionRef: (AgentSession | null) ref) (initial
                         let! freshSession = agent.CreateSessionAsync(CancellationToken.None)
                         session <- freshSession
                         sessionRef.Value <- session
+                        // Persist the model change to ~/.fugue/config.json so it
+                        // survives a session restart. Best-effort: I/O failures
+                        // shouldn't bring down the active session — the in-memory
+                        // change is already applied above. Same shape as the /short
+                        // and /long handlers (#922).
+                        try Fugue.Core.Config.saveToFile cfg with _ -> ()
                         let prov, _ = providerInfo cfg.Provider
-                        Surface.markupLine($"[green]✓[/] model → [cyan]{Markup.Escape prov}[/] / [green]{Markup.Escape newModel}[/] [dim](history reset)[/]")
+                        Surface.markupLine($"[green]✓[/] model → [cyan]{Markup.Escape prov}[/] / [green]{Markup.Escape newModel}[/] [dim](saved · history reset)[/]")
                         StatusBar.setCfg cfg
                         // Re-fetch model list for the (potentially) new provider in background.
                         // On empty result (HTTP failure proxy), keep the previous list and

--- a/src/Fugue.Cli/Repl.fs
+++ b/src/Fugue.Cli/Repl.fs
@@ -501,6 +501,16 @@ let private streamAndRender
                 if errorToolCalls.Count > 0 then
                     lastFailedTurn <- Some { BugReport.UserPrompt = input; BugReport.ToolCalls = errorToolCalls |> Seq.toList; BugReport.AiResponse = responseText.ToString(); BugReport.ErrorText = None }
                 lastResponseWasPlan <- Fugue.Core.ConversationIntent.looksLikePlan (responseText.ToString())
+            elif toolCallsThisTurn = 0 then
+                // The agent finished with no TextContent and no tool calls — the
+                // model produced nothing renderable.  Common cause (#923): the
+                // OpenAI-compat adapter for the active model returns only
+                // UsageContent, no TextContent (observed with LM Studio + Gemma).
+                // Without this hint the user sees their prompt echoed and silence,
+                // and assumes Fugue hung.
+                Surface.lineBreak ()
+                Surface.markupLine "[yellow]⚠ model returned no content[/] [dim](only usage / tool-call stats — check provider + model loading; try /model set <other>)[/]"
+                Surface.lineBreak ()
         with
         | :? OperationCanceledException ->
             if assistantStreaming then Surface.lineBreak ()

--- a/src/Fugue.Cli/StreamRender.fs
+++ b/src/Fugue.Cli/StreamRender.fs
@@ -3,6 +3,7 @@ module Fugue.Cli.StreamRender
 open System
 open System.Threading.Tasks
 open Spectre.Console.Rendering
+open Fugue.Surface
 
 // Layer 3 (domain UI): terminal-rendering concerns for assistant streaming
 // turns are localised here, isolated from Repl business logic. When a
@@ -39,33 +40,54 @@ let private occupiedRows (text: string) (termW: int) : int =
 ///   write them with a 12ms async delay between rows.  Otherwise render
 ///   in one shot.
 ///
-/// Sequence (the +1 in the move-up accounts for the line break we just
-/// emitted; without it the rewind lands inside the streamed text and the
-/// re-render concatenates onto the existing line — the duplicated-text
-/// bug we hit before this module existed):
+/// Sequence sent as ONE atomic actor batch (so a spinner SaveAndRestore can't
+/// interleave between cursor ops and split the rewind from the clear):
 ///   LineBreak → MoveCursorUpToCol0 (rawLines + 1) → ClearToEndOfScreen
 ///   → write final → LineBreak
+///
+/// The +1 in the move-up accounts for the line break we just emitted;
+/// without it the rewind lands inside the streamed text and the re-render
+/// concatenates onto the existing line (visible duplication).
 let finalizeTurn
     (rawText: string)
     (final: IRenderable option)
     (typewriter: bool)
     : Task<unit>
     = task {
-        Surface.lineBreak ()
         match final with
-        | None -> ()
-        | Some r ->
+        | None ->
+            // No-color path / no markdown — just close the streamed text with
+            // a line break so the next prompt starts on a clean row.
+            Surface.lineBreak ()
+        | Some r when typewriter ->
+            // Typewriter is inherently sequential (12ms async per row), so
+            // batching it doesn't help — fall back to per-op posts.
+            Surface.lineBreak ()
             let termW = max 20 Console.WindowWidth
             let rawLines = occupiedRows rawText termW
             if rawLines > 0 then
-                Surface.rewindLines (rawLines + 1)
-                Surface.clearBelow ()
-            if typewriter then
-                let lines = Render.captureLines r
-                for line in lines do
-                    Surface.writeLine line
-                    do! Task.Delay 12
-            else
-                Surface.writeRenderable r
-                Surface.lineBreak ()
+                Surface.batch [
+                    DrawOp.MoveCursorUpToCol0 (rawLines + 1)
+                    DrawOp.ClearToEndOfScreen
+                ]
+            for line in Render.captureLines r do
+                Surface.writeLine line
+                do! Task.Delay 12
+        | Some r ->
+            // One atomic batch: linebreak (advance past stream), rewind to
+            // start of stream, clear from there, render markdown, trailing
+            // linebreak.  Spectre.IRenderable rendering happens via the
+            // Surface.spectre helper which posts its own RawAnsi — that's
+            // a SECOND post, but by then the cursor is already at the right
+            // start position so a spinner restoring there is harmless.
+            let termW = max 20 Console.WindowWidth
+            let rawLines = occupiedRows rawText termW
+            Surface.batch [
+                DrawOp.LineBreak
+                if rawLines > 0 then
+                    DrawOp.MoveCursorUpToCol0 (rawLines + 1)
+                    DrawOp.ClearToEndOfScreen
+            ]
+            Surface.writeRenderable r
+            Surface.lineBreak ()
     }

--- a/src/Fugue.Cli/Surface.fs
+++ b/src/Fugue.Cli/Surface.fs
@@ -102,3 +102,25 @@ let flush () : unit =
         |> Async.RunSynchronously
     | None ->
         Console.Out.Flush ()
+
+/// Post a list of DrawOps as a single Execute message — the entire batch is
+/// applied atomically by the executor with no other op interleaved.
+/// Use this when a sequence of cursor moves must NOT be split by a spinner /
+/// status-bar SaveAndRestore that could land between individual posts (e.g.
+/// the streaming-finalise rewind + clear + re-render dance).
+let batch (ops: DrawOp list) : unit =
+    if List.isEmpty ops then () else
+    match agent with
+    | Some a -> a.Post(SurfaceMessage.Execute ops)
+    | None ->
+        // Fallback for headless: render each op directly.  Order matches actor.
+        for op in ops do
+            match op with
+            | DrawOp.RawAnsi s             -> Console.Out.Write s
+            | DrawOp.LineBreak             -> Console.Out.Write "\r\n"
+            | DrawOp.MoveCursorUp n        -> if n > 0 then Console.Out.Write $"\x1b[{n}A"
+            | DrawOp.MoveCursorUpToCol0 n  ->
+                if n > 0 then Console.Out.Write $"\r\x1b[{n}A" else Console.Out.Write "\r"
+            | DrawOp.ClearToEndOfScreen    -> Console.Out.Write "\x1b[J"
+            | _                            -> ()  // structured paint ops irrelevant in fallback
+        Console.Out.Flush ()


### PR DESCRIPTION
Three small fixes shipping together — all post-#921 follow-ups discovered in user testing.

## #922 — /model set persists to config.json

\`/model set <name>\` now best-effort writes to \`~/.fugue/config.json\` so the change survives session restart.  Same shape as \`/short\`/\`/long\` (Repl.fs:2028, 2037).  I/O wrapped in try/with so a write failure doesn't crash the active session — the in-memory change is already applied.

## #923 — warn when model returns no content

Diagnosed from \`~/.fugue/log.txt\`: with LM Studio + google/gemma-3n-e4b, Microsoft.Extensions.AI's OpenAI-compat adapter emits only \`UsageContent\` — no \`TextContent\` at all.  Conversation.fs (correctly) yields no \`TextChunk\`, so \`assistantStreaming\` stays false, finalise block is skipped, user sees prompt echoed and silence.

Fix: when streaming finishes with **no text AND no tool calls**, surface an inline warning so the silence is attributable to the model, not Fugue:

\`\`\`
⚠ model returned no content (only usage / tool-call stats — check provider + model loading; try /model set <other>)
\`\`\`

A tool-only turn stays silent (legitimate).

Root cause is upstream (MEAI ↔ LM Studio response shape).  This PR makes it observable.

## stream-finalise atomicity

After splitting the rewind-and-clear sequence into typed DrawOps in PR #921, each op became a separate Execute post.  A spinner SaveAndRestore (every 300ms during streaming) could land BETWEEN \`MoveCursorUpToCol0\` and \`ClearToEndOfScreen\`.  Spinner's \`\\x1b[s\` overwrites the implicit cursor state our clear depends on, so the clear ran from the wrong row → markdown re-render landed one row below the streamed text → visible duplication.

\`Surface.batch ops\`: posts a DrawOp list as ONE Execute message.  StreamRender.finalizeTurn now packs \`LineBreak + MoveCursorUpToCol0 + ClearToEndOfScreen\` into a single atomic batch.  Spectre IRenderable still posts its own RawAnsi after the batch — by that point cursor is at the rewind target, spinner restoring there is a no-op.

Typewriter mode keeps per-line writes (12ms async between rows — batching defeats the typewriter effect).

## Test plan

- [x] \`dotnet build\` — 0 warnings, 0 errors
- [x] \`dotnet test\` — 540/540
- [x] User-verified: gemma streaming works after fix
- [x] User-verified: /model set persistence (status bar shows new model)
- [ ] Manual: confirm no duplication on long streamed responses (>2 rows)

Closes #922, #923.