### PR TITLE
docs: lock AOT/JIT split — headless AOT, REPL JIT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,13 @@
 # Fugue
 
-> A small, fast, F#-on-.NET-AOT terminal coding agent.
-> Cold-starts in ~40ms. Single 47MB native binary. Provider-agnostic (Anthropic / OpenAI-compat / Ollama).
-> Inspired by Claude Code's workflow but built for engineers who don't want a 300MB Node tree.
+> A small, fast F# terminal coding agent. **Two binaries, two runtimes:**
+> `fugue-headless` (Native AOT, ~40ms cold start) for CI / pipes / `--print`.
+> `fugue` (JIT + ReadyToRun) for interactive REPL — long-lived, JIT warms once.
+> Provider-agnostic (Anthropic / OpenAI-compat / Ollama).
 
 **Repo:** `korat-ai/fugue` · **Status:** MVP shipped (Phase 1–5 closed, 2026-04-30) · **Default branch:** `main`
+
+**🪡 AOT/JIT split locked 2026-05-02** — see [§ AOT vs JIT](#aot-vs-jit--two-binaries) below.  Trim/AOT discipline applies ONLY to `Fugue.Cli.Headless` and its closure. REPL code (`Fugue.Cli`, `Fugue.Surface`) is JIT-only — write idiomatic F# without trim ceremony.
 
 ---
 
@@ -16,20 +19,46 @@ Polyglot backend / systems engineers on **macOS-arm64 and Linux-x64** working in
 
 ```
 src/
-  Fugue.Core/    — domain types, config, localization, system prompt, JSON DTOs (no UI, no network)
-  Fugue.Agent/   — Microsoft.Agents.AI factory + Conversation streaming + provider Discovery
-  Fugue.Tools/   — Read / Write / Edit / Bash / Glob / Grep as no-reflection AIFunction subclasses
-  Fugue.Cli/     — REPL: ReadLine (own ANSI), MarkdownRender (Markdig), DiffRender, Render, StatusBar (scroll-region), Repl, Program
+  Fugue.Core/         — domain types, config, localization, system prompt, JSON DTOs    [AOT-clean]
+  Fugue.Agent/        — Microsoft.Agents.AI factory + streaming + provider Discovery     [AOT-clean]
+  Fugue.Tools/        — Read / Write / Edit / Bash / Glob / Grep, no-reflection          [AOT-clean]
+  Fugue.Cli.Headless/ — entry point for --print / pipe-input mode                        [AOT-only, single-file]
+  Fugue.Surface/      — typed DrawOps + MailboxProcessor surface, MockExecutor           [JIT-only]
+  Fugue.Cli/          — REPL: ReadLine, MarkdownRender, DiffRender, StatusBar, Repl      [JIT-only, ReadyToRun]
 tests/
-  Fugue.Tests/   — xUnit + FsUnit, 120+ unit tests
+  Fugue.Tests/        — xUnit + FsUnit, 540+ unit tests
 docs/
   process.md, role-capabilities.md, workflows/  — orchestrator skill operational manual
   superpowers/specs/, superpowers/plans/        — design docs, implementation plans
 ```
 
-**Stack:** F# 9 · .NET 10 · Spectre.Console 0.49 · Markdig 0.41 · `Microsoft.Agents.AI` 1.3 · xUnit + FsUnit · Native AOT (single-file, trimmed).
+**Stack:** F# 9 · .NET 10 · Spectre.Console 0.49 · Markdig 0.41 · `Microsoft.Agents.AI` 1.3 · `System.CommandLine` (parser; F# DSL wrapper) · xUnit + FsUnit.
 
 **Authoritative spec:** `docs/superpowers/specs/2026-04-29-fugue-spectre-aot-pivot.md`.
+
+## AOT vs JIT — two binaries
+
+Fugue ships as **two distributions** with different runtime tradeoffs. Pivot locked 2026-05-02.
+
+| Binary             | Runtime                    | Cold start | Use case                                                       |
+|--------------------|----------------------------|-----------:|----------------------------------------------------------------|
+| `fugue-headless`   | **Native AOT** single-file | ~40 ms     | CI / scripting / pipe-input / `--print` / `-p` flag            |
+| `fugue`            | **JIT + ReadyToRun**       | ~150 ms    | Interactive REPL / TUI sessions (long-lived, JIT warms once)   |
+
+**Headless trigger** (decided in one place, `Fugue.Cli.Headless/Program.fs`):
+```fsharp
+let isHeadless (argv: string[]) : bool =
+    argv |> Array.exists (fun a -> a = "--print" || a = "-p")
+    || Console.IsInputRedirected
+```
+
+**Why we split:** keeping all code AOT-clean cost too much — binary 47MB vs 35MB target; constant trim-warning ceremony; `[<DynamicDependency>]` and source-gen workarounds; whole categories of NuGet packages off-limits. Interactive REPL stays alive for hours, so JIT pays its warmup once. Headless runs per-invocation, so its cold start is critical and AOT stays.
+
+**What this means for contributors:**
+- Code in `Fugue.Cli` (REPL) and `Fugue.Surface` (TUI primitives) is **JIT-only**. Write idiomatic F# without trim ceremony — reflection, dynamic loading, full Spectre features all OK.
+- Code in `Fugue.Core`, `Fugue.Tools`, `Fugue.Agent`, `Fugue.Cli.Headless` is **AOT-clean**. Same constraints as before for these modules: no `MakeGenericMethod` outside annotated boundaries, STJ source-gen for new DTOs, etc.
+- New features that don't fit AOT (MCP discovery, plugins, dynamic theme loading) live in `Fugue.Cli` / `Fugue.Surface` and are **interactive-only by design**. If a feature can't pass AOT publish, it doesn't belong in the headless surface — that's a deliberate signal, not a bug.
+- Argument parsing uses `System.CommandLine` (AOT source-gen friendly) wrapped in a thin F# DSL (`Cli.command "print" (fun args -> ...)`). One parser, both binaries.
 
 ## Conventions & red lines
 
@@ -38,15 +67,15 @@ These are **hard rules**. Don't ask, just follow.
 - **F# only under `src/`.** No C# files. C# is allowed only as external NuGet dependencies.
 - **`.slnx`, not `.sln`.** Modern .NET solution format.
 - **No `Co-Authored-By` trailers in commits.**
-- **`TreatWarningsAsErrors=true`** stays. **No `<NoWarn>` for our own code** — fix the underlying issue. `<NoWarn>` is allowed only for known third-party trim/AOT warnings (`IL2026`, `IL3050`, `IL3053`, `IL2104`).
-- **Every PR must produce an AOT-clean publish** (`dotnet publish src/Fugue.Cli -c Release -r osx-arm64`). No regressions in `Build succeeded. 0 Error(s).`
-- **Every 10 commits: run a full AOT publish and smoke-test the native binary locally:**
+- **`TreatWarningsAsErrors=true`** stays in `Fugue.Core`, `Fugue.Tools`, `Fugue.Agent`, `Fugue.Cli.Headless` (the AOT closure). For these, `<NoWarn>` is allowed only for known third-party trim/AOT warnings (`IL2026`, `IL3050`, `IL3053`, `IL2104`). For `Fugue.Cli` / `Fugue.Surface` (JIT-only): `TreatWarningsAsErrors=true` still on, but trim/AOT warnings simply don't appear there.
+- **Every PR must produce an AOT-clean publish of the headless binary** (`dotnet publish src/Fugue.Cli.Headless -c Release -r osx-arm64`). The interactive `Fugue.Cli` only needs `dotnet build` + `dotnet test` to pass — it doesn't get AOT-published.
+- **Every 10 commits: full AOT publish + smoke-test the headless binary locally:**
   ```
-  dotnet publish src/Fugue.Cli -c Release -r osx-arm64
-  src/Fugue.Cli/bin/Release/net10.0/osx-arm64/publish/fugue --version
-  src/Fugue.Cli/bin/Release/net10.0/osx-arm64/publish/fugue --help
+  dotnet publish src/Fugue.Cli.Headless -c Release -r osx-arm64
+  src/Fugue.Cli.Headless/bin/Release/net10.0/osx-arm64/publish/fugue-headless --version
+  src/Fugue.Cli.Headless/bin/Release/net10.0/osx-arm64/publish/fugue-headless --print "hello"
   ```
-  `dotnet build` / `dotnet test` run under JIT and will NOT catch AOT-specific failures (e.g. `MakeGenericMethod`, missing native code). Only the published native binary reveals them.
+  `dotnet build` / `dotnet test` run under JIT and will NOT catch AOT-specific failures in the headless closure (e.g. `MakeGenericMethod`, missing native code). Only the published native binary reveals them.
 - **`git status` stays clean.** No stray files, no half-finished `.bak`/`.tmp`. Tree is always merge-ready.
 - **No tests-on-mocks for things that hit the real boundary.** Tools tests run against `tmp/` directories; config tests isolate `HOME`.
 - **Never squash-merge PRs. Use `--merge` (merge commit) or `--rebase`.** Squash rewrites SHAs, which breaks stacked PRs (downstream branches lose their common history, GitHub auto-closes them when the base branch is deleted). Merge commits preserve original SHAs so downstream PRs see their predecessors as "already applied" and continue cleanly. Default: `gh pr merge <N> --merge --delete-branch`. Past incident: squash-merging Phase 1.2a auto-closed PR #905 and #906 (had to recreate as #907 + #908). Never repeat.
@@ -160,7 +189,7 @@ This project's domain emphasises:
 
 - **`AI`, `LLM`, `Claude`, `GPT`, `Ollama`, `Anthropic`, `OpenAI`** — agent framework integration is the core feature
 - **`CLI`, `TUI`, `terminal`, `ANSI`, `scroll region`** — UX is terminal-first
-- **`AOT`, `trimming`, `IL2026`, `IL3050`, `single-file`** — deployment constraints affect every code change
+- **`AOT`, `trimming`, `IL2026`, `IL3050`, `single-file`** — deployment constraints affect headless-closure code (`Fugue.Core` / `Fugue.Tools` / `Fugue.Agent` / `Fugue.Cli.Headless`); REPL code (`Fugue.Cli` / `Fugue.Surface`) is JIT-only and free of these
 - **`F#`, `dotnet`, `.NET 10`** — language/runtime is fixed; no polyglot mixing
 - **`performance`, `cold start`, `RSS`, `binary size`** — non-functional targets are first-class
 - **`localization`, `i18n`, `en`, `ru`** — project ships in two languages from day one

--- a/README.md
+++ b/README.md
@@ -3,13 +3,49 @@
 > _A fugue in F# for your terminal._
 > _Many voices, one console._
 
-A lean, native-AOT CLI agent. Chat with AI agents (Anthropic / OpenAI / Ollama) in a TUI, with the standard tool set (Read / Write / Edit / Bash / Glob / Grep). Built on F# + Microsoft Agent Framework + Terminal.Gui v2.
+A lean CLI agent. Chat with AI agents (Anthropic / OpenAI / Ollama) in a TUI,
+with the standard tool set (Read / Write / Edit / Bash / Glob / Grep).
+Built on F# + Microsoft Agent Framework + Spectre.Console.
+
+## Two binaries, two runtimes
+
+Fugue ships as **two distributions** with deliberately different tradeoffs:
+
+| Binary             | Runtime           | Cold start | Use case                              |
+|--------------------|-------------------|-----------:|---------------------------------------|
+| `fugue-headless`   | **Native AOT**    | ~40 ms     | CI / scripting / pipes / `--print`    |
+| `fugue`            | **JIT + ReadyToRun** | ~150 ms    | Interactive REPL / TUI                |
+
+**Why split:**
+
+- **Headless** (`fugue --print "prompt"`, or pipe input via `cat file \| fugue …`)
+  needs fast cold start on every invocation. Native AOT, single-file, no JIT
+  warmup. Strict trim-friendly code: no reflection beyond what `System.Text.Json`
+  source-gen and `Microsoft.Agents.AI` already need.
+- **Interactive** runs once and stays alive for hours — JIT warmup is paid
+  exactly once. Freed from AOT/trim constraints, the REPL can use reflection
+  freely (dynamic MCP loading, `JsonSerializer` reflection mode, plugin
+  discovery, full Spectre.Console feature surface).
+
+**What this means for contributors:** the `every PR must AOT-publish-clean`
+rule applies **only to `Fugue.Cli.Headless`** and its transitive closure
+(`Fugue.Core` + `Fugue.Tools` + `Fugue.Agent`). Code in `Fugue.Cli` (REPL)
+and `Fugue.Surface` (TUI primitives) is JIT-only — write idiomatic F#
+without trim ceremony.
+
+The headless trigger lives in one place (`Program.fs`):
+
+```fsharp
+let isHeadless (argv: string[]) : bool =
+    argv |> Array.exists (fun a -> a = "--print" || a = "-p")
+    || Console.IsInputRedirected
+```
 
 ## Status
 
-Pre-alpha — implementation in progress. See `docs/superpowers/specs/2026-04-29-fugue-design.md` and `docs/superpowers/plans/2026-04-29-fugue.md`.
+MVP shipped. AOT/JIT split adopted 2026-05-02 (see [§ Two binaries](#two-binaries-two-runtimes) above).
 
-## Quickstart (planned)
+## Quickstart
 
 ```sh
 brew install fugue                     # not yet
@@ -19,8 +55,16 @@ ANTHROPIC_API_KEY=sk-ant-... fugue
 ## Build from source
 
 ```sh
+# Tests + interactive (JIT, fast iteration)
 dotnet build
 dotnet test
-dotnet publish src/Fugue.Cli -c Release -r osx-arm64 /p:PublishAot=true
+dotnet run --project src/Fugue.Cli
+
+# Headless single-file native binary (Native AOT)
+dotnet publish src/Fugue.Cli.Headless -c Release -r osx-arm64
+./src/Fugue.Cli.Headless/bin/Release/net10.0/osx-arm64/publish/fugue-headless --print "hello"
+
+# Interactive distribution (ReadyToRun, no AOT)
+dotnet publish src/Fugue.Cli -c Release -r osx-arm64
 ./src/Fugue.Cli/bin/Release/net10.0/osx-arm64/publish/fugue
 ```


### PR DESCRIPTION
## Summary

Locks the architectural pivot decided 2026-05-02: Fugue ships as **two binaries with different runtimes**.

| Binary             | Runtime                    | Cold start | Use case                                                     |
|--------------------|----------------------------|-----------:|--------------------------------------------------------------|
| \`fugue-headless\`   | **Native AOT** single-file | ~40 ms     | CI / scripting / pipe-input / \`--print\` / \`-p\` flag            |
| \`fugue\`            | **JIT + ReadyToRun**       | ~150 ms    | Interactive REPL / TUI sessions (long-lived, JIT warms once) |

**Why split:** keeping all code AOT-clean cost too much — binary 47 MB vs 35 MB target, constant trim-warning ceremony, \`[<DynamicDependency>]\` and source-gen workarounds, whole categories of NuGet packages off-limits. Interactive REPL stays alive for hours so JIT pays its warmup exactly once. Headless runs per-invocation so its cold start is critical and AOT stays.

**Headless trigger** (one place, \`Fugue.Cli.Headless/Program.fs\`):

\`\`\`fsharp
let isHeadless (argv: string[]) : bool =
    argv |> Array.exists (fun a -> a = \"--print\" || a = \"-p\")
    || Console.IsInputRedirected
\`\`\`

## What changes

### README.md
- New § *Two binaries, two runtimes* with the decision table, why-split rationale, contributor-facing implications, and the \`isHeadless\` trigger snippet.
- Build-from-source section now shows both publish paths (AOT for headless, JIT/RtR for interactive).
- Removed mention of Terminal.Gui v2 (we run on Spectre.Console).

### CLAUDE.md
- Architecture diagram tags each project \`[AOT-clean]\` or \`[JIT-only]\`. New \`Fugue.Cli.Headless\` listed.
- New top-of-file callout flags the locked decision so future readers can't miss it.
- New § *AOT vs JIT — two binaries* explains the split + contributor implications:
  - \`Fugue.Core\`, \`Fugue.Tools\`, \`Fugue.Agent\`, \`Fugue.Cli.Headless\` — **AOT-clean**, same trim discipline as before.
  - \`Fugue.Cli\` (REPL), \`Fugue.Surface\` (TUI primitives) — **JIT-only**, free of trim/AOT ceremony.
  - New features that don't fit AOT (MCP discovery, plugins, dynamic theme loading) live interactive-only **by design**.
- Hard rule *\"every PR must AOT-publish-clean\"* rescoped: now applies only to \`Fugue.Cli.Headless\` and its transitive closure. The 10-commits smoke-test command updated accordingly.
- Focus signals at the bottom: \`AOT / trimming / IL2026 / IL3050\` no longer flagged as \"affecting every code change\" — only the headless closure.
- Stack line adds \`System.CommandLine\` as the parser (used via a thin F# DSL wrapper).

## Scope

**This PR is docs-only.** No code, no \`.fsproj\` changes, no AOT-publish behavior change. Implementation work follows in subsequent PRs:

1. Add \`System.CommandLine\` + thin F# DSL wrapper.
2. Migrate \`Program.fs\` argv parsing onto the DSL (replaces 33 ad-hoc \`argv |> Array.contains\` lookups).
3. Create \`Fugue.Cli.Headless\` project; move \`--print\` / pipe-input handling there.
4. \`Directory.Build.props\`: dual publish profile (AOT for headless, ReadyToRun for interactive).
5. Lift trim-friendly constraints from \`Fugue.Cli\` / \`Fugue.Surface\`.

## Test plan

- [x] \`git diff origin/main..HEAD -- CLAUDE.md README.md\` confirms only these two files touched
- [x] CLAUDE.md renders correctly (header callout links to \`#aot-vs-jit--two-binaries\`)
- [x] README renders correctly (link to \`#two-binaries-two-runtimes\`)
- [x] No \`docs/superpowers/\` references in README (those are internal pipeline docs, not for end users)
- [ ] Reviewer sanity check on the why-split rationale and headless trigger snippet

🤖 Generated with [Claude Code](https://claude.com/claude-code)