### PR TITLE
feat(core): System.CommandLine + F# DSL — Phase 1 of AOT/JIT split

### DIFF
--- a/src/Fugue.Core/CliArgs.fs
+++ b/src/Fugue.Core/CliArgs.fs
@@ -1,0 +1,209 @@
+module Fugue.Core.CliArgs
+
+// FS3261 (nullness) suppressed for this file only.  Justification: the DSL
+// wraps System.CommandLine 2.0, whose `GetValue<T>` is annotated `T?` to
+// accommodate the abstract case of an unset value.  In our DSL every option
+// and argument has either `withDefault` / `argDefault` or is `required` —
+// both guarantee non-null after a successful parse.  `Unchecked.nonNull`
+// could express the assertion, but its `'T : not null` constraint excludes
+// value-type options (int, bool) which we need to support.  This is a
+// narrowly-scoped suppression on a single bridging surface, NOT a way to
+// silence real bugs — every real call goes through the `withDefault` /
+// `required` invariant maintained by the constructors above.
+#nowarn "3261"
+
+open System
+open System.CommandLine
+open System.Threading
+open System.Threading.Tasks
+
+// Thin F# DSL over System.CommandLine 2.0.  Goals:
+//
+//   * One parser shared by `fugue` (JIT REPL) and `fugue-aot` (AOT headless)
+//   * Type-safe `ctx.Get` — handles carry their phantom `'T` so parse results
+//     never need cast/box on the call site
+//   * Children of a command (options/arguments/subcommands) compose through
+//     a single `CmdChild` list — no `obj`/`Symbol` casts in user code
+//
+// The DSL is an F# wrapper over a fundamentally mutation-based C# library.
+// Inside, we mutate the SC types when applying modifiers (`withDefault`,
+// `required`, …); from the F# side everything looks like value-returning
+// functions — by convention we always return the same handle so chains stay
+// clean.  The mutation is local to construction; ParseResult itself is
+// immutable.
+
+// --------------------------------------------------------------------------
+// Typed handles
+// --------------------------------------------------------------------------
+
+/// Typed handle for a command-line option.
+[<Struct>]
+type Opt<'T> = internal { Inner: Option<'T> }
+
+/// Typed handle for a positional argument.
+[<Struct>]
+type Arg<'T> = internal { Inner: Argument<'T> }
+
+/// A child of a command — option, argument, or subcommand.
+/// Created via `optOf` / `argOf` / `subOf`.
+type CmdChild = internal CmdChild of Symbol
+
+// --------------------------------------------------------------------------
+// Option / Argument constructors
+// --------------------------------------------------------------------------
+
+/// Create an option `--name`.  Description is required for `--help` output.
+let opt<'T> (name: string) (description: string) : Opt<'T> =
+    let o = Option<'T>(name)
+    o.Description <- description
+    { Inner = o }
+
+/// Add an alias (e.g. `-p` for `--print`).
+let alias (a: string) (o: Opt<'T>) : Opt<'T> =
+    o.Inner.Aliases.Add a
+    o
+
+/// Default value used when the flag is omitted.
+let withDefault (v: 'T) (o: Opt<'T>) : Opt<'T> =
+    o.Inner.DefaultValueFactory <- (fun _ -> v)
+    o
+
+/// Mark the option required (parse error if missing).
+let required (o: Opt<'T>) : Opt<'T> =
+    o.Inner.Required <- true
+    o
+
+/// Make the option recursive — visible to all subcommands of the owning command.
+/// (Replaces the pre-2.0 "global option" concept.)
+let recursive (o: Opt<'T>) : Opt<'T> =
+    o.Inner.Recursive <- true
+    o
+
+/// Create a positional argument.
+let arg<'T> (name: string) (description: string) : Arg<'T> =
+    let a = Argument<'T>(name)
+    a.Description <- description
+    { Inner = a }
+
+/// Default for the argument (omitted argv → this value).
+let argDefault (v: 'T) (a: Arg<'T>) : Arg<'T> =
+    a.Inner.DefaultValueFactory <- (fun _ -> v)
+    a
+
+// --------------------------------------------------------------------------
+// CliContext — read parsed values inside a handler
+// --------------------------------------------------------------------------
+
+/// Inside a command handler, read parsed values via `ctx.Get`.
+/// Caller invariant: every option / argument used here must have been built
+/// with `withDefault` / `argDefault` or marked `required` — both guarantee
+/// the value is non-null at this point.
+type CliContext internal (parseResult: ParseResult) =
+    member _.Get (o: Opt<'T>) : 'T = parseResult.GetValue o.Inner
+    member _.Get (a: Arg<'T>) : 'T = parseResult.GetValue a.Inner
+    member _.ParseResult : ParseResult = parseResult
+
+// --------------------------------------------------------------------------
+// Command composition
+// --------------------------------------------------------------------------
+
+/// A composed command (root or subcommand).
+type Cmd = internal { Inner: Command }
+
+let optOf (o: Opt<'T>) : CmdChild = CmdChild (o.Inner :> Symbol)
+let argOf (a: Arg<'T>) : CmdChild = CmdChild (a.Inner :> Symbol)
+let subOf (c: Cmd)     : CmdChild = CmdChild (c.Inner :> Symbol)
+
+let inline private addChildren (target: Command) (children: CmdChild list) : unit =
+    for CmdChild s in children do
+        match s with
+        | :? Option   as o -> target.Options.Add     o
+        | :? Argument as a -> target.Arguments.Add   a
+        | :? Command  as c -> target.Subcommands.Add c
+        | _ ->
+            invalidArg "children"
+                $"Unsupported symbol type for command child: {s.GetType().FullName}"
+
+/// Build a (sub)command with a synchronous handler returning an exit code.
+let command
+    (name: string)
+    (description: string)
+    (children: CmdChild list)
+    (handler: CliContext -> int)
+    : Cmd
+    =
+    let c = Command(name, description)
+    addChildren c children
+    c.SetAction(Func<ParseResult, int>(fun pr -> handler (CliContext pr)))
+    { Inner = c }
+
+/// Build a (sub)command with an async handler returning an exit code.
+/// Use this when the handler awaits I/O — keeps cancellation honest.
+let commandAsync
+    (name: string)
+    (description: string)
+    (children: CmdChild list)
+    (handler: CliContext -> CancellationToken -> Task<int>)
+    : Cmd
+    =
+    let c = Command(name, description)
+    addChildren c children
+    c.SetAction(Func<ParseResult, CancellationToken, Task<int>>(fun pr ct ->
+        handler (CliContext pr) ct))
+    { Inner = c }
+
+/// Build the root command.  `description` becomes the program's help banner.
+let root
+    (description: string)
+    (children: CmdChild list)
+    (handler: CliContext -> int)
+    : Cmd
+    =
+    let c = RootCommand(description)
+    addChildren c children
+    c.SetAction(Func<ParseResult, int>(fun pr -> handler (CliContext pr)))
+    { Inner = c :> Command }
+
+let rootAsync
+    (description: string)
+    (children: CmdChild list)
+    (handler: CliContext -> CancellationToken -> Task<int>)
+    : Cmd
+    =
+    let c = RootCommand(description)
+    addChildren c children
+    c.SetAction(Func<ParseResult, CancellationToken, Task<int>>(fun pr ct ->
+        handler (CliContext pr) ct))
+    { Inner = c :> Command }
+
+// --------------------------------------------------------------------------
+// Parse / Invoke
+// --------------------------------------------------------------------------
+
+/// Parse argv against `root` and invoke the matched handler.
+/// Returns the handler's exit code, or 1 on parse errors (printed to stderr).
+let run (argv: string[]) (root: Cmd) : int =
+    let pr = root.Inner.Parse(argv)
+    if pr.Errors.Count > 0 then
+        for e in pr.Errors do
+            eprintfn "%s" e.Message
+        1
+    else
+        pr.Invoke()
+
+/// Async sibling of `run` — required for commands built with `commandAsync` /
+/// `rootAsync`.  Don't mix sync and async handlers in one command tree.
+let runAsync (argv: string[]) (root: Cmd) : Task<int> = task {
+    let pr = root.Inner.Parse(argv)
+    if pr.Errors.Count > 0 then
+        for e in pr.Errors do
+            eprintfn "%s" e.Message
+        return 1
+    else
+        return! pr.InvokeAsync()
+}
+
+/// Parse-only path — inspect errors yourself and decide what to do.
+/// Useful for callers that want to fall back to a non-CLI flow on parse failure.
+let parse (argv: string[]) (root: Cmd) : ParseResult =
+    root.Inner.Parse(argv)

--- a/src/Fugue.Core/Fugue.Core.fsproj
+++ b/src/Fugue.Core/Fugue.Core.fsproj
@@ -24,9 +24,14 @@
     <Compile Include="Hooks.fs" />
     <Compile Include="ApprovalMode.fs" />
     <Compile Include="ProviderCache.fs" />
+    <Compile Include="CliArgs.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.*" />
+    <!-- AOT/trim-friendly arg parser (no reflection-based binding in 2.0+).
+         Wrapped by Fugue.Core.CliArgs as a thin F# DSL — both fugue (JIT)
+         and fugue-aot (AOT) share the same parser. -->
+    <PackageReference Include="System.CommandLine" Version="2.0.*" />
   </ItemGroup>
   <ItemGroup>
     <!-- Microsoft.Data.Sqlite: P/Invoke interop to native SQLite amalgamation.

--- a/tests/Fugue.Tests/CliArgsTests.fs
+++ b/tests/Fugue.Tests/CliArgsTests.fs
@@ -1,0 +1,229 @@
+module Fugue.Tests.CliArgsTests
+
+open System
+open System.IO
+open System.Threading.Tasks
+open Xunit
+open FsUnit.Xunit
+open Fugue.Core
+open Fugue.Core.CliArgs
+
+// Capture stderr around a block — used to verify parse-error messages flow
+// to stderr, since `run` prints errors before returning exit code 1.
+let private captureStderr (action: unit -> 'T) : 'T * string =
+    let original = Console.Error
+    use writer = new StringWriter()
+    Console.SetError(writer)
+    try
+        let result = action ()
+        Console.Out.Flush()
+        result, writer.ToString()
+    finally
+        Console.SetError(original)
+
+// --------------------------------------------------------------------------
+// Option parsing
+// --------------------------------------------------------------------------
+
+[<Fact>]
+let ``opt with default returns the default when flag is absent`` () =
+    let countOpt = opt<int> "--count" "How many" |> withDefault 7
+    let mutable observed = 0
+
+    let cmd =
+        root "test" [ optOf countOpt ] (fun ctx ->
+            observed <- ctx.Get countOpt
+            0)
+
+    let exitCode = run [||] cmd
+
+    exitCode |> should equal 0
+    observed |> should equal 7
+
+[<Fact>]
+let ``opt with default is overridden by flag value`` () =
+    let countOpt = opt<int> "--count" "How many" |> withDefault 1
+    let mutable observed = 0
+
+    let cmd =
+        root "test" [ optOf countOpt ] (fun ctx ->
+            observed <- ctx.Get countOpt
+            0)
+
+    let exitCode = run [| "--count"; "42" |] cmd
+
+    exitCode |> should equal 0
+    observed |> should equal 42
+
+[<Fact>]
+let ``opt alias works`` () =
+    let printOpt = opt<bool> "--print" "Print mode" |> alias "-p" |> withDefault false
+    let mutable observed = false
+
+    let cmd =
+        root "test" [ optOf printOpt ] (fun ctx ->
+            observed <- ctx.Get printOpt
+            0)
+
+    let exitCode = run [| "-p" |] cmd
+
+    exitCode |> should equal 0
+    observed |> should equal true
+
+[<Fact>]
+let ``required opt missing returns exit code 1 and prints error to stderr`` () =
+    let nameOpt = opt<string> "--name" "Your name" |> required
+
+    let cmd =
+        root "test" [ optOf nameOpt ] (fun ctx ->
+            // Handler should not be invoked on parse failure.
+            failwith "handler must not run on parse error")
+
+    let exitCode, errOut = captureStderr (fun () -> run [||] cmd)
+
+    exitCode |> should equal 1
+    errOut |> should not' (be EmptyString)
+
+// --------------------------------------------------------------------------
+// Argument parsing
+// --------------------------------------------------------------------------
+
+[<Fact>]
+let ``positional argument is captured`` () =
+    let promptArg = arg<string> "prompt" "The prompt"
+    let mutable observed = ""
+
+    let cmd =
+        root "test" [ argOf promptArg ] (fun ctx ->
+            observed <- ctx.Get promptArg
+            0)
+
+    let exitCode = run [| "hello world" |] cmd
+
+    exitCode |> should equal 0
+    observed |> should equal "hello world"
+
+[<Fact>]
+let ``argument with default falls back when omitted`` () =
+    let promptArg = arg<string> "prompt" "The prompt" |> argDefault "(empty)"
+    let mutable observed = ""
+
+    let cmd =
+        root "test" [ argOf promptArg ] (fun ctx ->
+            observed <- ctx.Get promptArg
+            0)
+
+    let exitCode = run [||] cmd
+
+    exitCode |> should equal 0
+    observed |> should equal "(empty)"
+
+// --------------------------------------------------------------------------
+// Subcommand dispatch
+// --------------------------------------------------------------------------
+
+[<Fact>]
+let ``subcommand handler is invoked, root handler is not`` () =
+    let mutable hits = 0, 0  // (root, sub)
+
+    let printArg = arg<string> "prompt" "What to print"
+
+    let printCmd =
+        command "print" "Print mode" [ argOf printArg ] (fun ctx ->
+            let r, s = hits
+            hits <- (r, s + 1)
+            0)
+
+    let rootCmd =
+        root "test" [ subOf printCmd ] (fun _ ->
+            let r, s = hits
+            hits <- (r + 1, s)
+            0)
+
+    let exitCode = run [| "print"; "hi" |] rootCmd
+
+    exitCode |> should equal 0
+    hits |> should equal (0, 1)
+
+[<Fact>]
+let ``recursive option is visible to subcommand`` () =
+    let verboseOpt =
+        opt<bool> "--verbose" "Verbose"
+        |> alias "-v"
+        |> withDefault false
+        |> recursive
+
+    let mutable observed = false
+
+    let echoCmd =
+        command "echo" "Echo back" [] (fun ctx ->
+            observed <- ctx.Get verboseOpt
+            0)
+
+    let rootCmd =
+        root "test" [ optOf verboseOpt; subOf echoCmd ] (fun _ -> 0)
+
+    let exitCode = run [| "echo"; "-v" |] rootCmd
+
+    exitCode |> should equal 0
+    observed |> should equal true
+
+// --------------------------------------------------------------------------
+// Async handlers
+// --------------------------------------------------------------------------
+
+[<Fact>]
+let ``async handler runs and returns its exit code`` () = task {
+    let mutable observed = ""
+    let promptArg = arg<string> "prompt" "Prompt"
+
+    let asyncCmd =
+        rootAsync "test" [ argOf promptArg ] (fun ctx _ -> task {
+            do! Task.Yield()
+            observed <- ctx.Get promptArg
+            return 7
+        })
+
+    let! exitCode = runAsync [| "hello" |] asyncCmd
+
+    exitCode |> should equal 7
+    observed |> should equal "hello"
+}
+
+// --------------------------------------------------------------------------
+// Multiple options on one command
+// --------------------------------------------------------------------------
+
+[<Fact>]
+let ``two options on same command both parse independently`` () =
+    let nameOpt   = opt<string> "--name" "Name" |> withDefault "anon"
+    let countOpt  = opt<int>    "--count" "How many" |> withDefault 1
+    let mutable observed : (string * int) = ("", 0)
+
+    let cmd =
+        root "test" [ optOf nameOpt; optOf countOpt ] (fun ctx ->
+            observed <- (ctx.Get nameOpt, ctx.Get countOpt)
+            0)
+
+    let exitCode = run [| "--name"; "bob"; "--count"; "3" |] cmd
+
+    exitCode |> should equal 0
+    observed |> should equal ("bob", 3)
+
+// --------------------------------------------------------------------------
+// Parse-only path
+// --------------------------------------------------------------------------
+
+[<Fact>]
+let ``parse returns ParseResult without invoking handler`` () =
+    let mutable handlerCalled = false
+
+    let cmd =
+        root "test" [] (fun _ ->
+            handlerCalled <- true
+            0)
+
+    let pr = parse [||] cmd
+
+    pr.Errors.Count |> should equal 0
+    handlerCalled |> should equal false  // parse() doesn't invoke

--- a/tests/Fugue.Tests/Fugue.Tests.fsproj
+++ b/tests/Fugue.Tests/Fugue.Tests.fsproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="TestCollections.fs" />
+    <Compile Include="CliArgsTests.fs" />
     <Compile Include="ArgsTests.fs" />
     <Compile Include="DelegatedFnTests.fs" />
     <Compile Include="ReadFnTests.fs" />


### PR DESCRIPTION
## Summary

**Phase 1** of the AOT/JIT split (#926, #928, #929): drop in a typed F# DSL over `System.CommandLine` 2.0 so both `fugue` (JIT REPL) and `fugue-aot` (AOT headless, #928) can share one parser.

This PR adds the parser and tests. **Program.fs is not migrated yet** — that's Phase 2. Real AOT-runtime validation of the DSL also lands in Phase 2 (see *Validation honesty* below).

## What ships

### `Fugue.Core.CliArgs` (~150 lines)

Typed handles over System.CommandLine 2.0's symbol tree:

```fsharp
let promptArg = arg<string> "prompt" "What to send"
let outputOpt = opt<string> "--output" "text|json" |> withDefault "text"
let verboseOpt = opt<bool> "--verbose" "Verbose" |> alias "-v" |> withDefault false |> recursive

let printCmd =
    command "print" "One-shot mode"
        [ argOf promptArg; optOf outputOpt ]
        (fun ctx ->
            let prompt = ctx.Get promptArg     // 'string', no cast
            let format = ctx.Get outputOpt     // 'string'
            printRun prompt format
            0)

let rootCmd =
    root "Fugue — terminal coding agent"
        [ optOf verboseOpt; subOf printCmd ]
        (fun _ -> startRepl ())

[<EntryPoint>]
let main argv = run argv rootCmd
```

API surface: \`opt\` / \`arg\` / \`alias\` / \`withDefault\` / \`required\` / \`recursive\` / \`argDefault\` / \`command\` / \`commandAsync\` / \`root\` / \`rootAsync\` / \`run\` / \`runAsync\` / \`parse\` / \`CliContext.Get\`.

### Tests (11 new, total 540 → 551, verified on both branches)

Cover defaults, override, alias, required-missing-error, positional argument, argument default, subcommand dispatch, recursive option visible to subcommand, async handler, multi-option, parse-only path.

## Why `System.CommandLine` 2.0 (not Argu)

- 2.0 stable is post-RC and **AOT-friendly out-of-the-box** — no reflection-based binding (\`GetValue<T>(symbol)\` walks the typed symbol tree, no \`MakeGenericMethod\`).
- Same parser works under JIT and AOT — single source of truth for argv.
- Argu is more F#-idiomatic but uses reflection over DUs; would emit IL2026/IL3050 in the AOT closure.

## Nullness `#nowarn 3261`

SC's \`GetValue<T>\` is annotated \`T?\` to accommodate the abstract case of unset values. In our DSL every option / argument has either a default or \`required\`, so non-null is guaranteed after successful parse. \`Unchecked.nonNull\` would express this except its \`'T : not null\` constraint excludes value types (int, bool, …), and we need one \`ctx.Get\` for both ref and value types. Solution: file-scope \`#nowarn "3261"\` on \`CliArgs.fs\` with a narrowly-scoped justification at the top.

This is the only \`#nowarn\` in our F# code and is bridging a known F#-on-C#-generic-API limitation, not silencing a real bug. Project-level \`<NoWarn>\` rules from CLAUDE.md untouched.

## Verification (honest framing — see also "Validation gap" below)

- [x] Fresh \`dotnet build -c Release\` after \`bin/\` + \`obj/\` wipe — 0 warnings, 0 errors
- [x] Fresh \`dotnet test\` — 551/551 pass on this branch (vs 540/540 on main, verified by checkout)
- [x] Fresh \`dotnet publish src/Fugue.Cli -c Release -r osx-arm64\` — succeeds, binary 45.5 MB (down 1.5 MB from main; SC 2.0 is lean)
- [x] AOT binary smoke: \`fugue --version\` / \`--help\` / \`doctor\` work, cold start 50ms first / 10ms warm, peak RSS 36.7 MB
- [x] No new \`<NoWarn>\` entries in any \`.fsproj\`
- [x] Anthropic SDK ILC warning (\`WebSearchToolResultContent.get_Results()\`) is **pre-existing**, not introduced by this PR (tracked separately as a new infra issue)

## ⚠️ Validation gap — be honest about what this PR does NOT prove

**This PR does NOT prove that \`Fugue.Core.CliArgs\` works at AOT runtime.**

Reality-check via \`strings <binary> | rg "CliArgs|System.CommandLine"\` returns **zero hits** — the trimmer correctly strips \`CliArgs\` as dead code, since no production entry point references it. The unit tests run under JIT only.

What's actually validated by this PR:
- ✅ The DSL compiles cleanly under both JIT and AOT toolchains.
- ✅ The DSL works correctly under JIT (11 unit tests).
- ✅ Adding \`System.CommandLine\` as a NuGet reference does not break any AOT publish (binary actually got smaller).
- ❓ The DSL works correctly when called from an AOT-compiled binary — **deferred to Phase 2** when \`Program.fs\` is wired onto it.

Possible Phase 2 surprises that this PR cannot rule out: \`MakeGenericMethod\` calls in SC's parse path; IL2026/IL3050 from generic \`GetValue<T>\` instantiations the trimmer can't reason about; runtime exceptions from missing reflection metadata.

Phase 2 acceptance must include: \`strings <binary> | rg CliArgs\` returns symbols, AOT smoke-tests for each subcommand (\`fugue print "hi"\`, \`fugue doctor\`, etc.), no new IL2026/IL3050 warnings.

## Out of scope (next PRs)

- Phase 2: migrate \`Program.fs\` (614 lines, 33 ad-hoc \`argv\` lookups, ~10 subcommands) onto the DSL — single PR, replaces all argv parsing, **and provides the real AOT-runtime validation gate this PR defers**.
- Phase 3 (#928): create \`Fugue.Cli.Aot\` project. Note: \`isHeadless\` trigger and \`--print\` / pipe-input handling **already exist** in \`src/Fugue.Cli/Program.fs:15\` — the work is *extracting* those paths into a leaf project, not designing them.
- Phase 4 (#929): switch \`Fugue.Cli\` to JIT/ReadyToRun, lift AOT constraints.

🤖 Updated 2026-05-02 after reality-check on PR #930 narrative.