### PR TITLE
spec(004): defer Phase 5 NuGet publish — preserve analysis baseline (gh-965)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,1 @@
-{
-  "feature_directory": "specs/003-layout-framework"
-}
+{"feature_directory":"specs/004-publish-adapters-console-nuget"}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,14 @@ on CI. 6 BLOCKERs caught pre-push across Phase 3 (justified Principle IX
 trust-but-verify pattern). Follow-up issues #958-#963 opened for deferred
 work (ZWJ width, Surface.fs port, horizontal cross-axis align, interactive
 round-trip tests, legacyRender cleanup, SIGWINCH timing monitoring).
+
+**Phase 5 (NuGet publish) — DEFERRED 2026-05-19.** See
+[`specs/004-publish-adapters-console-nuget/spec.md`](specs/004-publish-adapters-console-nuget/spec.md)
+"Deferral Note" for the three revisit conditions (Phase 4 dogfooding complete /
+≥ 2 external demand signals / bus factor > 1 OR explicit triage commitment).
+Spec, plan-draft, and research.md are preserved as the analysis baseline for a
+future return. Tracking issue: GitHub label `phase-5-deferred`.
+
 Project constitution: [`.specify/memory/constitution.md`](.specify/memory/constitution.md)
 v1.1.0.
 <!-- SPECKIT END -->

--- a/specs/004-publish-adapters-console-nuget/checklists/requirements.md
+++ b/specs/004-publish-adapters-console-nuget/checklists/requirements.md
@@ -1,0 +1,44 @@
+# Specification Quality Checklist: Publish Fugue.Adapters.Console as NuGet Package
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Initial draft passed validation in one iteration. Two architectural questions
+  (R-1 Renderer.toDrawOp disposition, R-2 mono vs split package) were resolved
+  as documented assumptions ("relocate to consuming code" and "monolithic v0.x")
+  rather than left as NEEDS CLARIFICATION, because reasonable defaults exist
+  and the spec's Assumptions section captures the chosen path with rationale.
+  These can be re-litigated in `/speckit-plan` research phase if new evidence
+  surfaces.
+- Two further open questions (R-3 SemVer policy, R-4 AOT-friendliness metadata)
+  were resolved by direct user recommendation in the feature description:
+  R-3 → independent versioning starting `0.1.0-prerelease`; R-4 → no AOT
+  declaration in v0.1, defer to consumer demand.

--- a/specs/004-publish-adapters-console-nuget/plan.md
+++ b/specs/004-publish-adapters-console-nuget/plan.md
@@ -1,0 +1,123 @@
+# Implementation Plan: Publish Fugue.Adapters.Console as NuGet Package
+
+**Status**: **Drafted but NOT pursued** — feature deferred during Phase 0 research. See spec.md "Deferral Note" for conditions of revisit. This document is preserved as the analysis baseline for the future return to the feature; only Constitution Check (passed all 11 gates trivially) and Phase 0 research (`research.md`) were completed. Phase 1 artefacts (`data-model.md`, `contracts/`, `quickstart.md`) were never written.
+
+**Branch**: `004-publish-adapters-console-nuget` (merged to main as documentation only; branch then deleted) | **Date**: 2026-05-19 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/004-publish-adapters-console-nuget/spec.md`
+
+## Summary
+
+Ship `src/Fugue.Adapters.Console/` (F# wrapper over Spectre.Console — Phase 1+2 primitives + Phase 3 Layout framework: Stack/Dock/LayoutGrid/Flex + LayoutScheduler) as a standalone NuGet package published directly from the existing `korat-ai/fugue` monorepo. No code extraction into a separate repository — monorepo publish is the chosen distribution model.
+
+Technical approach:
+
+1. **Decouple** the single point of coupling to `Fugue.Surface` by relocating `Renderer.toDrawOp` out of the package and into a new `Fugue.Cli.RenderBridge` module (Fugue-internal consumer code). The package becomes self-contained in its dependency graph (only Spectre.Console + siblings).
+2. **Annotate** `Fugue.Adapters.Console.fsproj` with NuGet packaging metadata (`PackageId`, `Version=0.1.0-prerelease`, `PackageReadmeFile`, license, repository URL, tags, `IsPackable=true`).
+3. **Author** `src/Fugue.Adapters.Console/README.md` as the embedded `PackageReadmeFile`: one-paragraph purpose, ≤ 15-line Quick Start, one minimal example per layout primitive, "When to use this" comparison with raw Spectre, link to the in-repo spec/data-model docs.
+4. **Add** a tag-driven GitHub Actions workflow `.github/workflows/publish-adapters-console.yml` that runs only on tags matching `adapters-console-v*`, executes `dotnet pack` → `dotnet nuget push`, reads `NUGET_API_KEY` from repository secrets.
+5. **Document** the SemVer-bump convention in `CLAUDE.md` under "Conventions & red lines" so contributors know when to bump the package version field on PRs that touch the public API surface.
+6. **Smoke-test** the end-to-end consumption path: build the `.nupkg` locally, install into a throwaway F# project via a local NuGet feed, render a non-trivial layout, assert non-empty well-formed output. Wire as a CI job.
+
+Out of scope (per spec): namespace rebranding, splitting into multiple packages, AOT validation, publishing to public nuget.org at feature completion (first release is dry-run on local/staging feed).
+
+## Technical Context
+
+**Language/Version**: F# 9 (.NET 10)
+
+**Primary Dependencies**: `Spectre.Console 0.49.*`, `Spectre.Console.Json 0.49.*`, `Spectre.Console.Testing 0.49.*` (existing — unchanged by this feature)
+
+**Storage**: N/A (library package, no persistent state)
+
+**Testing**: xUnit + FsUnit + FsCheck.Xunit (existing test suite, 264+ adapter tests + 573 core); one new smoke test job in CI that builds the `.nupkg` locally and installs it into a throwaway F# project
+
+**Target Platform**: Cross-platform .NET 10 (`net10.0` target framework); the package itself is platform-agnostic. CI continues to run on `ubuntu-latest`, `macos-14`, `windows-latest`.
+
+**Project Type**: Library (NuGet package) packaged from a monorepo; CI workflow + metadata configuration
+
+**Performance Goals**: N/A for the packaging change itself. Performance characteristics of the rendered output are unchanged from Phase 3 (SC-006 — median ≤ 10 ms on typical Fugue UI tree).
+
+**Constraints**:
+
+- Package size MUST be reasonable (no debug symbols in `Release` pack; no embedded large fonts or fixtures beyond what's needed for Spectre Figlet).
+- Tag-pattern workflow MUST be deterministic — same tag = same artefact bytes; concurrent tag pushes MUST NOT race on the same artefact path.
+- Publish credentials MUST come from `${{ secrets.NUGET_API_KEY }}`, never committed.
+- Existing 837+ test count on all 3 OSes MUST hold after decoupling (Quality Gate).
+
+**Scale/Scope**:
+
+- Source change footprint: ~10 lines of fsproj metadata + ~100 LOC `RenderBridge.fs` (extracted/relocated) + ~150 lines README.md + ~80 lines workflow YAML + ~30 lines CLAUDE.md addendum.
+- Net new files: ~4 (README, RenderBridge.fs+fsi, workflow YAML, smoke-test fs). Modified files: ~3 (fsproj, Renderer.fs+fsi, CLAUDE.md). Removed lines: ~10 from `Renderer.fs`/`Renderer.fsi` (the relocated `toDrawOp`).
+- Expected PR count: 4 (P1 decouple → P2 metadata+README → P3 workflow → P4 polish+SemVer doc), with Polish optional if smoke test gets covered inline.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Verified against `.specify/memory/constitution.md` (v1.1.0). Each gate maps to a numbered Principle.
+
+- [X] **Principle I — Test Coverage Discipline**: Decoupling adds new `Fugue.Cli.RenderBridge` module — happy-path + error-path tests will be added in `tests/Fugue.Tests/RenderBridgeTests.fs`. Smoke-test (FR-013) is a regression-guard for end-to-end package consumption. No new public API surface in the package itself (this PR only relocates an existing function).
+- [X] **Principle II — C#/F# Interop Sanitization**: No new C#/F# boundary introduced. The existing Spectre.Console boundary is unchanged; we're packaging it for redistribution. Existing 264+ adapter integration tests (which hit the real Spectre library, not mocks) continue to apply.
+- [X] **Principle III — Subagent-Driven Development**: 4 PRs, each delegatable to a specialist subagent: P1 decouple (`engineering-fsharp-developer`), P2 metadata+README (`engineering-senior-developer` or `engineering-fsharp-developer`), P3 workflow YAML (`engineering-senior-developer`), P4 polish (`engineering-fsharp-developer`). No dual-debate needed — all R-questions have informed defaults documented in spec; if research surfaces a real architectural fork, dual-debate fires then.
+- [X] **Principle IV — F# Purity at Source**: No `.cs` files added. The only NuGet dependency change is *metadata* on an existing project, not a new package reference.
+- [X] **Principle V — AOT-Closure vs JIT Discipline**: `Fugue.Adapters.Console` lives in the JIT closure today. The package is consumed by either JIT or AOT downstream applications, but the package itself does not change closure. The README will explicitly state "AOT consumption is unvalidated at v0.1" per FR-011 — that's a *consumer* warning, not a constitution violation. The new `Fugue.Cli.RenderBridge` lands in `Fugue.Cli` (JIT closure) where the relocated `Renderer.toDrawOp` logically belongs anyway.
+- [X] **Principle VI — Prompt-First Slash Commands**: N/A. No slash commands added.
+- [X] **Principle VIII — Tool Contract Discipline**: N/A. No tools added or modified.
+- [X] **Principle IX — Runtime Policy ≠ Prompt Policy**: N/A. No safety policies added. The CI workflow's credential handling reads from `${{ secrets.NUGET_API_KEY }}` — standard GitHub-native secrets, no policy code involved.
+- [X] **Principle X — Untrusted Content Boundary**: N/A. No retrieval channels added or modified. The publish workflow consumes a git tag (trusted — pushed by maintainer) and a secret (trusted — owned by maintainer); no external content enters the agent's action loop.
+- [X] **Principle XI — Context as Engineered Artifact**: This feature does NOT touch the system prompt, conversation compaction, or tool-schema preamble. The CLAUDE.md addendum (SemVer rule, ~30 lines) is a one-time write to a stable section — does not bust prompt cache differently from any other CLAUDE.md edit.
+- [X] **Quality Gates**: The decoupling work MUST preserve clean `dotnet build`, `dotnet test`, and `dotnet publish src/Fugue.Cli.Aot`. Smoke-test job adds a new CI step but does not alter existing gate semantics. Tag-driven publish workflow is gated on tag pattern (does not run on PRs/branches) so it does not add cost to the merge-time gate set.
+
+**Result**: 11/11 gates pass. No Complexity Tracking entries required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-publish-adapters-console-nuget/
+├── plan.md              # This file
+├── research.md          # Phase 0: resolves R-1 (Renderer.toDrawOp), R-2 (mono vs split), R-3 (SemVer), R-4 (AOT-friendliness)
+├── data-model.md        # Phase 1: package-metadata entity, release-tag entity, workflow-job entity, README sections
+├── quickstart.md        # Phase 1: local pack + install + render smoke procedure (FR-013 manual variant)
+├── contracts/
+│   ├── package-metadata.md   # required .fsproj PropertyGroup fields + their semantics
+│   ├── publish-workflow.md   # tag pattern, workflow inputs, step-by-step contract
+│   └── readme-structure.md   # mandated README sections in order
+└── tasks.md             # Phase 2 — created by /speckit-tasks
+```
+
+### Source Code (repository root)
+
+```text
+src/Fugue.Adapters.Console/                  # the package source — minor edits only
+├── Fugue.Adapters.Console.fsproj            # ⨯ add PackageId, Version, ReadmeFile, etc.
+├── README.md                                # ＋ NEW — embedded PackageReadmeFile
+├── Renderer.fs                              # ⨯ remove `toDrawOp` (relocate to Fugue.Cli)
+├── Renderer.fsi                             # ⨯ remove `toDrawOp` declaration
+├── Layout/                                  # ✓ unchanged (Stack, Dock, LayoutGrid, Flex, Scheduler, etc.)
+└── (rest unchanged)                         # ✓ Style, SafeText, Composition, Primitive, Console, etc.
+
+src/Fugue.Cli/
+├── RenderBridge.fs                          # ＋ NEW — houses the relocated `Composition → DrawOp` mapping
+├── RenderBridge.fsi                         # ＋ NEW — public signature for RenderBridge
+├── Fugue.Cli.fsproj                         # ⨯ add Compile entries for RenderBridge
+
+tests/Fugue.Tests/
+├── RenderBridgeTests.fs                     # ＋ NEW — happy + error path tests for the relocated function
+
+tests/Fugue.Adapters.Console.Tests/
+├── PackageSmokeTests.fs                     # ＋ NEW — FR-013 smoke (local pack → install → render)
+                                             #         OR runs entirely in CI YAML if cleaner
+
+.github/workflows/
+├── publish-adapters-console.yml             # ＋ NEW — tag-driven publish
+
+CLAUDE.md                                    # ⨯ append SemVer-bump rule under "Conventions & red lines"
+```
+
+**Structure Decision**: This feature operates on an existing monorepo whose structure is already established. Project layout is unchanged; the feature adds 4 new files, modifies 3 existing files, and removes ~10 lines of relocated code. Per spec scope, no new `.slnx` and no new `.fsproj` are created — the existing `Fugue.Adapters.Console.fsproj` becomes the packable project simply by adding metadata.
+
+## Complexity Tracking
+
+> Constitution Check passed all 11 gates without violations. No entries needed.

--- a/specs/004-publish-adapters-console-nuget/research.md
+++ b/specs/004-publish-adapters-console-nuget/research.md
@@ -1,0 +1,157 @@
+# Phase 0: Research — Publish Fugue.Adapters.Console as NuGet Package
+
+**Feature**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md) | **Date**: 2026-05-19
+
+This document resolves the four open architectural questions (R-1..R-4) flagged in the spec's Assumptions section. Each finding follows the standard format: **Decision / Rationale / Alternatives considered**.
+
+---
+
+## R-1 — Disposition of `Renderer.toDrawOp` (the single `Fugue.Surface` coupling point)
+
+**Question**: The only code in `src/Fugue.Adapters.Console/` that references `Fugue.Surface` is one method in `Renderer.fs`/`Renderer.fsi`:
+
+```fsharp
+let toDrawOp (ctx: RenderContext) (composition: Composition) : Result<Fugue.Surface.DrawOp, RenderError> =
+    toRawAnsi ctx composition
+    |> Result.map Fugue.Surface.DrawOp.RawAnsi
+```
+
+To publish the package with zero internal references (FR-002, FR-014), this method must move OR be dropped OR be sealed-internal. Three options:
+
+- **(a) Drop completely**: callers convert `string` ANSI to `DrawOp.RawAnsi` themselves at the call site.
+- **(b) Relocate to `Fugue.Cli.RenderBridge`**: a new ~20-line module inside the consuming Fugue REPL code.
+- **(c) Mark `internal` + `InternalsVisibleTo Fugue.Cli`**: keep the method in the package source but hide it from the public NuGet API surface.
+
+**Decision**: **(b) Relocate to `Fugue.Cli.RenderBridge`**.
+
+**Rationale**:
+
+- Option (a) "drop completely" leaks abstraction: every call site must repeat `match toRawAnsi ctx c with | Ok ansi -> Ok (DrawOp.RawAnsi ansi) | Error e -> Error e`. That's 6 lines repeated at every Fugue render path — exactly the kind of glue a small bridge module should absorb. There is one canonical mapping; we should have one canonical name for it.
+- Option (c) "internal + InternalsVisibleTo" is technically clean but semantically wrong: the method is *not* part of the package's intended public surface, but it is also not part of its internal machinery. It's a Fugue-specific *consumer-side* concern. Burying it inside the package's source tree mis-signals its ownership: the package's tests would have to test it, the package's docs would have to explain why, and any future contributor extracting the package to a separate repo (hypothetically v2.0) would have to find and remove it.
+- Option (b) "relocate to Fugue.Cli.RenderBridge" is the textbook **strangler-fig** placement: the package owns the abstract `Composition` type; consumers map it to their own draw-op shape in their own code. The Fugue REPL is one specific consumer; its mapping lives in `Fugue.Cli` where it can evolve independently of the package release cycle.
+
+**Mechanics**:
+
+- New files: `src/Fugue.Cli/RenderBridge.fsi` (declaration), `src/Fugue.Cli/RenderBridge.fs` (body), `tests/Fugue.Tests/RenderBridgeTests.fs` (happy + error tests).
+- Module signature:
+  ```fsharp
+  module Fugue.Cli.RenderBridge
+
+  open Fugue.Adapters.Console
+  open Fugue.Surface
+
+  /// Render a Composition to ANSI bytes wrapped as a DrawOp.RawAnsi, suitable for
+  /// posting to the Fugue Surface actor. The bridge owes nothing to the package;
+  /// it is the Fugue REPL's chosen mapping from the package's abstract output
+  /// (string ANSI) to Fugue's internal draw-op representation.
+  val toDrawOp :
+      ctx: RenderContext ->
+      composition: Composition ->
+          Result<DrawOp, RenderError>
+  ```
+- Call sites updated: `LayoutHost.fs` (currently calls `Renderer.toRawAnsi` and constructs `DrawOp.RawAnsi` inline — switch to `RenderBridge.toDrawOp`). Any other Fugue-side caller (none today, since legacy render paths bypass the package) updated similarly when migrated in Phase 4.
+- Removed from package: 4 lines in `Renderer.fs`, 4 lines in `Renderer.fsi`.
+
+**Alternatives considered**: (a) and (c) above; both rejected per rationale.
+
+---
+
+## R-2 — Single monolithic package vs split into `Fugue.Adapters.Console` + `Fugue.Adapters.Console.Layout`
+
+**Question**: Should we ship one package containing everything (Phase 1+2 wrapper + Phase 3 Layout), or split into a "core wrapper" package and an additive "layout framework" package that depends on it?
+
+**Decision**: **Single monolithic package** at v0.x. Split deferred to v0.2+ contingent on consumer demand.
+
+**Rationale**:
+
+- **Maintenance overhead**: Two packages require two `<Version>` fields, two release-tag patterns, two CI workflows, two READMEs, and dependency-version coordination (package B must specify a compatible version range of package A). For a single-maintainer project, that overhead is non-trivial and recurring.
+- **Discoverability**: A single package name on a NuGet feed is one search hit, not two. Splitting hurts SEO for the smaller package because consumers are likely to search for the layout primitive ("F# stack dock layout terminal") and find only the monolith.
+- **Bandwidth cost is negligible**: The complete adapter compiles to a small `.dll`; the Layout subset would only marginally shrink the package size. We are not in the territory where "downloading 200 KB you don't need" is a real concern.
+- **YAGNI**: No consumer has asked for the wrapper alone. Speculatively splitting is exactly the optimisation Fugue's "Don't add features beyond what the task requires" guidance warns against.
+- **Reversibility**: If a real signal arrives (someone files an issue: "I want Stack/Dock/Grid/Flex for an existing Spectre-using TUI, but I don't want to take the wrapper layer because I already have my own"), we can ship `Fugue.Adapters.Console.Layout` as an additive split in v0.2 and continue maintaining the monolith. The cost of the v0.x monolith is zero in that scenario.
+
+**Mechanics**:
+
+- One `Fugue.Adapters.Console.fsproj` with `<IsPackable>true</IsPackable>`.
+- One `PackageId=Fugue.Adapters.Console`.
+- One README inside `src/Fugue.Adapters.Console/`.
+- One workflow `.github/workflows/publish-adapters-console.yml`.
+
+**Alternatives considered**:
+
+- **Split-first** (two packages from v0.1): rejected for the maintenance and discoverability reasons above.
+- **Three packages** (Primitives / Widgets / Layout): rejected as further over-engineering; the inter-dependency graph would be a thin sandwich, and consumers would have to pick which two-of-three they want for any non-trivial use case.
+
+---
+
+## R-3 — SemVer policy: tracks Fugue product version or independent?
+
+**Question**: The Fugue binary has its own version (currently 0.x). Does the NuGet package follow the binary's version, or maintain its own?
+
+**Decision**: **Independent versioning**, starting at `0.1.0-prerelease`. First stable `0.1.0` only after parent product migrates its render paths to consume the package (Phase 4 dependency captured in spec FR-010 and Dependencies section).
+
+**Rationale**:
+
+- **Different audiences, different release cadences**: The Fugue product is shipped to end-users who run the binary; cadence is dictated by user-facing feature delivery. The package is shipped to F# developers who consume the API; cadence is dictated by API-surface stability and backward compatibility. Tying the two means every Fugue patch bump forces a package republish — even when nothing in the adapter changed. The opposite — a package API breaking change — must NOT be tied to Fugue binary bumps that have nothing to do with the adapter.
+- **Pre-release tail is essential**: `0.1.0-prerelease` (or equivalent NuGet pre-release suffix) signals to consumers: "API may change before 1.0, pin at your own risk." Without the pre-release suffix, anyone consuming `0.1.0` has SemVer-stability expectations the maintainer is not yet ready to honour. Per spec FR-010, the first stable `0.1.0` is gated on Phase 4 (parent product eats its own dog food) so we can confidently promise API stability at that point.
+- **Industry standard for .NET monorepo publishing**: ASP.NET Core, `Microsoft.Extensions.*`, FSharp.Core all publish per-package versions decoupled from any "umbrella product" version. This is the established norm; deviating from it confuses consumers who expect NuGet packages to version independently.
+
+**Mechanics**:
+
+- `<Version>0.1.0-prerelease</Version>` in `Fugue.Adapters.Console.fsproj`.
+- Release tag pattern: `adapters-console-vX.Y.Z[-suffix]` (e.g. `adapters-console-v0.1.0-prerelease`, later `adapters-console-v0.1.0`).
+- CLAUDE.md addendum maps public-API surface changes to bump categories:
+  - **Patch** (e.g. `0.1.0` → `0.1.1`): bug fix in implementation, no `.fsi` change.
+  - **Minor** (e.g. `0.1.0` → `0.2.0`): additive `.fsi` change (new type, new function, new DU case).
+  - **Major** (e.g. `0.x` → `1.0.0`): removed/renamed exported symbol, signature change, namespace rebrand.
+  - Pre-1.0 special: SemVer permits breaking changes in minor bumps for `0.x` — the addendum documents this so contributors don't unduly delay necessary breaks.
+
+**Alternatives considered**:
+
+- **Tracked to Fugue binary**: rejected — couples cadences with nothing in common.
+- **Calendar versioning (CalVer)** (e.g. `2026.5.19`): rejected — CalVer suits products where "what version are you on?" is the maintainer's preferred phrasing; for libraries, SemVer-encoded API compatibility wins.
+
+---
+
+## R-4 — AOT-friendliness package metadata (`<IsAotCompatible>` attribute)
+
+**Question**: .NET 8+ supports `<IsAotCompatible>true</IsAotCompatible>` in `.fsproj` to declare AOT-compatibility and surface trim warnings during build. Should `Fugue.Adapters.Console` declare itself AOT-compatible?
+
+**Decision**: **Do NOT declare AOT compatibility at v0.1**. Document the deferral in the README. Re-evaluate if a consumer files an issue requesting AOT support.
+
+**Rationale**:
+
+- **The package is JIT-only by design** (per Fugue's own AOT/JIT split, established 2026-05-02): `Fugue.Adapters.Console` lives in the JIT closure because Spectre.Console transitively triggers trim warnings (`IL2026`, `IL3050`) that the Fugue project has deliberately quarantined to the JIT-only `Fugue.Cli`/`Fugue.Surface` portion. Declaring `<IsAotCompatible>true</IsAotCompatible>` on the package would either (a) light up dozens of trim warnings at every consumer's build (bad UX, false alarms), or (b) require a Fugue-side investment in suppressing/annotating each warning — work that is unjustified until a consumer asks for AOT.
+- **Honest signalling is better than false promise**: Marking the package AOT-compatible while transitively pulling in Spectre.Console (which is not AOT-validated by its own authors) would set up consumers for unexpected failures at their own AOT-publish step. The package README MUST instead state explicitly: "v0.1 is JIT-validated only. AOT publish is not supported; if you need it, please file an issue."
+- **Re-evaluable on demand**: If even one issue arrives asking for AOT, we can: (i) confirm AOT trim closure on the package source itself (we control it), (ii) check Spectre's then-current AOT story (the upstream may have improved), (iii) decide if the work is justified. The cost of waiting is one explicit README sentence; the cost of declaring prematurely is broken consumer builds and bug-report triage.
+
+**Mechanics**:
+
+- No `<IsAotCompatible>` line in the `.fsproj`.
+- README "When NOT to use this" section explicitly lists AOT publish as a current non-target.
+- Follow-up GitHub issue template: "AOT-publish support" — created if/when the first consumer request lands, NOT created speculatively.
+
+**Alternatives considered**:
+
+- **Declare `<IsAotCompatible>true</IsAotCompatible>` immediately**: rejected — sets up trim-warning ambush for consumers.
+- **Declare `<IsAotCompatible>false</IsAotCompatible>` explicitly**: technically legal but `false` is the default; explicit `false` adds noise without affecting behaviour. Omitting the line is the cleaner expression.
+
+---
+
+## Summary of decisions
+
+| Question | Decision | Spec impact |
+|---|---|---|
+| R-1: `Renderer.toDrawOp` disposition | Relocate to `Fugue.Cli.RenderBridge` | Confirms FR-014 mechanics; new file added to plan |
+| R-2: Mono vs split package | Single monolithic package at v0.x | Confirms FR-001 (single artefact); split deferred |
+| R-3: SemVer policy | Independent, starts `0.1.0-prerelease` | Confirms FR-009, FR-010; tag pattern fixed as `adapters-console-vX.Y.Z[-suffix]` |
+| R-4: AOT-friendliness metadata | Do NOT declare; explicit README warning instead | Confirms FR-011; README structure must include the warning |
+
+All four decisions were resolvable through informed defaults; no consumer-survey or dual-agent debate was required. Should `/speckit-implement` surface contraindicating evidence (e.g. the strangler-fig relocation breaks a hidden consumer), this document is the place to record the re-litigation.
+
+## Best-practice references consulted
+
+- **.NET monorepo NuGet publishing**: aspnetcore (Microsoft), `Microsoft.Extensions.*`, FsToolkit.ErrorHandling — all use independent `<Version>` per packable project + tag-driven CI publish.
+- **PackageReadmeFile + embedded README**: NuGet docs require the file to be present in the `.nupkg` at a known path; `<PackageReadmeFile>README.md</PackageReadmeFile>` + `<None Include="README.md" Pack="true" PackagePath="\" />` is the standard incantation.
+- **GitHub Actions tag-triggered publish**: `on: push: tags: ['adapters-console-v*']` is the standard pattern; isolating to a tag prefix avoids accidental publishes from any other tag.
+- **SemVer for pre-1.0 .NET libraries**: SemVer spec §4 permits breaking changes in 0.x minor bumps; this is the convention adopted by FsHttp, FsToolkit.ErrorHandling, and similar libraries.

--- a/specs/004-publish-adapters-console-nuget/spec.md
+++ b/specs/004-publish-adapters-console-nuget/spec.md
@@ -1,0 +1,173 @@
+# Feature Specification: Publish Fugue.Adapters.Console as NuGet Package
+
+**Feature Branch**: `004-publish-adapters-console-nuget`
+
+**Created**: 2026-05-19
+
+**Status**: Draft
+
+**Input**: User description: "Phase 5 — publish `Fugue.Adapters.Console` (Phase 1+2 F# wrapper over Spectre.Console + Phase 3 Layout framework: Stack/Dock/LayoutGrid/Flex + Scheduler) as a standalone NuGet package directly from the existing `korat-ai/fugue` monorepo, without extraction into a separate repository."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — F# developer installs the package and renders a layout in their own project (Priority: P1)
+
+A polyglot .NET developer who already uses Spectre.Console in C# discovers an F# wrapper that gives them typed primitives, smart constructors returning `Result`, and a higher-level Layout API (Stack / Dock / Grid / Flex). They add the package to a new `dotnet new console -lang F#` project, write 10 lines of F#, and render an aligned multi-region layout to their terminal.
+
+**Why this priority**: This is the entire value proposition. Without an installable package that a stranger can `dotnet add package` and run examples from in under 5 minutes, the publication effort produces zero external value. Everything else in this feature is in service of this story.
+
+**Independent Test**: A reviewer clones a fresh empty directory, runs `dotnet new console -lang F#`, follows the README's "Quick start" snippet (≤ 15 lines of F#), and observes a correctly aligned layout in their terminal. No knowledge of Fugue (the AI agent product) is required.
+
+**Acceptance Scenarios**:
+
+1. **Given** the package is published to a NuGet feed (initially local; later nuget.org), **When** a developer runs `dotnet add package Fugue.Adapters.Console` in a fresh F# console project, **Then** the package restores cleanly with only the external rendering library (and its sibling packages already used by the adapter) as transitive dependencies — no Fugue product code is pulled in.
+2. **Given** a developer follows the README "Quick start" example, **When** they run `dotnet run`, **Then** their terminal displays a layout matching the README description (Stack with Dock containing two labelled regions).
+3. **Given** the developer wants to compose more advanced layouts, **When** they read the four primitive examples in the README, **Then** each example compiles and runs as-is without modification.
+
+---
+
+### User Story 2 — Maintainer cuts a release with a single tag push (Priority: P2)
+
+A Fugue maintainer decides the package is stable enough for a new public release. They bump the version field in the project file, push a git tag of an agreed shape, and within minutes the corresponding redistributable artefact appears on the configured NuGet feed without any further manual action.
+
+**Why this priority**: Without automated release plumbing, every publish becomes a manual ritual the maintainer postpones; releases bunch up and the package ages on a stale version even when source is moving. A tag-driven workflow makes the cost of cutting a release near-zero and aligns with industry-standard release practice for .NET libraries.
+
+**Independent Test**: A maintainer pushes a tag matching the agreed release-tag pattern to the repository, then within a bounded time window observes a successful CI run that produced a redistributable artefact and (when targeted at the public feed) confirms the new version appears on the public listing.
+
+**Acceptance Scenarios**:
+
+1. **Given** a tag matching the release-tag pattern is pushed, **When** the CI workflow runs, **Then** it produces a redistributable artefact whose version matches the tag and whose contents include the compiled library, embedded README, and license declaration.
+2. **Given** the tag is pushed and the workflow has credentials configured, **When** the workflow completes, **Then** the package is uploaded to the target feed and the listing displays the README, license, repository link, and tags.
+3. **Given** a tag does NOT match the release-tag pattern, **When** the developer pushes it, **Then** the publish workflow does NOT run (preventing accidental releases from miscellaneous tags).
+4. **Given** the workflow fails partway (e.g. authentication error during upload), **When** the maintainer inspects the CI log, **Then** the failure is clearly attributable to a single step and the maintainer can re-run after fixing without manual cleanup of partial state.
+
+---
+
+### User Story 3 — Fugue continues to build and run after the package is decoupled (Priority: P1)
+
+After the package is decoupled from the rest of the Fugue product, every existing Fugue contributor can clone the repository, build it, run the test suite, and run the Fugue REPL binary, with no observable change in behaviour. All existing tests continue to pass on all three supported continuous-integration operating systems, and both Fugue binaries continue to start and respond to standard flags.
+
+**Why this priority**: This is the "do no harm" guarantee. A NuGet publication effort that breaks the parent product is a net loss. Treating regression-prevention as a first-class user story (not an implicit non-functional requirement) makes it visible in the task list and ensures it gets test coverage equal to the new functionality. Same priority level as Story 1 because the two together form the feature's "minimum acceptable result": you cannot ship one without the other.
+
+**Independent Test**: A contributor on a fresh clone runs the standard full-test command and observes a passing test count greater than or equal to the pre-feature baseline, and additionally publishes both Fugue binaries per repository conventions and confirms each starts successfully and responds to standard flags.
+
+**Acceptance Scenarios**:
+
+1. **Given** the package decoupling work is merged, **When** any contributor runs the standard full-test command, **Then** the total passing test count meets or exceeds the pre-merge baseline.
+2. **Given** the decoupling is complete, **When** a contributor runs the headless and interactive binary smoke tests defined in the repository conventions, **Then** both binaries start, accept the standard version and help flags, and exit cleanly.
+3. **Given** the headless binary AOT-publish workflow runs on CI, **When** the binary is published for each supported runtime identifier, **Then** the publish produces a binary with no new trim or AOT warnings beyond the existing allow-listed set.
+
+---
+
+### User Story 4 — Reader of the package page understands what the package is for in under 60 seconds (Priority: P2)
+
+A developer skimming search results on a NuGet feed lands on the package listing, reads the README rendered inline, and within one minute either decides "this fits my need, I'll try it" or "this isn't what I'm looking for". They don't need to clone the repository, open external documentation, or piece together intent from doc comments to make that decision.
+
+**Why this priority**: Discoverability lives or dies on first-impression copy. A high-quality package with a vague README is invisible. This is a one-time content investment that compounds: every future visitor benefits.
+
+**Independent Test**: A developer who has never heard of Fugue or this package reads only the package README (as rendered on the feed), and after one minute can state in their own words (a) what problem the package solves, (b) which alternative they should pick instead in two specified scenarios, and (c) the rough scope of the four layout primitives.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reader opens the package listing on a NuGet feed, **When** they view the rendered README, **Then** the first paragraph clearly states what the package is for and who should use it.
+2. **Given** the reader scrolls past the first paragraph, **When** they reach the Quick Start, **Then** the example code is ≤ 15 lines, copy-pasteable, and produces visible output described in plain text alongside.
+3. **Given** the reader continues, **When** they reach the Primitives section, **Then** each of the four layout primitives has at least one minimal example and a one-line description of its intended use.
+4. **Given** the reader is comparing alternatives, **When** they read the "When to use this" section, **Then** they find an honest comparison with the underlying rendering library used directly (i.e. "use it directly if you only need X; use this if you need Y").
+
+---
+
+### User Story 5 — Maintainer enforces the SemVer-bump rule via convention captured in project docs (Priority: P3)
+
+A contributor opens a pull request that changes a publicly exposed signature in the package's API surface. The reviewer (human or automated) is reminded by a project-documented rule that this change requires a version bump in the package project file, and the contributor adjusts the PR accordingly before merge.
+
+**Why this priority**: Without a written convention, SemVer drift is inevitable — breaking changes ship as patch versions, consumers' builds break, package trust erodes. The cost of writing the rule once is ~30 minutes; the cost of skipping it is found in months when the first compatibility complaint arrives.
+
+**Independent Test**: A new contributor reads the relevant project doc, opens a contrived PR that modifies the public API surface but does not bump the version, and during review either receives a clear pointer to the convention or is auto-flagged by a check, and after applying the bump the PR is accepted.
+
+**Acceptance Scenarios**:
+
+1. **Given** a contributor changes a publicly exposed type or signature, **When** the reviewer checks the project docs, **Then** the documented convention specifies how to bump the version (major / minor / patch) for that change shape.
+2. **Given** the convention is published, **When** any contributor searches the contributor-facing context file for "version" or "SemVer", **Then** they find the rule with examples within 30 seconds.
+
+---
+
+### Edge Cases
+
+- **Stale fork installs the package as v0.x and never updates**: the package's public API may evolve before v1.0; consumers pinned to old prereleases should not block the maintainer from making breaking changes; the README must explicitly state pre-1.0 SemVer rules.
+- **Consumer adds the package and the parent product's internal libraries simultaneously**: an end-user could theoretically pull both the published package and a transitive reference to in-tree code with the same namespace. The package contents must be unambiguous about what is public.
+- **A reviewer pushes a malformed release tag** (e.g. `adapters-console-vfoo`): the workflow must not crash CI; it must either no-op or fail with a clear error attributable to the tag, and not leave a half-uploaded package on the feed.
+- **NuGet credentials are missing or expired** when a release tag is pushed: the workflow must fail loudly at a single named step, not silently succeed having uploaded nothing.
+- **Two release tags are pushed in close succession**: each must produce a separate, deterministic build; concurrent jobs must not race on the same artefact path.
+- **A consumer runs the package in an environment without a TTY** (e.g. CI logs, redirected stdout): the rendered output should degrade gracefully to plain text where the underlying renderer supports it, not crash.
+- **A consumer attempts to render a layout in an AOT-published application**: the package is JIT-validated only at v0.1; this constraint must be explicit on the listing so AOT consumers are not blindsided.
+- **The package is unlisted or deprecated later**: the maintainer must have a documented path to unlist a version without affecting the parent product.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The repository MUST produce a single redistributable package artefact whose contents are the compiled library, an embedded README, a license declaration, and standard NuGet metadata (id, version, authors, description, project URL, repository URL, tags).
+- **FR-002**: The package's runtime dependency graph MUST contain no project-internal references to other Fugue components; the only transitive dependencies MUST be the external rendering library and its sibling packages already in use by the adapter.
+- **FR-003**: The repository MUST continue to build and pass its existing test suite at no less than the pre-feature baseline after the decoupling work is merged.
+- **FR-004**: A reproducible local command MUST exist that, when invoked from a fresh clone, produces the package artefact suitable for inspection without requiring publish credentials.
+- **FR-005**: A continuous-integration workflow MUST publish the package to the configured NuGet feed when a release tag of the agreed pattern is pushed, and MUST NOT publish on any other event (commit, pull request, branch push, non-matching tag).
+- **FR-006**: The publish workflow MUST read credentials from the repository's secrets store (never from committed files), and MUST fail loudly with a single-step attribution if credentials are missing.
+- **FR-007**: The package README rendered on the NuGet feed MUST contain, in order: a one-paragraph statement of purpose, a Quick Start example of ≤ 15 lines that produces visible output, one minimal example per layout primitive (Stack, Dock, Grid, Flex), an honest comparison with the underlying rendering library used directly, and a link to the canonical source-of-truth location for deeper documentation.
+- **FR-008**: The repository's contributor-facing context document MUST contain a written rule that maps changes to the package's public surface to a version-bump category (major / minor / patch), with at least one example per category.
+- **FR-009**: The package version field MUST be independently maintainable from the parent product's version (i.e. bumping the parent does not bump the package and vice versa).
+- **FR-010**: The first published version MUST be a pre-release identifier until the parent product has migrated its own rendering paths to the package; only then MAY a stable `0.1.0` be released.
+- **FR-011**: The package listing MUST clearly state, at v0.1, that AOT-published consumption is not validated; removal of that warning is permitted only after AOT validation has been added.
+- **FR-012**: The package MUST NOT change its namespace or public type names as part of this feature; namespace rebranding is explicitly a v1.0 concern and out of scope here.
+- **FR-013**: A smoke test MUST exist that exercises end-to-end consumption: build the package locally, install it into a throwaway project, render a non-trivial layout, and assert the rendered output is non-empty and well-formed; this smoke test MUST run in CI.
+- **FR-014**: The single point of coupling between the package and the parent product's surface library MUST be relocated out of the package; the package's source MUST contain no project references to the parent product's code.
+
+### Key Entities
+
+- **Package artefact**: the redistributable unit produced by the build, identified by an id and a version, containing compiled code, embedded documentation, and metadata that describes itself to NuGet consumers.
+- **Release tag**: a repository tag of an agreed shape whose push triggers the publish workflow; the tag's text encodes the version to publish, providing a single source of truth.
+- **Publish workflow**: a CI job that runs only on release-tag pushes, packs the package, and uploads it to the configured feed using credentials from the repository secrets store.
+- **Embedded README**: a single Markdown document inside the package that is rendered by the NuGet feed on the listing page; the canonical first-impression document for the package.
+- **Public API surface**: the set of types, modules, and functions that are visible from outside the package — changes to which require version bumps per the documented SemVer convention.
+- **SemVer-bump rule**: the written convention in the contributor context document that maps API-surface change shapes to version-bump categories.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An F# developer who has never seen this repository can install the package into a fresh empty F# project and render a non-trivial layout (Stack containing Dock containing two labelled regions) by following only the package README, within 5 minutes from project creation to visible output.
+- **SC-002**: Pushing a matching release tag to the repository produces a successfully published package on the configured NuGet feed within 15 minutes, with zero manual intervention required between tag push and feed availability.
+- **SC-003**: After the decoupling work is merged, the full repository test suite passes with a total count greater than or equal to the pre-merge baseline on all three supported continuous-integration operating systems.
+- **SC-004**: A reader who has never heard of Fugue can describe, in their own words and after only reading the package README, what the package is for and which alternative to pick in at least two scenarios — within 60 seconds of opening the listing.
+- **SC-005**: A contributor opening a pull request that changes the public API surface finds the SemVer-bump rule in the contributor context document within 30 seconds of searching for "version" or "SemVer".
+- **SC-006**: A pushed tag that does NOT match the release pattern does NOT trigger a publish: zero unintended publishes occur during the feature's first year of operation.
+- **SC-007**: The published package's runtime dependency graph contains exactly the external rendering library and its sibling packages — zero project-internal Fugue references appear in the package's dependency listing.
+- **SC-008**: Inspection of the package's contents on the feed confirms: an embedded README is present and renders, a license declaration is present, a repository URL is present and resolves, and at least one tag matching the package's domain (terminal / TUI / Spectre / F#) is present.
+
+## Assumptions
+
+- **Naming**: The package id and namespace remain `Fugue.Adapters.Console` for v0.x. A neutral rebrand is deferred to a hypothetical v1.0 release with a compatibility shim for downstream consumers — that work is explicitly NOT part of this feature.
+- **Renderer-to-DrawOp bridge**: The single point of coupling between the adapter and the parent product's surface library — a method that maps a composition to a Fugue-specific draw operation — will be relocated out of the package and into the consuming Fugue REPL code, so the package's dependency graph contains zero internal references. This is the natural strangler-fig path: the package owns the abstract composition type; consumers are free to map it to their own draw-op shape.
+- **Single package vs split**: A single monolithic package is the v0.x default. Splitting into a "core wrapper" package and a "layout framework" package is a possible v0.2+ evolution if and only if real-world consumers ask for the wrapper alone (e.g. their TUI does not need the layout primitives). Until that signal arrives, splitting adds maintenance overhead without observable benefit.
+- **Independent versioning**: The package's version field is decoupled from the parent product's binary version. The first published version is a pre-release identifier; the first stable `0.1.0` is published only after the parent product has migrated its own rendering paths onto the package (Phase 4 follow-up work in the parent product, tracked separately and outside this feature's scope).
+- **AOT consumption deferred**: The package does NOT declare AOT compatibility metadata at v0.1; the listing explicitly warns that AOT-published consumption is unvalidated. AOT validation is a follow-up tracked separately and conditional on consumer demand.
+- **First release is a dry run**: The first tag push targets a local or staging feed (not the public one) for one full release cycle, to flush out workflow defects before any externally observable publish occurs.
+- **License**: The package license is the same as the parent repository (MIT). No legal review is required beyond that match.
+- **Existing tests are the safety net**: All existing adapter tests already covering the package's surface continue to run unchanged inside the monorepo; no separate test project is created for the published package. The smoke test (FR-013) is additive, not a replacement.
+- **Tag pattern**: A specific tag pattern conveys both intent and the version number in a single push. The pattern is implementation-defined and documented in the contributor context document alongside the SemVer rule.
+- **No retroactive support for prior rendering-library versions**: The package's supported underlying-library version range matches the parent product's range. When the parent bumps the library, the package bumps in step.
+
+## Dependencies
+
+- **External**: NuGet feed account and publish credentials (initially a local or staging feed for the dry run; later the public feed once the dry run validates the workflow).
+- **Internal — out of scope but blocks the stable release**: The parent product's migration of its REPL render paths onto the package (Phase 4 work in the parent product); a stable `0.1.0` is conditional on that migration completing successfully.
+- **Internal — required for the package to make sense**: The adapter's existing public API surface is stable enough to publish; this is established by the prior Phase 1 / Phase 2 / Phase 3 features and is not re-litigated here.
+
+## Out of Scope
+
+- Extracting the package into a separate Git repository (rejected — monorepo publish is the chosen model).
+- Renaming the namespace (deferred to a hypothetical v1.0 with compatibility shim).
+- Validating AOT-published consumption (deferred until consumer demand surfaces).
+- Splitting into two packages (deferred until consumer demand surfaces).
+- Publishing to the public NuGet feed at this feature's completion (the first feature-completing release is a dry-run on a local or staging feed; public release is a follow-up after the dry-run validates the workflow).
+- The parent product's migration of its render paths onto the package (Phase 4 work, tracked separately).
+- Authoring contributor onboarding documentation beyond the SemVer-bump rule (general onboarding lives elsewhere in the repository).

--- a/specs/004-publish-adapters-console-nuget/spec.md
+++ b/specs/004-publish-adapters-console-nuget/spec.md
@@ -4,9 +4,29 @@
 
 **Created**: 2026-05-19
 
-**Status**: Draft
+**Status**: **Deferred (2026-05-19)** — see "Deferral Note" below.
 
 **Input**: User description: "Phase 5 — publish `Fugue.Adapters.Console` (Phase 1+2 F# wrapper over Spectre.Console + Phase 3 Layout framework: Stack/Dock/LayoutGrid/Flex + Scheduler) as a standalone NuGet package directly from the existing `korat-ai/fugue` monorepo, without extraction into a separate repository."
+
+## Deferral Note (2026-05-19)
+
+During `/speckit-plan` Phase 0, three concerns surfaced that the v1.1.0 constitution does not currently cover:
+
+1. **New operating mode without governance**: publishing a NuGet creates an open-source-library maintainer role (external consumers, SemVer obligations to strangers, vulnerability response, transitive-dep migration support). The constitution speaks to Fugue-as-product, not Fugue-as-library-maintainer.
+2. **Naming is irreversible after first publish**: `Fugue.Adapters.Console` as a package id was treated in the spec as "v1.0 concern" via a hypothetical `TypeForwarded` shim, but the first publish creates external references (Google, StackOverflow, downstream projects) that no shim repairs cleanly. The naming decision needs to be made BEFORE publication, not deferred past it.
+3. **Bus factor = 1 + active development = bad time for external commitments**: a single active maintainer + ongoing Phase-3 churn means new issues from strangers compete with internal velocity; the worst outcome is an "abandoned-looking" package on a feed with stale `last commit` after 6+ months.
+
+The feature is therefore **deferred** rather than re-scoped. Revisit conditions (ALL three must be met before reopening):
+
+- **Condition 1 — dogfooding**: Phase 4 complete — `Fugue.Surface` / `Render.fs` / `MarkdownRender.fs` / `DiffRender.fs` / `StackTraceRender.fs` / `Doctor.fs` / `Picker.fs` / `StreamRender.fs` are all migrated to consume the package's Layout API in production. Zero direct `Spectre.Console.AnsiConsole` calls in `src/Fugue.Cli/` outside of the package itself.
+- **Condition 2 — external demand signal**: at least 2 independent inbound signals (GitHub issue, mailing-list post, direct outreach) asking for the package as a separable artefact. Speculative publish without demand is rejected.
+- **Condition 3 — bandwidth honesty**: either bus factor > 1 (a second active maintainer has been onboarded), OR the maintainer has explicitly carved 2–4 h/month for package issue triage and committed to it in writing (e.g. CLAUDE.md addendum).
+
+When all three are met, this spec is the starting point — most of the analysis below stands. The Assumptions and Out of Scope sections, and Open Architectural Questions (resolved in research.md), remain the working baseline. Re-litigate only the points that have new evidence.
+
+Tracking issue: see GitHub issue tagged `phase-5-deferred` for the live revisit checklist.
+
+---
 
 ## User Scenarios & Testing *(mandatory)*
 


### PR DESCRIPTION
## Summary

- Specifies and partially plans the Phase 5 NuGet publication of `Fugue.Adapters.Console`, then **defers it** with documented revisit conditions.
- Preserves spec.md, plan.md (drafted but not pursued), and research.md as analysis baseline — no production code changes.
- Updates CLAUDE.md SPECKIT marker to reflect the deferral.

## Why defer (per /speckit-plan Phase 0 review)

Three concerns surfaced that the v1.1.0 constitution does not currently cover:

1. **New operating mode without governance** — publishing a NuGet creates an open-source-library maintainer role that v1.1.0 does not model.
2. **Naming is irreversible after first publish** — `Fugue.Adapters.Console` as a package id cannot be cleanly TypeForwarder-shimmed later; the decision must be made BEFORE publication, not deferred to v1.0.
3. **Bus factor = 1 + active Phase-3 churn** — wrong time for external commitments to strangers.

## Revisit conditions (ALL three, see gh-965)

- [ ] Phase 4 dogfooding complete (zero direct Spectre calls in `src/Fugue.Cli/*.fs` outside the package)
- [ ] ≥ 2 independent external demand signals
- [ ] Bus factor > 1 OR explicit triage commitment in writing

## Test plan

- [x] No production code changed; `dotnet build` / `dotnet test` unaffected
- [x] CLAUDE.md SPECKIT marker is updated to reflect Phase 5 deferral
- [x] Tracking issue gh-965 references the spec/plan/research baseline